### PR TITLE
Implement consistent markdown handling for hovers & completions

### DIFF
--- a/src/Bicep.Core.Samples/Files/baselines/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Completions/declarations.json
@@ -33,7 +33,7 @@
     "detail": "Module declaration",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmodule Identifier Path = {\n  name: \n  \n}\n```"
+      "value": "```bicep\nmodule Identifier Path = {\n  name: \n  \n}\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -77,7 +77,7 @@
     "detail": "Output declaration",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\noutput Identifier Type = \n```"
+      "value": "```bicep\noutput Identifier Type = \n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -121,7 +121,7 @@
     "detail": "Parameter declaration",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparam Identifier Type\n```"
+      "value": "```bicep\nparam Identifier Type\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -151,7 +151,7 @@
     "detail": "Parameter declaration with default value",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparam Identifier Type = DefaultValue\n```"
+      "value": "```bicep\nparam Identifier Type = DefaultValue\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -181,7 +181,7 @@
     "detail": "Parameter declaration with default and allowed values",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n@allowed([\n  \n])\nparam Identifier Type = \n```"
+      "value": "```bicep\n@allowed([\n  \n])\nparam Identifier Type = \n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -211,7 +211,7 @@
     "detail": "Secure string parameter",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n@secure()\nparam Identifier string\n```"
+      "value": "```bicep\n@secure()\nparam Identifier string\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -241,7 +241,7 @@
     "detail": "Kubernetes Service Cluster",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {\n  name: 'name'\n  location: location\n  identity: {\n    type: 'SystemAssigned'\n  }\n  properties: {\n    kubernetesVersion: '1.19.7'\n    dnsPrefix: 'dnsprefix'\n    enableRBAC: true\n    agentPoolProfiles: [\n      {\n        name: 'agentpool'\n        count: 3\n        vmSize: 'Standard_DS2_v2'\n        osType: 'Linux'\n        mode: 'System'\n      }\n    ]\n    linuxProfile: {\n      adminUsername: 'adminUserName'\n      ssh: {\n        publicKeys: [\n          {\n            keyData: 'REQUIRED'\n          }\n        ]\n      }\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {\n  name: 'name'\n  location: location\n  identity: {\n    type: 'SystemAssigned'\n  }\n  properties: {\n    kubernetesVersion: '1.19.7'\n    dnsPrefix: 'dnsprefix'\n    enableRBAC: true\n    agentPoolProfiles: [\n      {\n        name: 'agentpool'\n        count: 3\n        vmSize: 'Standard_DS2_v2'\n        osType: 'Linux'\n        mode: 'System'\n      }\n    ]\n    linuxProfile: {\n      adminUsername: 'adminUserName'\n      ssh: {\n        publicKeys: [\n          {\n            keyData: 'REQUIRED'\n          }\n        ]\n      }\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -271,7 +271,7 @@
     "detail": "Api Management Instance",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource apiManagementInstance 'Microsoft.ApiManagement/service@2020-12-01' = {\n  name: 'name'\n  location: location\n  sku:{\n    capacity: 0\n    name: 'Developer'\n  }\n  properties:{\n    virtualNetworkType: 'None'\n    publisherEmail: 'publisherEmail@contoso.com'\n    publisherName: 'publisherName'\n  }\n}\n\n```"
+      "value": "```bicep\nresource apiManagementInstance 'Microsoft.ApiManagement/service@2020-12-01' = {\n  name: 'name'\n  location: location\n  sku:{\n    capacity: 0\n    name: 'Developer'\n  }\n  properties:{\n    virtualNetworkType: 'None'\n    publisherEmail: 'publisherEmail@contoso.com'\n    publisherName: 'publisherName'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -301,7 +301,7 @@
     "detail": "Application Gateway",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource applicationGateway 'Microsoft.Network/applicationGateways@2020-11-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    sku: {\n      name: 'Standard_Small'\n      tier: 'Standard'\n      capacity: 'capacity'\n    }\n    gatewayIPConfigurations: [\n      {\n        name: 'name'\n        properties: {\n          subnet: {\n            id: 'id'\n          }\n        }\n      }\n    ]\n    frontendIPConfigurations: [\n      {\n        name: 'name'\n        properties: {\n          publicIPAddress: {\n            id: 'id'\n          }\n        }\n      }\n    ]\n    frontendPorts: [\n      {\n        name: 'name'\n        properties: {\n          port: 'port'\n        }\n      }\n    ]\n    backendAddressPools: [\n      {\n        name: 'name'\n      }\n    ]\n    backendHttpSettingsCollection: [\n      {\n        name: 'name'\n        properties: {\n          port: 'port'\n          protocol: 'Http'\n          cookieBasedAffinity: 'Disabled'\n        }\n      }\n    ]\n    httpListeners: [\n      {\n        name: 'name'\n        properties: {\n          frontendIPConfiguration: {\n            id: 'id'\n          }\n          frontendPort: {\n            id: 'id'\n          }\n          protocol: 'Http'\n          sslCertificate: null\n        }\n      }\n    ]\n    requestRoutingRules: [\n      {\n        name: 'name'\n        properties: {\n          ruleType: 'Basic'\n          httpListener: {\n            id: 'id'\n          }\n          backendAddressPool: {\n            id: 'id'\n          }\n          backendHttpSettings: {\n            id: 'id'\n          }\n        }\n      }\n    ]\n  }\n}\n\n```"
+      "value": "```bicep\nresource applicationGateway 'Microsoft.Network/applicationGateways@2020-11-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    sku: {\n      name: 'Standard_Small'\n      tier: 'Standard'\n      capacity: 'capacity'\n    }\n    gatewayIPConfigurations: [\n      {\n        name: 'name'\n        properties: {\n          subnet: {\n            id: 'id'\n          }\n        }\n      }\n    ]\n    frontendIPConfigurations: [\n      {\n        name: 'name'\n        properties: {\n          publicIPAddress: {\n            id: 'id'\n          }\n        }\n      }\n    ]\n    frontendPorts: [\n      {\n        name: 'name'\n        properties: {\n          port: 'port'\n        }\n      }\n    ]\n    backendAddressPools: [\n      {\n        name: 'name'\n      }\n    ]\n    backendHttpSettingsCollection: [\n      {\n        name: 'name'\n        properties: {\n          port: 'port'\n          protocol: 'Http'\n          cookieBasedAffinity: 'Disabled'\n        }\n      }\n    ]\n    httpListeners: [\n      {\n        name: 'name'\n        properties: {\n          frontendIPConfiguration: {\n            id: 'id'\n          }\n          frontendPort: {\n            id: 'id'\n          }\n          protocol: 'Http'\n          sslCertificate: null\n        }\n      }\n    ]\n    requestRoutingRules: [\n      {\n        name: 'name'\n        properties: {\n          ruleType: 'Basic'\n          httpListener: {\n            id: 'id'\n          }\n          backendAddressPool: {\n            id: 'id'\n          }\n          backendHttpSettings: {\n            id: 'id'\n          }\n        }\n      }\n    ]\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -331,7 +331,7 @@
     "detail": "Application Gateway with Web Application Firewall",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource applicationGatewayFirewall 'Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies@2020-11-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    policySettings: {\n      requestBodyCheck: true\n      maxRequestBodySizeInKb: 'maxRequestBodySizeInKb'\n      fileUploadLimitInMb: 'fileUploadLimitInMb'\n      state: 'Enabled'\n      mode: 'Detection'\n    }\n    managedRules: {\n      managedRuleSets: [\n        {\n          ruleSetType: 'ruleSetType'\n          ruleSetVersion: 'ruleSetVersion'\n        }\n      ]\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource applicationGatewayFirewall 'Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies@2020-11-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    policySettings: {\n      requestBodyCheck: true\n      maxRequestBodySizeInKb: 'maxRequestBodySizeInKb'\n      fileUploadLimitInMb: 'fileUploadLimitInMb'\n      state: 'Enabled'\n      mode: 'Detection'\n    }\n    managedRules: {\n      managedRuleSets: [\n        {\n          ruleSetType: 'ruleSetType'\n          ruleSetVersion: 'ruleSetVersion'\n        }\n      ]\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -361,7 +361,7 @@
     "detail": "Application Insights for Web Apps",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource appInsightsComponents 'Microsoft.Insights/components@2020-02-02' = {\n  name: 'name'\n  location: location\n  kind: 'web'\n  properties: {\n    Application_Type: 'web'\n  }\n}\n\n```"
+      "value": "```bicep\nresource appInsightsComponents 'Microsoft.Insights/components@2020-02-02' = {\n  name: 'name'\n  location: location\n  kind: 'web'\n  properties: {\n    Application_Type: 'web'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -391,7 +391,7 @@
     "detail": "Application Insights Alert Rules",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource appInsightsAlertRules 'Microsoft.Insights/alertrules@2016-03-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    name: 'name'\n    description: 'description'\n    isEnabled: false\n    condition: {\n      failedLocationCount: 'failedLocationCount'\n      'odata.type': 'Microsoft.Azure.Management.Insights.Models.LocationThresholdRuleCondition'\n      dataSource: {\n        'odata.type': 'Microsoft.Azure.Management.Insights.Models.RuleManagementEventDataSource'\n        resourceUri: 'resourceUri'\n      }\n      windowSize: 'windowSize'\n    }\n    action: {\n      'odata.type': 'Microsoft.Azure.Management.Insights.Models.RuleEmailAction'\n      sendToServiceOwners: true\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource appInsightsAlertRules 'Microsoft.Insights/alertrules@2016-03-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    name: 'name'\n    description: 'description'\n    isEnabled: false\n    condition: {\n      failedLocationCount: 'failedLocationCount'\n      'odata.type': 'Microsoft.Azure.Management.Insights.Models.LocationThresholdRuleCondition'\n      dataSource: {\n        'odata.type': 'Microsoft.Azure.Management.Insights.Models.RuleManagementEventDataSource'\n        resourceUri: 'resourceUri'\n      }\n      windowSize: 'windowSize'\n    }\n    action: {\n      'odata.type': 'Microsoft.Azure.Management.Insights.Models.RuleEmailAction'\n      sendToServiceOwners: true\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -421,7 +421,7 @@
     "detail": "Application Insights Auto Scale Settings",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource appInsightsAutoScaleSettings 'Microsoft.Insights/autoscalesettings@2015-04-01' = {\n  name: 'name'\n  location: location\n  tags: {\n    Application_Type: 'web'\n    'hidden-link:appServiceId': 'Resource'\n  }\n  properties: {\n    name: 'name'\n    profiles: [\n      {\n        name: 'name'\n        capacity: {\n          minimum: 'minimum'\n          maximum: 'maximum'\n          default: 'default'\n        }\n        rules: [\n          {\n            metricTrigger: {\n              metricName: 'name'\n              metricResourceUri: 'metricResourceUri'\n              timeGrain: 'PT1M'\n              statistic: 'Average'\n              timeWindow: 'PT10M'\n              timeAggregation: 'Average'\n              operator: 'GreaterThan'\n              threshold: 80\n            }\n            scaleAction: {\n              direction: 'Increase'\n              type: 'ChangeCount'\n              value:  'value'\n              cooldown: 'PT10M'\n            }\n          }\n          {\n            metricTrigger: {\n              metricName: 'metricName'\n              metricResourceUri: 'metricResourceUri'\n              timeGrain: 'PT1M'\n              statistic: 'Average'\n              timeWindow: 'PT1H'\n              timeAggregation: 'Average'\n              operator: 'LessThan'\n              threshold: 60\n            }\n            scaleAction: {\n              direction: 'Decrease'\n              type: 'ChangeCount'\n              value: 'value'\n              cooldown: 'PT1H'\n            }\n          }\n        ]\n      }\n    ]\n    enabled: false\n    targetResourceUri: 'targetResourceUri'\n  }\n}\n\n```"
+      "value": "```bicep\nresource appInsightsAutoScaleSettings 'Microsoft.Insights/autoscalesettings@2015-04-01' = {\n  name: 'name'\n  location: location\n  tags: {\n    Application_Type: 'web'\n    'hidden-link:appServiceId': 'Resource'\n  }\n  properties: {\n    name: 'name'\n    profiles: [\n      {\n        name: 'name'\n        capacity: {\n          minimum: 'minimum'\n          maximum: 'maximum'\n          default: 'default'\n        }\n        rules: [\n          {\n            metricTrigger: {\n              metricName: 'name'\n              metricResourceUri: 'metricResourceUri'\n              timeGrain: 'PT1M'\n              statistic: 'Average'\n              timeWindow: 'PT10M'\n              timeAggregation: 'Average'\n              operator: 'GreaterThan'\n              threshold: 80\n            }\n            scaleAction: {\n              direction: 'Increase'\n              type: 'ChangeCount'\n              value:  'value'\n              cooldown: 'PT10M'\n            }\n          }\n          {\n            metricTrigger: {\n              metricName: 'metricName'\n              metricResourceUri: 'metricResourceUri'\n              timeGrain: 'PT1M'\n              statistic: 'Average'\n              timeWindow: 'PT1H'\n              timeAggregation: 'Average'\n              operator: 'LessThan'\n              threshold: 60\n            }\n            scaleAction: {\n              direction: 'Decrease'\n              type: 'ChangeCount'\n              value: 'value'\n              cooldown: 'PT1H'\n            }\n          }\n        ]\n      }\n    ]\n    enabled: false\n    targetResourceUri: 'targetResourceUri'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -451,7 +451,7 @@
     "detail": "Application Service Plan (Server Farm)",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource appServicePlan 'Microsoft.Web/serverfarms@2020-12-01' = {\n  name: 'name'\n  location: location\n  sku: {\n    name: 'F1'\n    capacity: 1\n  }\n}\n\n```"
+      "value": "```bicep\nresource appServicePlan 'Microsoft.Web/serverfarms@2020-12-01' = {\n  name: 'name'\n  location: location\n  sku: {\n    name: 'F1'\n    capacity: 1\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -481,7 +481,7 @@
     "detail": "Application Security Group",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource applicationSecurityGroup 'Microsoft.Network/applicationSecurityGroups@2020-11-01' = {\n  name: 'name'\n  location: location\n}\n\n```"
+      "value": "```bicep\nresource applicationSecurityGroup 'Microsoft.Network/applicationSecurityGroups@2020-11-01' = {\n  name: 'name'\n  location: location\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -511,7 +511,7 @@
     "detail": "Automation Account",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    sku: {\n      name: 'Free'\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    sku: {\n      name: 'Free'\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -541,7 +541,7 @@
     "detail": "Automation Certificate",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' = {\n  name: 'name'\n}\n\nresource automationCertificate 'Microsoft.Automation/automationAccounts/certificates@2019-06-01' = {\n  parent: automationAccount\n  name: 'name'\n  properties: {\n    base64Value: 'base64Value'\n    description: 'description'\n    thumbprint: 'thumbprint'\n    isExportable: true\n  }\n}\n\n```"
+      "value": "```bicep\nresource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' = {\n  name: 'name'\n}\n\nresource automationCertificate 'Microsoft.Automation/automationAccounts/certificates@2019-06-01' = {\n  parent: automationAccount\n  name: 'name'\n  properties: {\n    base64Value: 'base64Value'\n    description: 'description'\n    thumbprint: 'thumbprint'\n    isExportable: true\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -571,7 +571,7 @@
     "detail": "Automation Credential",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' = {\n  name: 'name'\n}\n\nresource automationCredential 'Microsoft.Automation/automationAccounts/credentials@2019-06-01' = {\n  parent: automationAccount\n  name: 'name'\n  properties: {\n    userName: 'userName'\n    password: 'password'\n    description: 'description'\n  }\n}\n\n```"
+      "value": "```bicep\nresource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' = {\n  name: 'name'\n}\n\nresource automationCredential 'Microsoft.Automation/automationAccounts/credentials@2019-06-01' = {\n  parent: automationAccount\n  name: 'name'\n  properties: {\n    userName: 'userName'\n    password: 'password'\n    description: 'description'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -601,7 +601,7 @@
     "detail": "Automation Job Schedule",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' = {\n  name: 'name'\n}\n\nresource automationJobSchedule 'Microsoft.Automation/automationAccounts/jobSchedules@2019-06-01' = {\n  parent: automationAccount\n  name: 'name'\n  properties: {\n    schedule: {\n      name: 'name'\n    }\n    runbook: {\n      name: 'name'\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' = {\n  name: 'name'\n}\n\nresource automationJobSchedule 'Microsoft.Automation/automationAccounts/jobSchedules@2019-06-01' = {\n  parent: automationAccount\n  name: 'name'\n  properties: {\n    schedule: {\n      name: 'name'\n    }\n    runbook: {\n      name: 'name'\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -631,7 +631,7 @@
     "detail": "Automation Module",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' = {\n  name: 'name'\n}\n\nresource automationAccountVariable 'Microsoft.Automation/automationAccounts/modules@2019-06-01' = {\n  parent: automationAccount\n  name: 'name'\n  properties: {\n    contentLink: {\n      uri: 'https://content-url.nupkg'\n    }\n  }\n}\n```"
+      "value": "```bicep\nresource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' = {\n  name: 'name'\n}\n\nresource automationAccountVariable 'Microsoft.Automation/automationAccounts/modules@2019-06-01' = {\n  parent: automationAccount\n  name: 'name'\n  properties: {\n    contentLink: {\n      uri: 'https://content-url.nupkg'\n    }\n  }\n}\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -661,7 +661,7 @@
     "detail": "Automation Runbook",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' = {\n  name: 'name'\n}\n\nresource automationRunbook 'Microsoft.Automation/automationAccounts/runbooks@2019-06-01' = {\n  parent: automationAccount\n  name: 'name'\n  location: location\n  properties: {\n    logVerbose: true\n    logProgress: true\n    runbookType: 'Script'\n    publishContentLink: {\n      uri: 'uri'\n      version: '1.0.0.0'\n    }\n    description: 'description'\n  }\n}\n\n```"
+      "value": "```bicep\nresource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' = {\n  name: 'name'\n}\n\nresource automationRunbook 'Microsoft.Automation/automationAccounts/runbooks@2019-06-01' = {\n  parent: automationAccount\n  name: 'name'\n  location: location\n  properties: {\n    logVerbose: true\n    logProgress: true\n    runbookType: 'Script'\n    publishContentLink: {\n      uri: 'uri'\n      version: '1.0.0.0'\n    }\n    description: 'description'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -691,7 +691,7 @@
     "detail": "Automation Schedule",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' = {\n  name: 'name'\n}\n\nresource automationSchedule 'Microsoft.Automation/automationAccounts/schedules@2019-06-01' = {\n  parent: automationAccount\n  name: 'name'\n  properties: {\n    description: 'description'\n    startTime: 'startTime'\n    interval: 'interval'\n    frequency: 'OneTime'\n  }\n}\n\n```"
+      "value": "```bicep\nresource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' = {\n  name: 'name'\n}\n\nresource automationSchedule 'Microsoft.Automation/automationAccounts/schedules@2019-06-01' = {\n  parent: automationAccount\n  name: 'name'\n  properties: {\n    description: 'description'\n    startTime: 'startTime'\n    interval: 'interval'\n    frequency: 'OneTime'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -721,7 +721,7 @@
     "detail": "Automation Variable",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' = {\n  name: 'name'\n}\n\nresource automationVariable 'Microsoft.Automation/automationAccounts/variables@2019-06-01' = {\n  parent: automationAccount\n  name: 'name'\n  properties: {\n    value: 'value'\n    description: 'description'\n    isEncrypted: true\n  }\n}\n\n```"
+      "value": "```bicep\nresource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' = {\n  name: 'name'\n}\n\nresource automationVariable 'Microsoft.Automation/automationAccounts/variables@2019-06-01' = {\n  parent: automationAccount\n  name: 'name'\n  properties: {\n    value: 'value'\n    description: 'description'\n    isEncrypted: true\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -751,7 +751,7 @@
     "detail": "Availability Set",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource availabilitySet 'Microsoft.Compute/availabilitySets@2020-12-01' = {\n  name: 'name'\n  location: location\n}\n\n```"
+      "value": "```bicep\nresource availabilitySet 'Microsoft.Compute/availabilitySets@2020-12-01' = {\n  name: 'name'\n  location: location\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -781,7 +781,7 @@
     "detail": "Container Group",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource containerGroup 'Microsoft.ContainerInstance/containerGroups@2021-03-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    containers: [\n      {\n        name: 'containername'\n        properties: {\n          image: 'mcr.microsoft.com/azuredocs/aci-helloworld:latest'\n          ports: [\n            {\n              port: 80\n            }\n          ]\n          resources: {\n            requests: {\n              cpu: 1\n              memoryInGB: 4\n            }\n          }\n        }\n      }\n    ]\n    restartPolicy: 'OnFailure'\n    osType: 'Linux'\n    ipAddress: {\n      type: 'Public'\n      ports: [\n        {\n          protocol: 'TCP'\n          port: 80\n        }\n      ]\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource containerGroup 'Microsoft.ContainerInstance/containerGroups@2021-03-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    containers: [\n      {\n        name: 'containername'\n        properties: {\n          image: 'mcr.microsoft.com/azuredocs/aci-helloworld:latest'\n          ports: [\n            {\n              port: 80\n            }\n          ]\n          resources: {\n            requests: {\n              cpu: 1\n              memoryInGB: 4\n            }\n          }\n        }\n      }\n    ]\n    restartPolicy: 'OnFailure'\n    osType: 'Linux'\n    ipAddress: {\n      type: 'Public'\n      ports: [\n        {\n          protocol: 'TCP'\n          port: 80\n        }\n      ]\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -811,7 +811,7 @@
     "detail": "Container Registry",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource containerRegistry 'Microsoft.ContainerRegistry/registries@2021-06-01-preview' = {\n  name: 'name'\n  location: location\n  sku: {\n    name: 'Basic'\n  }\n  properties: {\n    adminUserEnabled: true\n  }\n}\n\n```"
+      "value": "```bicep\nresource containerRegistry 'Microsoft.ContainerRegistry/registries@2021-06-01-preview' = {\n  name: 'name'\n  location: location\n  sku: {\n    name: 'Basic'\n  }\n  properties: {\n    adminUserEnabled: true\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -841,7 +841,7 @@
     "detail": "Cosmos DB Database Account",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2021-03-15' = {\n  name: 'name'\n  location: location\n  kind: 'GlobalDocumentDB'\n  properties: {\n    consistencyPolicy: {\n      defaultConsistencyLevel: 'Eventual'\n      maxStalenessPrefix: 1\n      maxIntervalInSeconds: 5\n    }\n    locations: [\n      {\n        locationName: location\n        failoverPriority: 0\n      }\n    ]\n    databaseAccountOfferType: 'Standard'\n    enableAutomaticFailover: true\n    capabilities: [\n      {\n        name: 'EnableTable'\n      }\n    ]\n  }\n}\n\n```"
+      "value": "```bicep\nresource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2021-03-15' = {\n  name: 'name'\n  location: location\n  kind: 'GlobalDocumentDB'\n  properties: {\n    consistencyPolicy: {\n      defaultConsistencyLevel: 'Eventual'\n      maxStalenessPrefix: 1\n      maxIntervalInSeconds: 5\n    }\n    locations: [\n      {\n        locationName: location\n        failoverPriority: 0\n      }\n    ]\n    databaseAccountOfferType: 'Standard'\n    enableAutomaticFailover: true\n    capabilities: [\n      {\n        name: 'EnableTable'\n      }\n    ]\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -871,7 +871,7 @@
     "detail": "Cosmos DB Cassandra Namespace",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource cassandraKeyspace 'Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces@2021-06-15' = {\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {\n      throughput: 'throughput'\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource cassandraKeyspace 'Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces@2021-06-15' = {\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {\n      throughput: 'throughput'\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -901,7 +901,7 @@
     "detail": "Cosmos DB Cassandra Table",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource cassandraKeyspace 'Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces@2021-06-15' = {\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {}\n  }\n}\n\nresource cassandraKeyspaceTable 'Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/tables@2021-06-15' = {\n  parent: cassandraKeyspace\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {}\n  }\n}\n\n```"
+      "value": "```bicep\nresource cassandraKeyspace 'Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces@2021-06-15' = {\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {}\n  }\n}\n\nresource cassandraKeyspaceTable 'Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/tables@2021-06-15' = {\n  parent: cassandraKeyspace\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {}\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -931,7 +931,7 @@
     "detail": "Cosmos DB Gremlin Database",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource gremlinDb 'Microsoft.DocumentDB/databaseAccounts/gremlinDatabases@2021-06-15' = {\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {\n      throughput: 'throughput'\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource gremlinDb 'Microsoft.DocumentDB/databaseAccounts/gremlinDatabases@2021-06-15' = {\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {\n      throughput: 'throughput'\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -961,7 +961,7 @@
     "detail": "Cosmos DB Gremlin Graph",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource gremlinDb 'Microsoft.DocumentDB/databaseAccounts/gremlinDatabases@2021-06-15' = {\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {\n      throughput: 'throughput'\n    }\n  }\n}\n\nresource cosmosDbGremlinGraph 'Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/graphs@2021-06-15' = {\n  parent: gremlinDb\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n      partitionKey: {\n        paths: [\n          'paths'\n        ]\n        kind: 'Hash'\n      }\n      indexingPolicy: {\n        indexingMode: 'consistent'\n        includedPaths: [\n          {\n            path: 'path'\n            indexes: [\n              {\n                kind: 'Hash'\n                dataType: 'String'\n                precision: -1\n              }\n            ]\n          }\n        ]\n        excludedPaths: [\n          {\n            path: 'path'\n          }\n        ]\n      }\n    }\n    options: {\n      throughput: 'throughput'\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource gremlinDb 'Microsoft.DocumentDB/databaseAccounts/gremlinDatabases@2021-06-15' = {\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {\n      throughput: 'throughput'\n    }\n  }\n}\n\nresource cosmosDbGremlinGraph 'Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/graphs@2021-06-15' = {\n  parent: gremlinDb\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n      partitionKey: {\n        paths: [\n          'paths'\n        ]\n        kind: 'Hash'\n      }\n      indexingPolicy: {\n        indexingMode: 'consistent'\n        includedPaths: [\n          {\n            path: 'path'\n            indexes: [\n              {\n                kind: 'Hash'\n                dataType: 'String'\n                precision: -1\n              }\n            ]\n          }\n        ]\n        excludedPaths: [\n          {\n            path: 'path'\n          }\n        ]\n      }\n    }\n    options: {\n      throughput: 'throughput'\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -991,7 +991,7 @@
     "detail": "Cosmos DB Mongo Database",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource mongoDb 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases@2021-06-15' = {\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {}\n  }\n}\n\n```"
+      "value": "```bicep\nresource mongoDb 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases@2021-06-15' = {\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {}\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1021,7 +1021,7 @@
     "detail": "Cosmos DB SQL Container",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource sqlDb 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2021-06-15' = {\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {}\n  }\n}\n\nresource sqlContainerName 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2021-06-15' = {\n  parent: sqlDb \n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n      partitionKey: {\n        paths: [\n          'paths'\n        ]\n        kind: 'Hash'\n      }\n      indexingPolicy: {\n        indexingMode: 'consistent'\n        includedPaths: [\n          {\n            path: 'path'\n            indexes: [\n              {\n                kind: 'Hash'\n                dataType: 'String'\n                precision: 'precision'\n              }\n            ]\n          }\n        ]\n        excludedPaths: [\n          {\n            path: 'path'\n          }\n        ]\n      }\n    }\n    options: {}\n  }\n}\n\n```"
+      "value": "```bicep\nresource sqlDb 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2021-06-15' = {\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {}\n  }\n}\n\nresource sqlContainerName 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2021-06-15' = {\n  parent: sqlDb \n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n      partitionKey: {\n        paths: [\n          'paths'\n        ]\n        kind: 'Hash'\n      }\n      indexingPolicy: {\n        indexingMode: 'consistent'\n        includedPaths: [\n          {\n            path: 'path'\n            indexes: [\n              {\n                kind: 'Hash'\n                dataType: 'String'\n                precision: 'precision'\n              }\n            ]\n          }\n        ]\n        excludedPaths: [\n          {\n            path: 'path'\n          }\n        ]\n      }\n    }\n    options: {}\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1051,7 +1051,7 @@
     "detail": "Cosmos DB SQL Database",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource sqlDb 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2021-06-15' = {\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {\n      throughput: 'throughput'\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource sqlDb 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2021-06-15' = {\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {\n      throughput: 'throughput'\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1081,7 +1081,7 @@
     "detail": "Cosmos Table Storage",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource cosmosTable 'Microsoft.DocumentDB/databaseAccounts/tables@2021-06-15' = {\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {\n      throughput: 'throughput'\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource cosmosTable 'Microsoft.DocumentDB/databaseAccounts/tables@2021-06-15' = {\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {\n      throughput: 'throughput'\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1111,7 +1111,7 @@
     "detail": "Data Lake Store Account",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource dataLakeStore 'Microsoft.DataLakeStore/accounts@2016-11-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    newTier: 'Consumption'\n    encryptionState: 'Enabled'\n  }\n}\n\n```"
+      "value": "```bicep\nresource dataLakeStore 'Microsoft.DataLakeStore/accounts@2016-11-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    newTier: 'Consumption'\n    encryptionState: 'Enabled'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1141,7 +1141,7 @@
     "detail": "DNS Record",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {\n  name: 'name'\n  location: location\n}\n\nresource dnsRecord 'Microsoft.Network/dnsZones/A@2018-05-01' = {\n  parent: dnsZone\n  name: 'name'\n  properties: {\n    TTL: 3600\n    ARecords: []\n  }\n}\n\n```"
+      "value": "```bicep\nresource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {\n  name: 'name'\n  location: location\n}\n\nresource dnsRecord 'Microsoft.Network/dnsZones/A@2018-05-01' = {\n  parent: dnsZone\n  name: 'name'\n  properties: {\n    TTL: 3600\n    ARecords: []\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1171,7 +1171,7 @@
     "detail": "",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource dnsResolvers 'Microsoft.Network/dnsResolvers@2022-07-01' = {\n  name: 'name'\n  location: location\n  properties: {\n     virtualNetwork: {\n      id: 'virtualNetworkId'\n     }\n  }\n\n  resource inboundEndpoints 'inboundEndpoints' = {\n    name: 'name'\n    location: location\n    properties: {\n      ipConfigurations: [\n        {\n          privateIpAllocationMethod: 'Static'\n          subnet: {\n            id: 'subnetId'\n          }\n        }\n      ]\n    }\n  }\n\n  resource outboundEndpoints 'outboundEndpoints' = {\n    name: 'name'\n    location: location\n    properties: {\n      subnet: {\n        id: 'subnetId'\n      }\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource dnsResolvers 'Microsoft.Network/dnsResolvers@2022-07-01' = {\n  name: 'name'\n  location: location\n  properties: {\n     virtualNetwork: {\n      id: 'virtualNetworkId'\n     }\n  }\n\n  resource inboundEndpoints 'inboundEndpoints' = {\n    name: 'name'\n    location: location\n    properties: {\n      ipConfigurations: [\n        {\n          privateIpAllocationMethod: 'Static'\n          subnet: {\n            id: 'subnetId'\n          }\n        }\n      ]\n    }\n  }\n\n  resource outboundEndpoints 'outboundEndpoints' = {\n    name: 'name'\n    location: location\n    properties: {\n      subnet: {\n        id: 'subnetId'\n      }\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1201,7 +1201,7 @@
     "detail": "DNS Zone",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {\n  name: 'name'\n  location: 'global'\n}\n\n```"
+      "value": "```bicep\nresource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {\n  name: 'name'\n  location: 'global'\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1231,7 +1231,7 @@
     "detail": "ExpressRoute Circuit",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource expressRouteCircuit 'Microsoft.Network/expressRouteCircuits@2020-11-01' = {\n  name: 'name'\n  location: location\n  sku:{\n    family: 'MeteredData'\n    tier: 'Local'\n    name: 'Local_MeteredData'\n  }\n  properties:{\n    serviceProviderProperties:{\n      bandwidthInMbps: 50\n        peeringLocation: 'Amsterdam'\n      serviceProviderName: 'Telia Carrier'\n    }\n    allowClassicOperations:true\n  }\n}\n\n```"
+      "value": "```bicep\nresource expressRouteCircuit 'Microsoft.Network/expressRouteCircuits@2020-11-01' = {\n  name: 'name'\n  location: location\n  sku:{\n    family: 'MeteredData'\n    tier: 'Local'\n    name: 'Local_MeteredData'\n  }\n  properties:{\n    serviceProviderProperties:{\n      bandwidthInMbps: 50\n        peeringLocation: 'Amsterdam'\n      serviceProviderName: 'Telia Carrier'\n    }\n    allowClassicOperations:true\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1261,7 +1261,7 @@
     "detail": "ExpressRoute Gateway",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource expressRouteGateways 'Microsoft.Network/expressRouteGateways@2021-02-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    virtualHub: {\n      id: 'virtualHub.id'\n    }\n    autoScaleConfiguration: {\n      bounds: {\n        min: 1\n        max: 1\n      }\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource expressRouteGateways 'Microsoft.Network/expressRouteGateways@2021-02-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    virtualHub: {\n      id: 'virtualHub.id'\n    }\n    autoScaleConfiguration: {\n      bounds: {\n        min: 1\n        max: 1\n      }\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1291,7 +1291,7 @@
     "detail": "Azure Firewall using classic rules",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource firewall 'Microsoft.Network/azureFirewalls@2020-11-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    applicationRuleCollections: [\n      {\n        name: 'name'\n        properties: {\n          priority: 'priority'\n          action: {\n            type: 'Allow'\n          }\n          rules: [\n            {\n              name: 'name'\n              description: 'description'\n              sourceAddresses: [\n                'sourceAddress'\n              ]\n              protocols: [\n                {\n                  protocolType: 'Http'\n                  port: 80\n                }\n              ]\n              targetFqdns: [\n                'www.microsoft.com'\n              ]\n            }\n          ]\n        }\n      }\n    ]\n    natRuleCollections: [\n      {\n        name: 'name'\n        properties: {\n          priority: 'priority'\n          action: {\n            type: 'Dnat'\n          }\n          rules: [\n            {\n              name: 'name'\n              description: 'description'\n              sourceAddresses: [\n                'sourceAddress'\n              ]\n              destinationAddresses: [\n                'destinationAddress'\n              ]\n              destinationPorts: [\n                'port'\n              ]\n              protocols: [\n                'TCP'\n              ]\n              translatedAddress: 'translatedAddress'\n              translatedPort: 'translatedPort'\n            }\n          ]\n        }\n      }\n    ]\n    networkRuleCollections: [\n      {\n        name: 'name'\n        properties: {\n          priority: 'priority'\n          action: {\n            type: 'Deny'\n          }\n          rules: [\n            {\n              name: 'name'\n              description: 'description'\n              sourceAddresses: [\n                'sourceAddress'\n              ]\n              destinationAddresses: [\n                'destinationAddress'\n              ]\n              destinationPorts: [\n                'destinationPort'\n              ]\n              protocols: [\n                'TCP'\n              ]\n            }\n          ]\n        }\n      }\n    ]\n    ipConfigurations: [\n      {\n        name: 'name'\n        properties: {\n          subnet: {\n            id: 'id'\n          }\n          publicIPAddress: {\n            id: 'id'\n          }\n        }\n      }\n    ]\n  }\n}\n\n```"
+      "value": "```bicep\nresource firewall 'Microsoft.Network/azureFirewalls@2020-11-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    applicationRuleCollections: [\n      {\n        name: 'name'\n        properties: {\n          priority: 'priority'\n          action: {\n            type: 'Allow'\n          }\n          rules: [\n            {\n              name: 'name'\n              description: 'description'\n              sourceAddresses: [\n                'sourceAddress'\n              ]\n              protocols: [\n                {\n                  protocolType: 'Http'\n                  port: 80\n                }\n              ]\n              targetFqdns: [\n                'www.microsoft.com'\n              ]\n            }\n          ]\n        }\n      }\n    ]\n    natRuleCollections: [\n      {\n        name: 'name'\n        properties: {\n          priority: 'priority'\n          action: {\n            type: 'Dnat'\n          }\n          rules: [\n            {\n              name: 'name'\n              description: 'description'\n              sourceAddresses: [\n                'sourceAddress'\n              ]\n              destinationAddresses: [\n                'destinationAddress'\n              ]\n              destinationPorts: [\n                'port'\n              ]\n              protocols: [\n                'TCP'\n              ]\n              translatedAddress: 'translatedAddress'\n              translatedPort: 'translatedPort'\n            }\n          ]\n        }\n      }\n    ]\n    networkRuleCollections: [\n      {\n        name: 'name'\n        properties: {\n          priority: 'priority'\n          action: {\n            type: 'Deny'\n          }\n          rules: [\n            {\n              name: 'name'\n              description: 'description'\n              sourceAddresses: [\n                'sourceAddress'\n              ]\n              destinationAddresses: [\n                'destinationAddress'\n              ]\n              destinationPorts: [\n                'destinationPort'\n              ]\n              protocols: [\n                'TCP'\n              ]\n            }\n          ]\n        }\n      }\n    ]\n    ipConfigurations: [\n      {\n        name: 'name'\n        properties: {\n          subnet: {\n            id: 'id'\n          }\n          publicIPAddress: {\n            id: 'id'\n          }\n        }\n      }\n    ]\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1321,7 +1321,7 @@
     "detail": "Azure Firewall Policy Standard SKU",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource firewallPolicy 'Microsoft.Network/firewallPolicies@2021-05-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    sku: {\n      tier: 'Standard'\n    }\n    dnsSettings: {\n      enableProxy: true\n    }\n    threatIntelMode: 'Alert'\n  }\n}\n\n```"
+      "value": "```bicep\nresource firewallPolicy 'Microsoft.Network/firewallPolicies@2021-05-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    sku: {\n      tier: 'Standard'\n    }\n    dnsSettings: {\n      enableProxy: true\n    }\n    threatIntelMode: 'Alert'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1351,7 +1351,7 @@
     "detail": "Azure Firewall Standard SKU",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource firewall 'Microsoft.Network/azureFirewalls@2021-05-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    sku: {\n      name: 'AZFW_VNet'\n      tier: 'Standard'\n    }    \n    firewallPolicy: {\n      id: 'firewallPolicy.id'\n    }\n    ipConfigurations: [\n      {\n        name: 'name'\n        properties: {\n          subnet: {\n            id: 'subnet.id'\n          }\n          publicIPAddress: {\n            id: 'publicIPAddress.id'\n          }\n        }\n      }\n    ]\n  }\n}\n\n```"
+      "value": "```bicep\nresource firewall 'Microsoft.Network/azureFirewalls@2021-05-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    sku: {\n      name: 'AZFW_VNet'\n      tier: 'Standard'\n    }    \n    firewallPolicy: {\n      id: 'firewallPolicy.id'\n    }\n    ipConfigurations: [\n      {\n        name: 'name'\n        properties: {\n          subnet: {\n            id: 'subnet.id'\n          }\n          publicIPAddress: {\n            id: 'publicIPAddress.id'\n          }\n        }\n      }\n    ]\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1381,7 +1381,7 @@
     "detail": "Azure Firewall Standard SKU for Virtual WAN Hub",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource firewall 'Microsoft.Network/azureFirewalls@2021-05-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    sku: {\n      name: 'AZFW_Hub'\n      tier: 'Standard'\n    }    \n    firewallPolicy: {\n      id: 'firewallPolicy.id'\n    }\n    virtualHub: {\n      id: 'virtualHub.id'\n    }\n    hubIPAddresses: {\n       publicIPs: {\n         count: 2\n       }\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource firewall 'Microsoft.Network/azureFirewalls@2021-05-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    sku: {\n      name: 'AZFW_Hub'\n      tier: 'Standard'\n    }    \n    firewallPolicy: {\n      id: 'firewallPolicy.id'\n    }\n    virtualHub: {\n      id: 'virtualHub.id'\n    }\n    hubIPAddresses: {\n       publicIPs: {\n         count: 2\n       }\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1411,7 +1411,7 @@
     "detail": "Azure Functions (v2)",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource azureFunction 'Microsoft.Web/sites@2020-12-01' = {\n  name: 'name'\n  location: location\n  kind: 'functionapp'\n  properties: {\n    serverFarmId: 'serverfarms.id'\n    siteConfig: {\n      appSettings: [\n        {\n          name: 'AzureWebJobsDashboard'\n          value: 'DefaultEndpointsProtocol=https;AccountName=storageAccountName1;AccountKey=${listKeys('storageAccountID1', '2019-06-01').key1}'\n        }\n        {\n          name: 'AzureWebJobsStorage'\n          value: 'DefaultEndpointsProtocol=https;AccountName=storageAccountName2;AccountKey=${listKeys('storageAccountID2', '2019-06-01').key1}'\n        }\n        {\n          name: 'WEBSITE_CONTENTAZUREFILECONNECTIONSTRING'\n          value: 'DefaultEndpointsProtocol=https;AccountName=storageAccountName3;AccountKey=${listKeys('storageAccountID3', '2019-06-01').key1}'\n        }\n        {\n          name: 'WEBSITE_CONTENTSHARE'\n          value: toLower('name')\n        }\n        {\n          name: 'FUNCTIONS_EXTENSION_VERSION'\n          value: '~2'\n        }\n        {\n          name: 'APPINSIGHTS_INSTRUMENTATIONKEY'\n          value: reference('insightsComponents.id', '2015-05-01').InstrumentationKey\n        }\n        {\n          name: 'FUNCTIONS_WORKER_RUNTIME'\n          value: 'dotnet'\n        }\n      ]\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource azureFunction 'Microsoft.Web/sites@2020-12-01' = {\n  name: 'name'\n  location: location\n  kind: 'functionapp'\n  properties: {\n    serverFarmId: 'serverfarms.id'\n    siteConfig: {\n      appSettings: [\n        {\n          name: 'AzureWebJobsDashboard'\n          value: 'DefaultEndpointsProtocol=https;AccountName=storageAccountName1;AccountKey=${listKeys('storageAccountID1', '2019-06-01').key1}'\n        }\n        {\n          name: 'AzureWebJobsStorage'\n          value: 'DefaultEndpointsProtocol=https;AccountName=storageAccountName2;AccountKey=${listKeys('storageAccountID2', '2019-06-01').key1}'\n        }\n        {\n          name: 'WEBSITE_CONTENTAZUREFILECONNECTIONSTRING'\n          value: 'DefaultEndpointsProtocol=https;AccountName=storageAccountName3;AccountKey=${listKeys('storageAccountID3', '2019-06-01').key1}'\n        }\n        {\n          name: 'WEBSITE_CONTENTSHARE'\n          value: toLower('name')\n        }\n        {\n          name: 'FUNCTIONS_EXTENSION_VERSION'\n          value: '~2'\n        }\n        {\n          name: 'APPINSIGHTS_INSTRUMENTATIONKEY'\n          value: reference('insightsComponents.id', '2015-05-01').InstrumentationKey\n        }\n        {\n          name: 'FUNCTIONS_WORKER_RUNTIME'\n          value: 'dotnet'\n        }\n      ]\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1441,7 +1441,7 @@
     "detail": "Public IP Address",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource publicIPAddress 'Microsoft.Network/publicIPAddresses@2019-11-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    publicIPAllocationMethod: 'Dynamic'\n    dnsSettings: {\n      domainNameLabel: 'dnsname'\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource publicIPAddress 'Microsoft.Network/publicIPAddresses@2019-11-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    publicIPAllocationMethod: 'Dynamic'\n    dnsSettings: {\n      domainNameLabel: 'dnsname'\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1471,7 +1471,7 @@
     "detail": "Public IP Prefix",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource publicIPPrefix 'Microsoft.Network/publicIPPrefixes@2019-11-01' = {\n  name: 'name'\n  location: location\n  sku: {\n    name: 'Standard'\n  }\n  properties: {\n    publicIPAddressVersion: 'IPv4'\n    prefixLength: 28\n  }\n}\n\n```"
+      "value": "```bicep\nresource publicIPPrefix 'Microsoft.Network/publicIPPrefixes@2019-11-01' = {\n  name: 'name'\n  location: location\n  sku: {\n    name: 'Standard'\n  }\n  properties: {\n    publicIPAddressVersion: 'IPv4'\n    prefixLength: 28\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1501,7 +1501,7 @@
     "detail": "KeyVault",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource keyVault 'Microsoft.KeyVault/vaults@2019-09-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    enabledForDeployment: true\n    enabledForTemplateDeployment: true\n    enabledForDiskEncryption: true\n    tenantId: 'tenantId'\n    accessPolicies: [\n      {\n        tenantId: 'tenantId'\n        objectId: 'objectId'\n        permissions: {\n          keys: [\n            'get'\n          ]\n          secrets: [\n            'list'\n            'get'\n          ]\n        }\n      }\n    ]\n    sku: {\n      name: 'standard'\n      family: 'A'\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource keyVault 'Microsoft.KeyVault/vaults@2019-09-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    enabledForDeployment: true\n    enabledForTemplateDeployment: true\n    enabledForDiskEncryption: true\n    tenantId: 'tenantId'\n    accessPolicies: [\n      {\n        tenantId: 'tenantId'\n        objectId: 'objectId'\n        permissions: {\n          keys: [\n            'get'\n          ]\n          secrets: [\n            'list'\n            'get'\n          ]\n        }\n      }\n    ]\n    sku: {\n      name: 'standard'\n      family: 'A'\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1531,7 +1531,7 @@
     "detail": "Key Vault Secret",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource keyVaultSecret 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {\n  name: 'keyVaultName/name'\n  properties: {\n    value: 'value'\n  }\n}\n\n```"
+      "value": "```bicep\nresource keyVaultSecret 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {\n  name: 'keyVaultName/name'\n  properties: {\n    value: 'value'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1561,7 +1561,7 @@
     "detail": "External Load Balancer",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource loadBalancerExternal 'Microsoft.Network/loadBalancers@2020-11-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    frontendIPConfigurations: [\n      {\n        name: 'name'\n        properties: {\n          publicIPAddress: {\n            id: 'publicIPAddresses.id'\n          }\n        }\n      }\n    ]\n    backendAddressPools: [\n      {\n        name: 'name'\n      }\n    ]\n    inboundNatRules: [\n      {\n        name: 'name'\n        properties: {\n          frontendIPConfiguration: {\n            id: 'frontendIPConfiguration.id'\n          }\n          protocol: 'Tcp'\n          frontendPort: 50001\n          backendPort: 3389\n          enableFloatingIP: false\n        }\n      }\n    ]\n    loadBalancingRules: [\n      {\n        name: 'name'\n        properties: {\n          frontendIPConfiguration: {\n             id: 'frontendIPConfiguration.id'\n          }\n          backendAddressPool: {\n            id: 'backendAddressPool.id'\n          }\n          protocol: 'Tcp'\n          frontendPort: 80\n          backendPort: 80\n          enableFloatingIP: false\n          idleTimeoutInMinutes: 5\n          probe: {\n            id: 'probe.id'\n          }\n        }\n      }\n    ]\n    probes: [\n      {\n        name: 'name'\n        properties: {\n          protocol: 'Tcp'\n          port: 80\n          intervalInSeconds: 5\n          numberOfProbes: 2\n        }\n      }\n    ]\n  }\n}\n\n```"
+      "value": "```bicep\nresource loadBalancerExternal 'Microsoft.Network/loadBalancers@2020-11-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    frontendIPConfigurations: [\n      {\n        name: 'name'\n        properties: {\n          publicIPAddress: {\n            id: 'publicIPAddresses.id'\n          }\n        }\n      }\n    ]\n    backendAddressPools: [\n      {\n        name: 'name'\n      }\n    ]\n    inboundNatRules: [\n      {\n        name: 'name'\n        properties: {\n          frontendIPConfiguration: {\n            id: 'frontendIPConfiguration.id'\n          }\n          protocol: 'Tcp'\n          frontendPort: 50001\n          backendPort: 3389\n          enableFloatingIP: false\n        }\n      }\n    ]\n    loadBalancingRules: [\n      {\n        name: 'name'\n        properties: {\n          frontendIPConfiguration: {\n             id: 'frontendIPConfiguration.id'\n          }\n          backendAddressPool: {\n            id: 'backendAddressPool.id'\n          }\n          protocol: 'Tcp'\n          frontendPort: 80\n          backendPort: 80\n          enableFloatingIP: false\n          idleTimeoutInMinutes: 5\n          probe: {\n            id: 'probe.id'\n          }\n        }\n      }\n    ]\n    probes: [\n      {\n        name: 'name'\n        properties: {\n          protocol: 'Tcp'\n          port: 80\n          intervalInSeconds: 5\n          numberOfProbes: 2\n        }\n      }\n    ]\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1591,7 +1591,7 @@
     "detail": "Internal Load Balancer",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource loadBalancerInternal 'Microsoft.Network/loadBalancers@2020-11-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    frontendIPConfigurations: [\n      {\n        name: 'name'\n        properties: {\n          privateIPAddress: '0.0.0.0'\n          privateIPAllocationMethod: 'Static'\n          subnet: {\n            id: 'subnet.id'\n          }\n        }\n      }\n    ]\n    backendAddressPools: [\n      {\n        name: 'name'\n      }\n    ]\n    loadBalancingRules: [\n      {\n        name: 'name'\n        properties: {\n          frontendIPConfiguration: {\n            id: 'frontendIPConfiguration.id'\n          }\n          backendAddressPool: {\n            id: 'backendAddressPool.id'\n          }\n          protocol: 'Tcp'\n          frontendPort: 80\n          backendPort: 80\n          enableFloatingIP: false\n          idleTimeoutInMinutes: 5\n          probe: {\n            id: 'probe.id'\n          }\n        }\n      }\n    ]\n    probes: [\n      {\n        name: 'name'\n        properties: {\n          protocol: 'Tcp'\n          port: 80\n          intervalInSeconds: 5\n          numberOfProbes: 2\n        }\n      }\n    ]\n  }\n}\n\n```"
+      "value": "```bicep\nresource loadBalancerInternal 'Microsoft.Network/loadBalancers@2020-11-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    frontendIPConfigurations: [\n      {\n        name: 'name'\n        properties: {\n          privateIPAddress: '0.0.0.0'\n          privateIPAllocationMethod: 'Static'\n          subnet: {\n            id: 'subnet.id'\n          }\n        }\n      }\n    ]\n    backendAddressPools: [\n      {\n        name: 'name'\n      }\n    ]\n    loadBalancingRules: [\n      {\n        name: 'name'\n        properties: {\n          frontendIPConfiguration: {\n            id: 'frontendIPConfiguration.id'\n          }\n          backendAddressPool: {\n            id: 'backendAddressPool.id'\n          }\n          protocol: 'Tcp'\n          frontendPort: 80\n          backendPort: 80\n          enableFloatingIP: false\n          idleTimeoutInMinutes: 5\n          probe: {\n            id: 'probe.id'\n          }\n        }\n      }\n    ]\n    probes: [\n      {\n        name: 'name'\n        properties: {\n          protocol: 'Tcp'\n          port: 80\n          intervalInSeconds: 5\n          numberOfProbes: 2\n        }\n      }\n    ]\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1621,7 +1621,7 @@
     "detail": "",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource lock 'Microsoft.Authorization/locks@2017-04-01' = {\n  name: 'name'\n  properties: {\n    level: 'NotSpecified'\n  }\n}\n\n```"
+      "value": "```bicep\nresource lock 'Microsoft.Authorization/locks@2017-04-01' = {\n  name: 'name'\n  properties: {\n    level: 'NotSpecified'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1651,7 +1651,7 @@
     "detail": "Log Analytics Solution",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource logAnalyticsSolution 'Microsoft.OperationsManagement/solutions@2015-11-01-preview' = {\n  name: 'name'\n  location: location\n  properties: {\n    workspaceResourceId: 'operationalInsightsWorkspace.id'\n    containedResources: [\n      'view.id'\n    ]\n  }\n  plan: {\n    name: 'name'\n    product: 'product'\n    publisher: 'publisher'\n    promotionCode: 'promotionCode'\n  }\n}\n\n```"
+      "value": "```bicep\nresource logAnalyticsSolution 'Microsoft.OperationsManagement/solutions@2015-11-01-preview' = {\n  name: 'name'\n  location: location\n  properties: {\n    workspaceResourceId: 'operationalInsightsWorkspace.id'\n    containedResources: [\n      'view.id'\n    ]\n  }\n  plan: {\n    name: 'name'\n    product: 'product'\n    publisher: 'publisher'\n    promotionCode: 'promotionCode'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1681,7 +1681,7 @@
     "detail": "Log Analytics Workspace",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2020-10-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    sku: {\n      name: 'Free'\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2020-10-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    sku: {\n      name: 'Free'\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1711,7 +1711,7 @@
     "detail": "Logic App",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource logicApp 'Microsoft.Logic/workflows@2019-05-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    definition: {\n      '$schema': 'https://schema.management.azure.com/schemas/2016-06-01/Microsoft.Logic.json'\n      contentVersion: '1.0.0.0'\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource logicApp 'Microsoft.Logic/workflows@2019-05-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    definition: {\n      '$schema': 'https://schema.management.azure.com/schemas/2016-06-01/Microsoft.Logic.json'\n      contentVersion: '1.0.0.0'\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1741,7 +1741,7 @@
     "detail": "Logic App Connector",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource logicAppConnector 'Microsoft.Web/connections@2016-06-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    api: any({\n      id: subscriptionResourceId('Microsoft.Web/locations/managedApis', location, 'logicAppConnectorApi')\n    })\n  }\n}\n\n```"
+      "value": "```bicep\nresource logicAppConnector 'Microsoft.Web/connections@2016-06-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    api: any({\n      id: subscriptionResourceId('Microsoft.Web/locations/managedApis', location, 'logicAppConnectorApi')\n    })\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1771,7 +1771,7 @@
     "detail": "Logic App",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource logicApp 'Microsoft.Logic/workflows@2019-05-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    definition: json(loadTextContent('REQUIRED')).definition\n  }\n}\n\n```"
+      "value": "```bicep\nresource logicApp 'Microsoft.Logic/workflows@2019-05-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    definition: json(loadTextContent('REQUIRED')).definition\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1801,7 +1801,7 @@
     "detail": "Logic App Integration Account",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource logicAppIntegrationAccount 'Microsoft.Logic/integrationAccounts@2019-05-01' = {\n  name: 'name'\n  location: location\n}\n\n```"
+      "value": "```bicep\nresource logicAppIntegrationAccount 'Microsoft.Logic/integrationAccounts@2019-05-01' = {\n  name: 'name'\n  location: location\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1831,7 +1831,7 @@
     "detail": "Managed Identity (User Assigned)",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {\n  name: 'name'\n  location: location\n}\n\n```"
+      "value": "```bicep\nresource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {\n  name: 'name'\n  location: location\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1861,7 +1861,7 @@
     "detail": "Media Services account",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource mediaServices 'Microsoft.Media/mediaServices@2020-05-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    storageAccounts: [\n      {\n        id: 'storageAccount.id'\n        type: 'Primary'\n      }\n    ]\n  }\n}\n\n```"
+      "value": "```bicep\nresource mediaServices 'Microsoft.Media/mediaServices@2020-05-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    storageAccounts: [\n      {\n        id: 'storageAccount.id'\n        type: 'Primary'\n      }\n    ]\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1891,7 +1891,7 @@
     "detail": "Management Group(for tenant scope)",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource 'managementGroup' 'Microsoft.Management/managementGroups@2021-04-01' = {\n  name: 'name'\n  properties: {\n    displayName: 'displayName'\n    details: {\n      parent: {\n        id: 'id'\n      }\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource 'managementGroup' 'Microsoft.Management/managementGroups@2021-04-01' = {\n  name: 'name'\n  properties: {\n    displayName: 'displayName'\n    details: {\n      parent: {\n        id: 'id'\n      }\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1921,7 +1921,7 @@
     "detail": "MySQL Database",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource mySQLdb 'Microsoft.DBforMySQL/servers@2017-12-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    administratorLogin: 'administratorLogin'\n    administratorLoginPassword: 'administratorLoginPassword'\n    createMode: 'Default'\n  }\n}\n\n```"
+      "value": "```bicep\nresource mySQLdb 'Microsoft.DBforMySQL/servers@2017-12-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    administratorLogin: 'administratorLogin'\n    administratorLoginPassword: 'administratorLoginPassword'\n    createMode: 'Default'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1951,7 +1951,7 @@
     "detail": "Network Interface",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource networkInterface 'Microsoft.Network/networkInterfaces@2020-11-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    ipConfigurations: [\n      {\n        name: 'name'\n        properties: {\n          privateIPAllocationMethod: 'Dynamic'\n          subnet: {\n            id: 'subnet.id'\n          }\n        }\n      }\n    ]\n  }\n}\n\n```"
+      "value": "```bicep\nresource networkInterface 'Microsoft.Network/networkInterfaces@2020-11-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    ipConfigurations: [\n      {\n        name: 'name'\n        properties: {\n          privateIPAllocationMethod: 'Dynamic'\n          subnet: {\n            id: 'subnet.id'\n          }\n        }\n      }\n    ]\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1981,7 +1981,7 @@
     "detail": "Network Security Group",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2019-11-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    securityRules: [\n      {\n        name: 'nsgRule'\n        properties: {\n          description: 'description'\n          protocol: 'Tcp'\n          sourcePortRange: '*'\n          destinationPortRange: '*'\n          sourceAddressPrefix: '*'\n          destinationAddressPrefix: '*'\n          access: 'Allow'\n          priority: 100\n          direction: 'Inbound'\n        }\n      }\n    ]\n  }\n}\n\n```"
+      "value": "```bicep\nresource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2019-11-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    securityRules: [\n      {\n        name: 'nsgRule'\n        properties: {\n          description: 'description'\n          protocol: 'Tcp'\n          sourcePortRange: '*'\n          destinationPortRange: '*'\n          sourceAddressPrefix: '*'\n          destinationAddressPrefix: '*'\n          access: 'Allow'\n          priority: 100\n          direction: 'Inbound'\n        }\n      }\n    ]\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2011,7 +2011,7 @@
     "detail": "Network Security Group Rule",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource networkSecurityGroupSecurityRule 'Microsoft.Network/networkSecurityGroups/securityRules@2019-11-01' = {\n  name: 'networkSecurityGroup/name'\n  properties: {\n    description: 'description'\n    protocol: '*'\n    sourcePortRange: 'sourcePortRange'\n    destinationPortRange: 'destinationPortRange'\n    sourceAddressPrefix: 'sourceAddressPrefix'\n    destinationAddressPrefix: 'destinationAddressPrefix'\n    access: 'Allow'\n    priority: 100\n    direction: 'Inbound'\n  }\n}\n\n```"
+      "value": "```bicep\nresource networkSecurityGroupSecurityRule 'Microsoft.Network/networkSecurityGroups/securityRules@2019-11-01' = {\n  name: 'networkSecurityGroup/name'\n  properties: {\n    description: 'description'\n    protocol: '*'\n    sourcePortRange: 'sourcePortRange'\n    destinationPortRange: 'destinationPortRange'\n    sourceAddressPrefix: 'sourceAddressPrefix'\n    destinationAddressPrefix: 'destinationAddressPrefix'\n    access: 'Allow'\n    priority: 100\n    direction: 'Inbound'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2041,7 +2041,7 @@
     "detail": "Application Service Plan (Server Farm)",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource appServicePlan 'Microsoft.Web/serverfarms@2020-12-01' = {\n  name: 'name'\n  location: location\n  sku: {\n    name: 'name'\n    capacity: capacity\n  }\n}\n\n```"
+      "value": "```bicep\nresource appServicePlan 'Microsoft.Web/serverfarms@2020-12-01' = {\n  name: 'name'\n  location: location\n  sku: {\n    name: 'name'\n    capacity: capacity\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2071,7 +2071,7 @@
     "detail": "Policy Assignment",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource policyAssignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = {\n  name: 'name'\n  location: location\n  identity: {\n    type: 'SystemAssigned'\n  }\n  properties: {\n    displayName: 'displayName'\n    description: 'description'\n    enforcementMode: 'Default'\n    metadata: {\n      source: 'source'\n      version: '0.1.0'\n    }\n    policyDefinitionId: 'policyDefinitionId'\n    parameters: {\n      parameterName: {\n        value: 'value'\n      }\n    }\n    nonComplianceMessages: [\n      {\n        message: 'message'\n      }\n      {\n        message: 'message'\n        policyDefinitionReferenceId: 'policyDefinitionReferenceId'\n      }\n    ]\n  }\n}\n\n```"
+      "value": "```bicep\nresource policyAssignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = {\n  name: 'name'\n  location: location\n  identity: {\n    type: 'SystemAssigned'\n  }\n  properties: {\n    displayName: 'displayName'\n    description: 'description'\n    enforcementMode: 'Default'\n    metadata: {\n      source: 'source'\n      version: '0.1.0'\n    }\n    policyDefinitionId: 'policyDefinitionId'\n    parameters: {\n      parameterName: {\n        value: 'value'\n      }\n    }\n    nonComplianceMessages: [\n      {\n        message: 'message'\n      }\n      {\n        message: 'message'\n        policyDefinitionReferenceId: 'policyDefinitionReferenceId'\n      }\n    ]\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2101,7 +2101,7 @@
     "detail": "Policy Definition",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource policyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = {\n  name: 'name'\n  properties: {\n    displayName: 'displayName'\n    policyType: 'Custom'\n    mode: 'All'\n    description: 'description'\n    metadata: {\n      version: '0.1.0'\n      category: 'category'\n      source: 'source'\n    }\n    parameters: {\n      parameterName: {\n        type: 'String'\n        defaultValue: 'defaultValue'\n        metadata: {\n          displayName: 'displayName'\n          description: 'description'\n        }\n      }\n    }\n    policyRule: {\n      if: {\n        allOf: [\n          {\n            field: 'field'\n            equals: 'conditionValue'\n          }\n        ]\n      }\n      then: {\n        effect: 'Audit'\n      }\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource policyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = {\n  name: 'name'\n  properties: {\n    displayName: 'displayName'\n    policyType: 'Custom'\n    mode: 'All'\n    description: 'description'\n    metadata: {\n      version: '0.1.0'\n      category: 'category'\n      source: 'source'\n    }\n    parameters: {\n      parameterName: {\n        type: 'String'\n        defaultValue: 'defaultValue'\n        metadata: {\n          displayName: 'displayName'\n          description: 'description'\n        }\n      }\n    }\n    policyRule: {\n      if: {\n        allOf: [\n          {\n            field: 'field'\n            equals: 'conditionValue'\n          }\n        ]\n      }\n      then: {\n        effect: 'Audit'\n      }\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2131,7 +2131,7 @@
     "detail": "Policy Definition",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource policyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = {\n  name: 'name'\n  properties: {\n    displayName: 'displayName'\n    policyType: 'Custom'\n    mode: 'All'\n    description: 'description'\n    metadata: {\n      version: '0.1.0'\n      category: 'category'\n      source: 'source'\n    }\n    parameters: {\n      parameterName: {\n        type: 'String'\n        defaultValue: 'defaultValue'\n        metadata: {\n          displayName: 'displayName'\n          description: 'description'\n        }\n      }\n    }\n    policyRule: {\n      if: {\n        allOf: [\n          {\n            field: 'field'\n            equals: 'conditionValue'\n          }\n        ]\n      }\n      then: {\n        effect: 'Audit'\n        details: {\n          roleDefinitionIds: [\n            'roleDefinitionIds'\n          ]\n          type: 'type'\n          existenceCondition: {\n            allOf: [\n              {\n                field: 'field'\n                equals: 'conditionValue'\n              }\n            ]\n          }\n          deployment: {\n            properties: {\n              mode: 'incremental'\n              template: {\n                '$schema': 'schema'\n                contentVersion: '1.0.0.0'\n                parameters: {\n                  parameterName: {\n                    type: 'String'\n                    metadata: {\n                      displayName: 'displayName'\n                      description: 'description'\n                    }\n                  }\n                }\n                variables: {}\n                resources: [\n                  {\n                    name: 'name'\n                    type: 'type'\n                    apiVersion: 'apiVersion'\n                    location: location\n                    properties: {}\n                  }\n                ]\n              }\n              parameters: {\n                parameterName: {\n                  value: 'value'\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource policyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = {\n  name: 'name'\n  properties: {\n    displayName: 'displayName'\n    policyType: 'Custom'\n    mode: 'All'\n    description: 'description'\n    metadata: {\n      version: '0.1.0'\n      category: 'category'\n      source: 'source'\n    }\n    parameters: {\n      parameterName: {\n        type: 'String'\n        defaultValue: 'defaultValue'\n        metadata: {\n          displayName: 'displayName'\n          description: 'description'\n        }\n      }\n    }\n    policyRule: {\n      if: {\n        allOf: [\n          {\n            field: 'field'\n            equals: 'conditionValue'\n          }\n        ]\n      }\n      then: {\n        effect: 'Audit'\n        details: {\n          roleDefinitionIds: [\n            'roleDefinitionIds'\n          ]\n          type: 'type'\n          existenceCondition: {\n            allOf: [\n              {\n                field: 'field'\n                equals: 'conditionValue'\n              }\n            ]\n          }\n          deployment: {\n            properties: {\n              mode: 'incremental'\n              template: {\n                '$schema': 'schema'\n                contentVersion: '1.0.0.0'\n                parameters: {\n                  parameterName: {\n                    type: 'String'\n                    metadata: {\n                      displayName: 'displayName'\n                      description: 'description'\n                    }\n                  }\n                }\n                variables: {}\n                resources: [\n                  {\n                    name: 'name'\n                    type: 'type'\n                    apiVersion: 'apiVersion'\n                    location: location\n                    properties: {}\n                  }\n                ]\n              }\n              parameters: {\n                parameterName: {\n                  value: 'value'\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2161,7 +2161,7 @@
     "detail": "Policy Definition",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource policyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = {\n  name: 'name'\n  properties: {\n    displayName: 'displayName'\n    policyType: 'Custom'\n    mode: 'All'\n    description: 'description'\n    metadata: {\n      version: '0.1.0'\n      category: 'category'\n      source: 'source'\n    }\n    parameters: {\n      parameterName: {\n        type: 'String'\n        defaultValue: 'defaultValue'\n        metadata: {\n          displayName: 'displayName'\n          description: 'description'\n        }\n      }\n    }\n    policyRule: {\n      if: {\n        allOf: [\n          {\n            field: 'field'\n            equals: 'conditionValue'\n          }\n        ]\n      }\n      then: {\n        effect: 'Audit'\n        details: {\n          roleDefinitionIds: [\n            'roleDefinitionIds'\n          ]\n          operations: [\n            {\n              operation: 'add'\n              field: 'field'\n              value: 'value'\n            }\n          ]\n        }\n      }\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource policyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = {\n  name: 'name'\n  properties: {\n    displayName: 'displayName'\n    policyType: 'Custom'\n    mode: 'All'\n    description: 'description'\n    metadata: {\n      version: '0.1.0'\n      category: 'category'\n      source: 'source'\n    }\n    parameters: {\n      parameterName: {\n        type: 'String'\n        defaultValue: 'defaultValue'\n        metadata: {\n          displayName: 'displayName'\n          description: 'description'\n        }\n      }\n    }\n    policyRule: {\n      if: {\n        allOf: [\n          {\n            field: 'field'\n            equals: 'conditionValue'\n          }\n        ]\n      }\n      then: {\n        effect: 'Audit'\n        details: {\n          roleDefinitionIds: [\n            'roleDefinitionIds'\n          ]\n          operations: [\n            {\n              operation: 'add'\n              field: 'field'\n              value: 'value'\n            }\n          ]\n        }\n      }\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2191,7 +2191,7 @@
     "detail": "Policy Exemption",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource policyExemption 'Microsoft.Authorization/policyExemptions@2020-07-01-preview' = {\n  name: 'name'\n  properties: {\n    policyAssignmentId: 'policyAssignmentId'\n    policyDefinitionReferenceIds: [\n      'policyDefinitionReferenceIds'\n    ]\n    exemptionCategory: 'Mitigated'\n    expiresOn: 'expiresOn'\n    displayName: 'displayName'\n    description: 'description'\n    metadata: {\n      version: '0.1.0'\n      source: 'source'\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource policyExemption 'Microsoft.Authorization/policyExemptions@2020-07-01-preview' = {\n  name: 'name'\n  properties: {\n    policyAssignmentId: 'policyAssignmentId'\n    policyDefinitionReferenceIds: [\n      'policyDefinitionReferenceIds'\n    ]\n    exemptionCategory: 'Mitigated'\n    expiresOn: 'expiresOn'\n    displayName: 'displayName'\n    description: 'description'\n    metadata: {\n      version: '0.1.0'\n      source: 'source'\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2221,7 +2221,7 @@
     "detail": "Guest configuration assignment for virtual machine",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: 'name'\n  location: location\n}\n\nresource guestConfigAssignment 'Microsoft.GuestConfiguration/guestConfigurationAssignments@2022-01-25' = {\n  name: 'name'\n  scope: virtualMachine\n  location: location\n  properties: {\n    guestConfiguration: {\n      name: 'configurationName'\n      assignmentType: 'ApplyAndMonitor'\n      version: '1.*'\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: 'name'\n  location: location\n}\n\nresource guestConfigAssignment 'Microsoft.GuestConfiguration/guestConfigurationAssignments@2022-01-25' = {\n  name: 'name'\n  scope: virtualMachine\n  location: location\n  properties: {\n    guestConfiguration: {\n      name: 'configurationName'\n      assignmentType: 'ApplyAndMonitor'\n      version: '1.*'\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2251,7 +2251,7 @@
     "detail": "Guest configuration assignment for virtual machine",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource arcEnabledMachine 'Microsoft.HybridCompute/machines@2021-05-20' = {\n  name: 'name'\n  location: location\n}\n\nresource guestConfigAssignment 'Microsoft.GuestConfiguration/guestConfigurationAssignments@2022-01-25' = {\n  name: 'name'\n  scope: arcEnabledMachine\n  location: location\n  properties: {\n    guestConfiguration: {\n      name: 'configurationName'\n      assignmentType: 'ApplyAndMonitor'\n      version: '1.*'\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource arcEnabledMachine 'Microsoft.HybridCompute/machines@2021-05-20' = {\n  name: 'name'\n  location: location\n}\n\nresource guestConfigAssignment 'Microsoft.GuestConfiguration/guestConfigurationAssignments@2022-01-25' = {\n  name: 'name'\n  scope: arcEnabledMachine\n  location: location\n  properties: {\n    guestConfiguration: {\n      name: 'configurationName'\n      assignmentType: 'ApplyAndMonitor'\n      version: '1.*'\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2281,7 +2281,7 @@
     "detail": "Guest configuration assignment with parameters, for virtual machine",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: 'name'\n  location: location\n}\n\nresource guestConfigAssignment 'Microsoft.GuestConfiguration/guestConfigurationAssignments@2022-01-25' = {\n  name: 'name'\n  scope: virtualMachine\n  location: location\n  properties: {\n    guestConfiguration: {\n      name: 'configurationName'\n      assignmentType: 'ApplyAndMonitor'\n      version: '1.*'\n      configurationParameter: [\n        {\n          name: 'parameter1[dscResourceType]dscResourceName;propertyName'\n          value: 'parameter1Value'\n        }\n        {\n          name: 'parameter2[dscResourceType]dscResourceName;propertyName'\n          value: 'parameter2Value'\n        }\n      ]\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: 'name'\n  location: location\n}\n\nresource guestConfigAssignment 'Microsoft.GuestConfiguration/guestConfigurationAssignments@2022-01-25' = {\n  name: 'name'\n  scope: virtualMachine\n  location: location\n  properties: {\n    guestConfiguration: {\n      name: 'configurationName'\n      assignmentType: 'ApplyAndMonitor'\n      version: '1.*'\n      configurationParameter: [\n        {\n          name: 'parameter1[dscResourceType]dscResourceName;propertyName'\n          value: 'parameter1Value'\n        }\n        {\n          name: 'parameter2[dscResourceType]dscResourceName;propertyName'\n          value: 'parameter2Value'\n        }\n      ]\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2311,7 +2311,7 @@
     "detail": "Policy Remediation",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource policyRemediation 'Microsoft.PolicyInsights/remediations@2019-07-01' = {\n  name: 'name'\n  properties: {\n    policyAssignmentId: 'policyAssignmentId'\n    policyDefinitionReferenceId: 'policyDefinitionReferenceId'\n    resourceDiscoveryMode: 'ExistingNonCompliant'\n    filters: {\n      locations: [\n        location\n      ]\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource policyRemediation 'Microsoft.PolicyInsights/remediations@2019-07-01' = {\n  name: 'name'\n  properties: {\n    policyAssignmentId: 'policyAssignmentId'\n    policyDefinitionReferenceId: 'policyDefinitionReferenceId'\n    resourceDiscoveryMode: 'ExistingNonCompliant'\n    filters: {\n      locations: [\n        location\n      ]\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2341,7 +2341,7 @@
     "detail": "PolicySet Definition",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource policySetDefinition 'Microsoft.Authorization/policySetDefinitions@2020-09-01' = {\n  name: 'name'\n  properties: {\n    displayName: 'displayName'\n    policyType: 'Custom'\n    description: 'description'\n    metadata: {\n      version: '0.1.0'\n      category: 'category'\n      source: 'source'\n    }\n    parameters: {\n      parameterName: {\n        type: 'String'\n        metadata: {\n          displayName: 'displayName'\n          description: 'description'\n        }\n      }\n    }\n    policyDefinitions: [\n      {\n        policyDefinitionId: 'policyDefinitionId'\n        policyDefinitionReferenceId: 'policyDefinitionReferenceId'\n        parameters: {\n          parameterName: {\n            value: 'value'\n          }\n        }\n      }\n      {\n        policyDefinitionId: 'policyDefinitionId'\n        policyDefinitionReferenceId: 'policyDefinitionReferenceId'\n        parameters: {\n          parameterName: {\n            value: 'value'\n          }\n        }\n      }\n    ]\n  }\n}\n\n```"
+      "value": "```bicep\nresource policySetDefinition 'Microsoft.Authorization/policySetDefinitions@2020-09-01' = {\n  name: 'name'\n  properties: {\n    displayName: 'displayName'\n    policyType: 'Custom'\n    description: 'description'\n    metadata: {\n      version: '0.1.0'\n      category: 'category'\n      source: 'source'\n    }\n    parameters: {\n      parameterName: {\n        type: 'String'\n        metadata: {\n          displayName: 'displayName'\n          description: 'description'\n        }\n      }\n    }\n    policyDefinitions: [\n      {\n        policyDefinitionId: 'policyDefinitionId'\n        policyDefinitionReferenceId: 'policyDefinitionReferenceId'\n        parameters: {\n          parameterName: {\n            value: 'value'\n          }\n        }\n      }\n      {\n        policyDefinitionId: 'policyDefinitionId'\n        policyDefinitionReferenceId: 'policyDefinitionReferenceId'\n        parameters: {\n          parameterName: {\n            value: 'value'\n          }\n        }\n      }\n    ]\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2371,7 +2371,7 @@
     "detail": "",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource privateEndpoint 'Microsoft.Network/privateEndpoints@2022-01-01' = {\n  name: name\n  location: location\n  properties: {\n    privateLinkServiceConnections: [\n      {\n        name: name\n        properties: {\n          privateLinkServiceId: privateLinkServiceId\n          groupIds: [\n            groupId\n          ]\n        }\n      }\n    ]\n    subnet: {\n      id: subnetId\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource privateEndpoint 'Microsoft.Network/privateEndpoints@2022-01-01' = {\n  name: name\n  location: location\n  properties: {\n    privateLinkServiceConnections: [\n      {\n        name: name\n        properties: {\n          privateLinkServiceId: privateLinkServiceId\n          groupIds: [\n            groupId\n          ]\n        }\n      }\n    ]\n    subnet: {\n      id: subnetId\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2401,7 +2401,7 @@
     "detail": "Recovery Service Vault",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource recoveryServiceVault 'Microsoft.RecoveryServices/vaults@2021-01-01' = {\n  name: 'name'\n  location: location\n  sku: {\n    name: 'RS0'\n    tier: 'Standard'\n  }\n}\n\n```"
+      "value": "```bicep\nresource recoveryServiceVault 'Microsoft.RecoveryServices/vaults@2021-01-01' = {\n  name: 'name'\n  location: location\n  sku: {\n    name: 'RS0'\n    tier: 'Standard'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2431,7 +2431,7 @@
     "detail": "Redis Cache",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource redisCache 'Microsoft.Cache/Redis@2019-07-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    sku: {\n      name: 'Basic'\n      family: 'C'\n      capacity: 0\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource redisCache 'Microsoft.Cache/Redis@2019-07-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    sku: {\n      name: 'Basic'\n      family: 'C'\n      capacity: 0\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2461,7 +2461,7 @@
     "detail": "Resource Group",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {\n  name: 'name'\n  location: location\n}\n\n```"
+      "value": "```bicep\nresource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {\n  name: 'name'\n  location: location\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2491,7 +2491,7 @@
     "detail": "",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = {\n  name: 'name'\n  properties: {\n    roleDefinitionId: 'roleDefinitionId'\n    principalId: 'principalId'\n    principalType: 'ServicePrincipal'\n  }\n}\n\n```"
+      "value": "```bicep\nresource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = {\n  name: 'name'\n  properties: {\n    roleDefinitionId: 'roleDefinitionId'\n    principalId: 'principalId'\n    principalType: 'ServicePrincipal'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2521,7 +2521,7 @@
     "detail": "Route Server",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource virtualHub 'Microsoft.Network/virtualHubs@2021-02-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    sku: 'Standard'\n  }\n}\n\nresource ipConfiguration 'Microsoft.Network/virtualHubs/ipConfigurations@2021-02-01' = {\n  name: 'name'\n  parent: virtualHub\n  properties: {\n    subnet: {\n      id: 'subnet.id'\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource virtualHub 'Microsoft.Network/virtualHubs@2021-02-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    sku: 'Standard'\n  }\n}\n\nresource ipConfiguration 'Microsoft.Network/virtualHubs/ipConfigurations@2021-02-01' = {\n  name: 'name'\n  parent: virtualHub\n  properties: {\n    subnet: {\n      id: 'subnet.id'\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2551,7 +2551,7 @@
     "detail": "Route Table",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource routeTable 'Microsoft.Network/routeTables@2019-11-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    routes: [\n      {\n        name: 'name'\n        properties: {\n          addressPrefix: 'destinationCIDR'\n          nextHopType: 'VirtualNetworkGateway'\n          nextHopIpAddress: 'nextHopIp'\n        }\n      }\n    ]\n    disableBgpRoutePropagation: true\n  }\n}\n\n```"
+      "value": "```bicep\nresource routeTable 'Microsoft.Network/routeTables@2019-11-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    routes: [\n      {\n        name: 'name'\n        properties: {\n          addressPrefix: 'destinationCIDR'\n          nextHopType: 'VirtualNetworkGateway'\n          nextHopIpAddress: 'nextHopIp'\n        }\n      }\n    ]\n    disableBgpRoutePropagation: true\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2581,7 +2581,7 @@
     "detail": "Azure Route Table Route",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource routeTableRoute 'Microsoft.Network/routeTables/routes@2019-11-01' = {\n  name: 'routeTableName/name'\n  properties: {\n    addressPrefix: 'addressPrefix'\n    nextHopType: 'VirtualNetworkGateway'\n    nextHopIpAddress: 'nextHopIp'\n  }\n}\n\n```"
+      "value": "```bicep\nresource routeTableRoute 'Microsoft.Network/routeTables/routes@2019-11-01' = {\n  name: 'routeTableName/name'\n  properties: {\n    addressPrefix: 'addressPrefix'\n    nextHopType: 'VirtualNetworkGateway'\n    nextHopIpAddress: 'nextHopIp'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2611,7 +2611,7 @@
     "detail": "",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource lock 'Microsoft.Authorization/locks@2017-04-01' = {\n  name: 'name'\n  scope: scopeResource\n  properties: {\n    level: 'NotSpecified'\n  }\n}\n\n```"
+      "value": "```bicep\nresource lock 'Microsoft.Authorization/locks@2017-04-01' = {\n  name: 'name'\n  scope: scopeResource\n  properties: {\n    level: 'NotSpecified'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2641,7 +2641,7 @@
     "detail": "Service Bus Namespace",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2021-06-01-preview' = {\n  name: 'name'\n  location: location\n  sku: {\n    name: 'Basic'\n    capacity: 1\n    tier: 'Basic'\n  }\n}\n\n```"
+      "value": "```bicep\nresource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2021-06-01-preview' = {\n  name: 'name'\n  location: location\n  sku: {\n    name: 'Basic'\n    capacity: 1\n    tier: 'Basic'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2671,7 +2671,7 @@
     "detail": "Create Image Gallery",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource sharedImageGallery 'Microsoft.Compute/galleries@2020-09-30' = {\n  name: 'name'\n  location: location\n  properties: {\n    description: 'description'\n  }\n}\n\n```"
+      "value": "```bicep\nresource sharedImageGallery 'Microsoft.Compute/galleries@2020-09-30' = {\n  name: 'name'\n  location: location\n  properties: {\n    description: 'description'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2701,7 +2701,7 @@
     "detail": "SQL Database",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource sqlServer 'Microsoft.Sql/servers@2014-04-01' ={\n  name: 'name'\n  location: location\n}\n\nresource sqlServerDatabase 'Microsoft.Sql/servers/databases@2014-04-01' = {\n  parent: sqlServer\n  name: 'name'\n  location: location\n  properties: {\n    collation: 'collation'\n    edition: 'Basic'\n    maxSizeBytes: 'maxSizeBytes'\n    requestedServiceObjectiveName: 'Basic'\n  }\n}\n\n```"
+      "value": "```bicep\nresource sqlServer 'Microsoft.Sql/servers@2014-04-01' ={\n  name: 'name'\n  location: location\n}\n\nresource sqlServerDatabase 'Microsoft.Sql/servers/databases@2014-04-01' = {\n  parent: sqlServer\n  name: 'name'\n  location: location\n  properties: {\n    collation: 'collation'\n    edition: 'Basic'\n    maxSizeBytes: 'maxSizeBytes'\n    requestedServiceObjectiveName: 'Basic'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2731,7 +2731,7 @@
     "detail": "SQL Database Import",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource sqlServerDatabase 'Microsoft.Sql/servers/databases@2014-04-01' = {\n  name: 'name'\n  location: location\n}\n\nresource sqlDatabaseImport 'Microsoft.Sql/servers/databases/extensions@2014-04-01' = {\n  parent: sqlServerDatabase\n  name: 'import'\n  properties: {\n    storageKeyType: 'StorageAccessKey'\n    storageKey: 'storageKey'\n    storageUri: 'storageUri'\n    administratorLogin: 'administratorLogin'\n    administratorLoginPassword: 'administratorLoginPassword'\n    operationMode: 'Import'\n  }\n}\n\n```"
+      "value": "```bicep\nresource sqlServerDatabase 'Microsoft.Sql/servers/databases@2014-04-01' = {\n  name: 'name'\n  location: location\n}\n\nresource sqlDatabaseImport 'Microsoft.Sql/servers/databases/extensions@2014-04-01' = {\n  parent: sqlServerDatabase\n  name: 'import'\n  properties: {\n    storageKeyType: 'StorageAccessKey'\n    storageKey: 'storageKey'\n    storageUri: 'storageUri'\n    administratorLogin: 'administratorLogin'\n    administratorLoginPassword: 'administratorLoginPassword'\n    operationMode: 'Import'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2761,7 +2761,7 @@
     "detail": "SQL Server Firewall Rules",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource sqlServer 'Microsoft.Sql/servers@2021-02-01-preview' = {\n  name: 'name'\n  location: location\n  properties: {\n    administratorLogin: 'administratorLogin'\n    administratorLoginPassword: 'administratorLoginPassword'\n  }\n}\n\nresource sqlServerFirewallRules 'Microsoft.Sql/servers/firewallRules@2021-02-01-preview' = {\n  parent: sqlServer\n  name: 'name'\n  properties: {\n    startIpAddress: 'startIpAddress'\n    endIpAddress: 'endIpAddress'\n  }\n}\n\n```"
+      "value": "```bicep\nresource sqlServer 'Microsoft.Sql/servers@2021-02-01-preview' = {\n  name: 'name'\n  location: location\n  properties: {\n    administratorLogin: 'administratorLogin'\n    administratorLoginPassword: 'administratorLoginPassword'\n  }\n}\n\nresource sqlServerFirewallRules 'Microsoft.Sql/servers/firewallRules@2021-02-01-preview' = {\n  parent: sqlServer\n  name: 'name'\n  properties: {\n    startIpAddress: 'startIpAddress'\n    endIpAddress: 'endIpAddress'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2791,7 +2791,7 @@
     "detail": "Storage Account",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource storageaccount 'Microsoft.Storage/storageAccounts@2021-02-01' = {\n  name: 'name'\n  location: location\n  kind: 'StorageV2'\n  sku: {\n    name: 'Premium_LRS'\n  }\n}\n\n```"
+      "value": "```bicep\nresource storageaccount 'Microsoft.Storage/storageAccounts@2021-02-01' = {\n  name: 'name'\n  location: location\n  kind: 'StorageV2'\n  sku: {\n    name: 'Premium_LRS'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2821,7 +2821,7 @@
     "detail": "Template spec",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource templateSpec 'Microsoft.Resources/templateSpecs@2021-05-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    description: 'description'\n    displayName: 'displayName'\n  }\n}\n\n```"
+      "value": "```bicep\nresource templateSpec 'Microsoft.Resources/templateSpecs@2021-05-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    description: 'description'\n    displayName: 'displayName'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2851,7 +2851,7 @@
     "detail": "Traffic Manager Profile",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource trafficManagerProfile 'Microsoft.Network/trafficManagerProfiles@2018-08-01' = {\n  name: 'name'\n  location: 'global'\n  properties: {\n    profileStatus: 'Enabled'\n    trafficRoutingMethod: 'Performance'\n    dnsConfig: {\n      relativeName: 'dnsConfigRelativeName'\n      ttl: 30\n    }\n    monitorConfig: {\n      protocol: 'HTTP'\n      port: 80\n      path: 'path'\n      intervalInSeconds: 30\n      timeoutInSeconds: 5\n      toleratedNumberOfFailures: 3\n    }\n    endpoints: [\n      {\n        properties: {\n          targetResourceId: 'targetResourceId'\n          endpointStatus: 'Enabled'\n          weight: 100\n          priority: 1\n        }\n      }\n    ]\n  }\n}\n\n```"
+      "value": "```bicep\nresource trafficManagerProfile 'Microsoft.Network/trafficManagerProfiles@2018-08-01' = {\n  name: 'name'\n  location: 'global'\n  properties: {\n    profileStatus: 'Enabled'\n    trafficRoutingMethod: 'Performance'\n    dnsConfig: {\n      relativeName: 'dnsConfigRelativeName'\n      ttl: 30\n    }\n    monitorConfig: {\n      protocol: 'HTTP'\n      port: 80\n      path: 'path'\n      intervalInSeconds: 30\n      timeoutInSeconds: 5\n      toleratedNumberOfFailures: 3\n    }\n    endpoints: [\n      {\n        properties: {\n          targetResourceId: 'targetResourceId'\n          endpointStatus: 'Enabled'\n          weight: 100\n          priority: 1\n        }\n      }\n    ]\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2881,7 +2881,7 @@
     "detail": "Virtual WAN",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource virtualWan 'Microsoft.Network/virtualWans@2020-07-01' = {\n  name: 'name'\n  location: location\n  properties: any({\n    type: 'Standard'\n    disableVpnEncryption: false\n    allowBranchToBranchTraffic: true\n    allowVnetToVnetTraffic: true\n    office365LocalBreakoutCategory: 'Optimize'\n  })\n}\n\n```"
+      "value": "```bicep\nresource virtualWan 'Microsoft.Network/virtualWans@2020-07-01' = {\n  name: 'name'\n  location: location\n  properties: any({\n    type: 'Standard'\n    disableVpnEncryption: false\n    allowBranchToBranchTraffic: true\n    allowVnetToVnetTraffic: true\n    office365LocalBreakoutCategory: 'Optimize'\n  })\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2911,7 +2911,7 @@
     "detail": "Desired State Configuration PowerShell script for a Windows Virtual Machine",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: 'name'\n  location: location\n}\n\nresource windowsVMDsc 'Microsoft.Compute/virtualMachines/extensions@2020-12-01' = {\n  parent: virtualMachine\n  name: 'name'\n  location: location\n  properties: {\n    publisher: 'Microsoft.Powershell'\n    type: 'DSC'\n    typeHandlerVersion: '2.9'\n    autoUpgradeMinorVersion: true\n    settings: {\n      modulesUrl: 'modulesUrl'\n      sasToken: 'sasToken'\n      configurationFunction: 'configurationFunction'\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: 'name'\n  location: location\n}\n\nresource windowsVMDsc 'Microsoft.Compute/virtualMachines/extensions@2020-12-01' = {\n  parent: virtualMachine\n  name: 'name'\n  location: location\n  properties: {\n    publisher: 'Microsoft.Powershell'\n    type: 'DSC'\n    typeHandlerVersion: '2.9'\n    autoUpgradeMinorVersion: true\n    settings: {\n      modulesUrl: 'modulesUrl'\n      sasToken: 'sasToken'\n      configurationFunction: 'configurationFunction'\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2941,7 +2941,7 @@
     "detail": "Guest configuration extension for Linux virtual machine",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: 'name'\n  location: location\n  identity: {\n    type:'SystemAssigned'\n  }\n}\n\nresource windowsVMGuestConfigExtension 'Microsoft.Compute/virtualMachines/extensions@2020-12-01' = {\n  parent: virtualMachine\n  name: 'AzurePolicyforLinux'\n  location: location\n  properties: {\n    publisher: 'Microsoft.GuestConfiguration'\n    type: 'ConfigurationforLinux'\n    typeHandlerVersion: '1.0'\n    autoUpgradeMinorVersion: true\n    enableAutomaticUpgrade: true\n    settings: {}\n    protectedSettings: {}\n  }\n}\n\n```"
+      "value": "```bicep\nresource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: 'name'\n  location: location\n  identity: {\n    type:'SystemAssigned'\n  }\n}\n\nresource windowsVMGuestConfigExtension 'Microsoft.Compute/virtualMachines/extensions@2020-12-01' = {\n  parent: virtualMachine\n  name: 'AzurePolicyforLinux'\n  location: location\n  properties: {\n    publisher: 'Microsoft.GuestConfiguration'\n    type: 'ConfigurationforLinux'\n    typeHandlerVersion: '1.0'\n    autoUpgradeMinorVersion: true\n    enableAutomaticUpgrade: true\n    settings: {}\n    protectedSettings: {}\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2971,7 +2971,7 @@
     "detail": "Custom script extension for Linux Virtual Machine",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: 'name'\n  location: location\n}\n\nresource linuxVMExtensions 'Microsoft.Compute/virtualMachines/extensions@2019-07-01' = {\n  parent: virtualMachine\n  name: 'name'\n  location: location\n  properties: {\n    publisher: 'Microsoft.Azure.Extensions'\n    type: 'CustomScript'\n    typeHandlerVersion: '2.1'\n    autoUpgradeMinorVersion: true\n    settings: {\n      fileUris: [\n        'fileUris'\n      ]\n    }\n    protectedSettings: {\n      commandToExecute: 'sh customScript.sh'\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: 'name'\n  location: location\n}\n\nresource linuxVMExtensions 'Microsoft.Compute/virtualMachines/extensions@2019-07-01' = {\n  parent: virtualMachine\n  name: 'name'\n  location: location\n  properties: {\n    publisher: 'Microsoft.Azure.Extensions'\n    type: 'CustomScript'\n    typeHandlerVersion: '2.1'\n    autoUpgradeMinorVersion: true\n    settings: {\n      fileUris: [\n        'fileUris'\n      ]\n    }\n    protectedSettings: {\n      commandToExecute: 'sh customScript.sh'\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3001,7 +3001,7 @@
     "detail": "Custom script extension for a Windows Virtual Machine",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: 'name'\n  location: location\n}\n\nresource windowsVMExtensions 'Microsoft.Compute/virtualMachines/extensions@2020-12-01' = {\n  parent: virtualMachine\n  name: 'name'\n  location: location\n  properties: {\n    publisher: 'Microsoft.Compute'\n    type: 'CustomScriptExtension'\n    typeHandlerVersion: '1.10'\n    autoUpgradeMinorVersion: true\n    settings: {\n      fileUris: [\n        'fileUris'\n      ]\n    }\n    protectedSettings: {\n      commandToExecute: 'powershell -ExecutionPolicy Bypass -file customScript.ps1'\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: 'name'\n  location: location\n}\n\nresource windowsVMExtensions 'Microsoft.Compute/virtualMachines/extensions@2020-12-01' = {\n  parent: virtualMachine\n  name: 'name'\n  location: location\n  properties: {\n    publisher: 'Microsoft.Compute'\n    type: 'CustomScriptExtension'\n    typeHandlerVersion: '1.10'\n    autoUpgradeMinorVersion: true\n    settings: {\n      fileUris: [\n        'fileUris'\n      ]\n    }\n    protectedSettings: {\n      commandToExecute: 'powershell -ExecutionPolicy Bypass -file customScript.ps1'\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3031,7 +3031,7 @@
     "detail": "Ubuntu Virtual Machine",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource ubuntuVM 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    hardwareProfile: {\n      vmSize: 'Standard_A2_v2'\n    }\n    osProfile: {\n      computerName: 'computerName'\n      adminUsername: 'adminUsername'\n      adminPassword: 'adminPassword'\n    }\n    storageProfile: {\n      imageReference: {\n        publisher: 'Canonical'\n        offer: 'UbuntuServer'\n        sku: '16.04-LTS'\n        version: 'latest'\n      }\n      osDisk: {\n        name: 'name'\n        caching: 'ReadWrite'\n        createOption: 'FromImage'\n      }\n    }\n    networkProfile: {\n      networkInterfaces: [\n        {\n          id: 'id'\n        }\n      ]\n    }\n    diagnosticsProfile: {\n      bootDiagnostics: {\n        enabled: true\n        storageUri: 'storageUri'\n      }\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource ubuntuVM 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    hardwareProfile: {\n      vmSize: 'Standard_A2_v2'\n    }\n    osProfile: {\n      computerName: 'computerName'\n      adminUsername: 'adminUsername'\n      adminPassword: 'adminPassword'\n    }\n    storageProfile: {\n      imageReference: {\n        publisher: 'Canonical'\n        offer: 'UbuntuServer'\n        sku: '16.04-LTS'\n        version: 'latest'\n      }\n      osDisk: {\n        name: 'name'\n        caching: 'ReadWrite'\n        createOption: 'FromImage'\n      }\n    }\n    networkProfile: {\n      networkInterfaces: [\n        {\n          id: 'id'\n        }\n      ]\n    }\n    diagnosticsProfile: {\n      bootDiagnostics: {\n        enabled: true\n        storageUri: 'storageUri'\n      }\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3061,7 +3061,7 @@
     "detail": "Windows Virtual Machine",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource windowsVM 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    hardwareProfile: {\n      vmSize: 'Standard_A2_v2'\n    }\n    osProfile: {\n      computerName: 'computerName'\n      adminUsername: 'adminUsername'\n      adminPassword: 'adminPassword'\n    }\n    storageProfile: {\n      imageReference: {\n        publisher: 'MicrosoftWindowsServer'\n        offer: 'WindowsServer'\n        sku: '2012-R2-Datacenter'\n        version: 'latest'\n      }\n      osDisk: {\n        name: 'name'\n        caching: 'ReadWrite'\n        createOption: 'FromImage'\n      }\n    }\n    networkProfile: {\n      networkInterfaces: [\n        {\n          id: 'id'\n        }\n      ]\n    }\n    diagnosticsProfile: {\n      bootDiagnostics: {\n        enabled: true\n        storageUri:  'storageUri'\n      }\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource windowsVM 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    hardwareProfile: {\n      vmSize: 'Standard_A2_v2'\n    }\n    osProfile: {\n      computerName: 'computerName'\n      adminUsername: 'adminUsername'\n      adminPassword: 'adminPassword'\n    }\n    storageProfile: {\n      imageReference: {\n        publisher: 'MicrosoftWindowsServer'\n        offer: 'WindowsServer'\n        sku: '2012-R2-Datacenter'\n        version: 'latest'\n      }\n      osDisk: {\n        name: 'name'\n        caching: 'ReadWrite'\n        createOption: 'FromImage'\n      }\n    }\n    networkProfile: {\n      networkInterfaces: [\n        {\n          id: 'id'\n        }\n      ]\n    }\n    diagnosticsProfile: {\n      bootDiagnostics: {\n        enabled: true\n        storageUri:  'storageUri'\n      }\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3091,7 +3091,7 @@
     "detail": "Diagnostics Extension for a Windows Virtual Machine",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource windowsVMDiagnostics 'Microsoft.Compute/virtualMachines/extensions@2020-12-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    publisher: 'Microsoft.Azure.Diagnostics'\n    type: 'IaaSDiagnostics'\n    typeHandlerVersion: '1.5'\n    autoUpgradeMinorVersion: true\n    settings: {\n      xmlCfg: base64('<WadCfg> <DiagnosticMonitorConfiguration overallQuotaInMB=\"4096\" xmlns=\"http://schemas.microsoft.com/ServiceHosting/2010/10/DiagnosticsConfiguration\"> <DiagnosticInfrastructureLogs scheduledTransferLogLevelFilter=\"Error\"/> <Logs scheduledTransferPeriod=\"PT1M\" scheduledTransferLogLevelFilter=\"Error\" /> <Directories scheduledTransferPeriod=\"PT1M\"> <IISLogs containerName =\"wad-iis-logfiles\" /> <FailedRequestLogs containerName =\"wad-failedrequestlogs\" /> </Directories> <WindowsEventLog scheduledTransferPeriod=\"PT1M\" > <DataSource name=\"Application!*\" /> </WindowsEventLog> <CrashDumps containerName=\"wad-crashdumps\" dumpType=\"Mini\"> <CrashDumpConfiguration processName=\"WaIISHost.exe\"/> <CrashDumpConfiguration processName=\"WaWorkerHost.exe\"/> <CrashDumpConfiguration processName=\"w3wp.exe\"/> </CrashDumps> <PerformanceCounters scheduledTransferPeriod=\"PT1M\"> <PerformanceCounterConfiguration counterSpecifier=\"\\\\\\\\\\\\\\\\Memory\\\\\\\\\\\\\\\\Available MBytes\" sampleRate=\"PT3M\" /> <PerformanceCounterConfiguration counterSpecifier=\"\\\\\\\\\\\\\\\\Web Service(_Total)\\\\\\\\\\\\\\\\ISAPI Extension Requests/sec\" sampleRate=\"PT3M\" /> <PerformanceCounterConfiguration counterSpecifier=\"\\\\\\\\\\\\\\\\Web Service(_Total)\\\\\\\\\\\\\\\\Bytes Total/Sec\" sampleRate=\"PT3M\" /> <PerformanceCounterConfiguration counterSpecifier=\"\\\\\\\\\\\\\\\\ASP.NET Applications(__Total__)\\\\\\\\\\\\\\\\Requests/Sec\" sampleRate=\"PT3M\" /> <PerformanceCounterConfiguration counterSpecifier=\"\\\\\\\\\\\\\\\\ASP.NET Applications(__Total__)\\\\\\\\\\\\\\\\Errors Total/Sec\" sampleRate=\"PT3M\" /> <PerformanceCounterConfiguration counterSpecifier=\"\\\\\\\\\\\\\\\\ASP.NET\\\\\\\\\\\\\\\\Requests Queued\" sampleRate=\"PT3M\" /> <PerformanceCounterConfiguration counterSpecifier=\"\\\\\\\\\\\\\\\\ASP.NET\\\\\\\\\\\\\\\\Requests Rejected\" sampleRate=\"PT3M\" /> <PerformanceCounterConfiguration counterSpecifier=\"\\\\\\\\\\\\\\\\Processor(_Total)\\\\\\\\\\\\\\\\% Processor Time\" sampleRate=\"PT3M\" /> </PerformanceCounters> </DiagnosticMonitorConfiguration> </WadCfg>')\n      storageAccount: 'storageAccount'\n    }\n    protectedSettings: {\n      storageAccountName: 'storageAccountName'\n      storageAccountKey: 'storageAccountKey'\n      storageAccountEndPoint: 'storageAccountEndPoint'\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource windowsVMDiagnostics 'Microsoft.Compute/virtualMachines/extensions@2020-12-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    publisher: 'Microsoft.Azure.Diagnostics'\n    type: 'IaaSDiagnostics'\n    typeHandlerVersion: '1.5'\n    autoUpgradeMinorVersion: true\n    settings: {\n      xmlCfg: base64('<WadCfg> <DiagnosticMonitorConfiguration overallQuotaInMB=\"4096\" xmlns=\"http://schemas.microsoft.com/ServiceHosting/2010/10/DiagnosticsConfiguration\"> <DiagnosticInfrastructureLogs scheduledTransferLogLevelFilter=\"Error\"/> <Logs scheduledTransferPeriod=\"PT1M\" scheduledTransferLogLevelFilter=\"Error\" /> <Directories scheduledTransferPeriod=\"PT1M\"> <IISLogs containerName =\"wad-iis-logfiles\" /> <FailedRequestLogs containerName =\"wad-failedrequestlogs\" /> </Directories> <WindowsEventLog scheduledTransferPeriod=\"PT1M\" > <DataSource name=\"Application!*\" /> </WindowsEventLog> <CrashDumps containerName=\"wad-crashdumps\" dumpType=\"Mini\"> <CrashDumpConfiguration processName=\"WaIISHost.exe\"/> <CrashDumpConfiguration processName=\"WaWorkerHost.exe\"/> <CrashDumpConfiguration processName=\"w3wp.exe\"/> </CrashDumps> <PerformanceCounters scheduledTransferPeriod=\"PT1M\"> <PerformanceCounterConfiguration counterSpecifier=\"\\\\\\\\\\\\\\\\Memory\\\\\\\\\\\\\\\\Available MBytes\" sampleRate=\"PT3M\" /> <PerformanceCounterConfiguration counterSpecifier=\"\\\\\\\\\\\\\\\\Web Service(_Total)\\\\\\\\\\\\\\\\ISAPI Extension Requests/sec\" sampleRate=\"PT3M\" /> <PerformanceCounterConfiguration counterSpecifier=\"\\\\\\\\\\\\\\\\Web Service(_Total)\\\\\\\\\\\\\\\\Bytes Total/Sec\" sampleRate=\"PT3M\" /> <PerformanceCounterConfiguration counterSpecifier=\"\\\\\\\\\\\\\\\\ASP.NET Applications(__Total__)\\\\\\\\\\\\\\\\Requests/Sec\" sampleRate=\"PT3M\" /> <PerformanceCounterConfiguration counterSpecifier=\"\\\\\\\\\\\\\\\\ASP.NET Applications(__Total__)\\\\\\\\\\\\\\\\Errors Total/Sec\" sampleRate=\"PT3M\" /> <PerformanceCounterConfiguration counterSpecifier=\"\\\\\\\\\\\\\\\\ASP.NET\\\\\\\\\\\\\\\\Requests Queued\" sampleRate=\"PT3M\" /> <PerformanceCounterConfiguration counterSpecifier=\"\\\\\\\\\\\\\\\\ASP.NET\\\\\\\\\\\\\\\\Requests Rejected\" sampleRate=\"PT3M\" /> <PerformanceCounterConfiguration counterSpecifier=\"\\\\\\\\\\\\\\\\Processor(_Total)\\\\\\\\\\\\\\\\% Processor Time\" sampleRate=\"PT3M\" /> </PerformanceCounters> </DiagnosticMonitorConfiguration> </WadCfg>')\n      storageAccount: 'storageAccount'\n    }\n    protectedSettings: {\n      storageAccountName: 'storageAccountName'\n      storageAccountKey: 'storageAccountKey'\n      storageAccountEndPoint: 'storageAccountEndPoint'\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3121,7 +3121,7 @@
     "detail": "Guest configuration assignment for Windows virtual machine",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: 'name'\n  location: location\n  identity: {\n    type:'SystemAssigned'\n  }\n}\n\nresource windowsVMGuestConfigExtension 'Microsoft.Compute/virtualMachines/extensions@2020-12-01' = {\n  parent: virtualMachine\n  name: 'AzurePolicyforWindows'\n  location: location\n  properties: {\n    publisher: 'Microsoft.GuestConfiguration'\n    type: 'ConfigurationforWindows'\n    typeHandlerVersion: '1.0'\n    autoUpgradeMinorVersion: true\n    enableAutomaticUpgrade: true\n    settings: {}\n    protectedSettings: {}\n  }\n}\n\n```"
+      "value": "```bicep\nresource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: 'name'\n  location: location\n  identity: {\n    type:'SystemAssigned'\n  }\n}\n\nresource windowsVMGuestConfigExtension 'Microsoft.Compute/virtualMachines/extensions@2020-12-01' = {\n  parent: virtualMachine\n  name: 'AzurePolicyforWindows'\n  location: location\n  properties: {\n    publisher: 'Microsoft.GuestConfiguration'\n    type: 'ConfigurationforWindows'\n    typeHandlerVersion: '1.0'\n    autoUpgradeMinorVersion: true\n    enableAutomaticUpgrade: true\n    settings: {}\n    protectedSettings: {}\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3151,7 +3151,7 @@
     "detail": "Virtual Network",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource virtualNetwork 'Microsoft.Network/virtualNetworks@2019-11-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    addressSpace: {\n      addressPrefixes: [\n        '10.0.0.0/16'\n      ]\n    }\n    subnets: [\n      {\n        name: 'Subnet-1'\n        properties: {\n          addressPrefix: '10.0.0.0/24'\n        }\n      }\n      {\n        name: 'Subnet-2'\n        properties: {\n          addressPrefix: '10.0.1.0/24'\n        }\n      }\n    ]\n  }\n}\n\n```"
+      "value": "```bicep\nresource virtualNetwork 'Microsoft.Network/virtualNetworks@2019-11-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    addressSpace: {\n      addressPrefixes: [\n        '10.0.0.0/16'\n      ]\n    }\n    subnets: [\n      {\n        name: 'Subnet-1'\n        properties: {\n          addressPrefix: '10.0.0.0/24'\n        }\n      }\n      {\n        name: 'Subnet-2'\n        properties: {\n          addressPrefix: '10.0.1.0/24'\n        }\n      }\n    ]\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3181,7 +3181,7 @@
     "detail": "Virtual Network Peering",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource peering 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2020-07-01' = {\n  name: 'virtualNetwork/name'\n  properties: {\n    allowVirtualNetworkAccess: true\n    allowForwardedTraffic: true\n    allowGatewayTransit: true\n    useRemoteGateways: true\n    remoteVirtualNetwork: {\n      id: 'virtualNetworks.id'\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource peering 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2020-07-01' = {\n  name: 'virtualNetwork/name'\n  properties: {\n    allowVirtualNetworkAccess: true\n    allowForwardedTraffic: true\n    allowGatewayTransit: true\n    useRemoteGateways: true\n    remoteVirtualNetwork: {\n      id: 'virtualNetworks.id'\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3211,7 +3211,7 @@
     "detail": "VPN Local Network Gateway",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource localNetworkGateway 'Microsoft.Network/localNetworkGateways@2019-11-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    localNetworkAddressSpace: {\n      addressPrefixes: [\n        'REQUIRED'\n      ]\n    }\n    gatewayIpAddress: 'gatewayIpAddress'\n  }\n}\n\n```"
+      "value": "```bicep\nresource localNetworkGateway 'Microsoft.Network/localNetworkGateways@2019-11-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    localNetworkAddressSpace: {\n      addressPrefixes: [\n        'REQUIRED'\n      ]\n    }\n    gatewayIpAddress: 'gatewayIpAddress'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3241,7 +3241,7 @@
     "detail": "VPN Virtual Network Connection",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource vpnVnetConnection 'Microsoft.Network/connections@2020-11-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    virtualNetworkGateway1: {\n      id: 'virtualNetworkGateways.id'\n      properties:{}\n    }\n    localNetworkGateway2: {\n      id: 'localNetworkGateways.id'\n      properties:{}\n    }\n    connectionType: 'IPsec'\n    routingWeight: 0\n    sharedKey: 'sharedkey'\n  }\n}\n\n```"
+      "value": "```bicep\nresource vpnVnetConnection 'Microsoft.Network/connections@2020-11-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    virtualNetworkGateway1: {\n      id: 'virtualNetworkGateways.id'\n      properties:{}\n    }\n    localNetworkGateway2: {\n      id: 'localNetworkGateways.id'\n      properties:{}\n    }\n    connectionType: 'IPsec'\n    routingWeight: 0\n    sharedKey: 'sharedkey'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3271,7 +3271,7 @@
     "detail": "VPN Virtual Network Gateway",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource virtualNetworkGateway 'Microsoft.Network/virtualNetworkGateways@2020-11-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    ipConfigurations: [\n      {\n        name: 'name'\n        properties: {\n          privateIPAllocationMethod: 'Dynamic'\n          subnet: {\n            id: 'subnet.id'\n          }\n          publicIPAddress: {\n            id: 'publicIPAdresses.id'\n          }\n        }\n      }\n    ]\n    sku: {\n      name: 'Basic'\n      tier: 'Basic'\n    }\n    gatewayType: 'Vpn'\n    vpnType: 'PolicyBased'\n    enableBgp: true\n  }\n}\n\n```"
+      "value": "```bicep\nresource virtualNetworkGateway 'Microsoft.Network/virtualNetworkGateways@2020-11-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    ipConfigurations: [\n      {\n        name: 'name'\n        properties: {\n          privateIPAllocationMethod: 'Dynamic'\n          subnet: {\n            id: 'subnet.id'\n          }\n          publicIPAddress: {\n            id: 'publicIPAdresses.id'\n          }\n        }\n      }\n    ]\n    sku: {\n      name: 'Basic'\n      tier: 'Basic'\n    }\n    gatewayType: 'Vpn'\n    vpnType: 'PolicyBased'\n    enableBgp: true\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3301,7 +3301,7 @@
     "detail": "Web Application",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource webApplication 'Microsoft.Web/sites@2021-01-15' = {\n  name: 'name'\n  location: location\n  tags: {\n    'hidden-related:${resourceGroup().id}/providers/Microsoft.Web/serverfarms/appServicePlan': 'Resource'\n  }\n  properties: {\n    serverFarmId: 'webServerFarms.id'\n  }\n}\n\n```"
+      "value": "```bicep\nresource webApplication 'Microsoft.Web/sites@2021-01-15' = {\n  name: 'name'\n  location: location\n  tags: {\n    'hidden-related:${resourceGroup().id}/providers/Microsoft.Web/serverfarms/appServicePlan': 'Resource'\n  }\n  properties: {\n    serverFarmId: 'webServerFarms.id'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3331,7 +3331,7 @@
     "detail": "Web Deploy for a Web Application",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource webApplication 'Microsoft.Web/sites@2020-12-01' = {\n  name: 'name'\n  location: location\n}\n\nresource webApplicationExtension 'Microsoft.Web/sites/extensions@2020-12-01' = {\n  parent: webApplication\n  name: 'MSDeploy'\n  properties: {\n    packageUri: 'packageUri'\n    dbType: 'None'\n    connectionString: 'connectionString'\n    setParameters: {\n      'IIS Web Application Name': 'name'\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource webApplication 'Microsoft.Web/sites@2020-12-01' = {\n  name: 'name'\n  location: location\n}\n\nresource webApplicationExtension 'Microsoft.Web/sites/extensions@2020-12-01' = {\n  parent: webApplication\n  name: 'MSDeploy'\n  properties: {\n    packageUri: 'packageUri'\n    dbType: 'None'\n    connectionString: 'connectionString'\n    setParameters: {\n      'IIS Web Application Name': 'name'\n    }\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3361,7 +3361,7 @@
     "detail": "WVD AppGroup",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource applicationGroup 'Microsoft.DesktopVirtualization/applicationgroups@2021-07-12' = {\n  name: 'name'\n  location: location\n  properties: {\n    friendlyName: 'friendlyName'\n    applicationGroupType: 'Desktop'\n    hostPoolArmPath: 'desktopVirtualizationHostPools.id'\n  }\n}\n\n```"
+      "value": "```bicep\nresource applicationGroup 'Microsoft.DesktopVirtualization/applicationgroups@2021-07-12' = {\n  name: 'name'\n  location: location\n  properties: {\n    friendlyName: 'friendlyName'\n    applicationGroupType: 'Desktop'\n    hostPoolArmPath: 'desktopVirtualizationHostPools.id'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3391,7 +3391,7 @@
     "detail": "WVD Host Pool",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource hostPool 'Microsoft.DesktopVirtualization/hostpools@2021-07-12' = {\n  name: 'name'\n  location: location\n  properties: {\n    friendlyName: 'hostpoolFriendlyName'\n    hostPoolType: 'Personal'\n    loadBalancerType: 'BreadthFirst'\n    preferredAppGroupType: 'Desktop'\n  }\n}\n\n```"
+      "value": "```bicep\nresource hostPool 'Microsoft.DesktopVirtualization/hostpools@2021-07-12' = {\n  name: 'name'\n  location: location\n  properties: {\n    friendlyName: 'hostpoolFriendlyName'\n    hostPoolType: 'Personal'\n    loadBalancerType: 'BreadthFirst'\n    preferredAppGroupType: 'Desktop'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3421,7 +3421,7 @@
     "detail": "WVD Workspace",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource workSpace 'Microsoft.DesktopVirtualization/workspaces@2021-07-12' = {\n  name: 'name'\n  location: location\n  properties: {\n    friendlyName: 'friendlyName'\n  }\n}\n\n```"
+      "value": "```bicep\nresource workSpace 'Microsoft.DesktopVirtualization/workspaces@2021-07-12' = {\n  name: 'name'\n  location: location\n  properties: {\n    friendlyName: 'friendlyName'\n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3465,7 +3465,7 @@
     "detail": "Child Resource with defaults",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource Identifier 'Provider/ParentType/ChildType@Version' = {\n  name: \n  properties: {\n    \n  }\n}\n```"
+      "value": "```bicep\nresource Identifier 'Provider/ParentType/ChildType@Version' = {\n  name: \n  properties: {\n    \n  }\n}\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3495,7 +3495,7 @@
     "detail": "Child Resource without defaults",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource Identifier 'Provider/ParentType/ChildType@Version' = {\n  name: \n  \n}\n```"
+      "value": "```bicep\nresource Identifier 'Provider/ParentType/ChildType@Version' = {\n  name: \n  \n}\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3525,7 +3525,7 @@
     "detail": "Resource with defaults",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource Identifier 'Provider/Type@Version' = {\n  name: \n  location: location\n  properties: {\n    \n  }\n}\n\n```"
+      "value": "```bicep\nresource Identifier 'Provider/Type@Version' = {\n  name: \n  location: location\n  properties: {\n    \n  }\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3555,7 +3555,7 @@
     "detail": "Resource without defaults",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource Identifier 'Provider/Type@Version' = {\n  name: \n  \n}\n```"
+      "value": "```bicep\nresource Identifier 'Provider/Type@Version' = {\n  name: \n  \n}\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3627,7 +3627,7 @@
     "detail": "Variable declaration",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nvar Identifier = \n```"
+      "value": "```bicep\nvar Identifier = \n```  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/Completions/moduleObject.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Completions/moduleObject.json
@@ -5,7 +5,7 @@
     "detail": "for",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n[for item in list: {\n\t\n}]\n```"
+      "value": "```bicep\n[for item in list: {\n\t\n}]\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23,7 +23,7 @@
     "detail": "for-filtered",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n[for (item, index) in list: if (condition) {\n\t\n}]\n```"
+      "value": "```bicep\n[for (item, index) in list: if (condition) {\n\t\n}]\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41,7 +41,7 @@
     "detail": "for-indexed",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n[for (item, index) in list: {\n\t\n}]\n```"
+      "value": "```bicep\n[for (item, index) in list: {\n\t\n}]\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -73,7 +73,7 @@
     "detail": "{}",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n{\n\t\n}\n```"
+      "value": "```bicep\n{\n\t\n}\n```  \n"
     },
     "deprecated": false,
     "preselect": true,

--- a/src/Bicep.Core.Samples/Files/baselines/Completions/paramTypes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Completions/paramTypes.json
@@ -61,7 +61,7 @@
     "detail": "Secure object",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nobject\n```"
+      "value": "```bicep\nobject\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -85,7 +85,7 @@
     "detail": "Secure string",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring\n```"
+      "value": "```bicep\nstring\n```  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/Completions/resourceObject.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Completions/resourceObject.json
@@ -5,7 +5,7 @@
     "detail": "for",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n[for item in list: {\n\t\n}]\n```"
+      "value": "```bicep\n[for item in list: {\n\t\n}]\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23,7 +23,7 @@
     "detail": "for-filtered",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n[for (item, index) in list: if (condition) {\n\t\n}]\n```"
+      "value": "```bicep\n[for (item, index) in list: if (condition) {\n\t\n}]\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41,7 +41,7 @@
     "detail": "for-indexed",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n[for (item, index) in list: {\n\t\n}]\n```"
+      "value": "```bicep\n[for (item, index) in list: {\n\t\n}]\n```  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/Completions/resourceTypes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Completions/resourceTypes.json
@@ -4,7 +4,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Astronomer.Astro/organizations`  \n`"
+      "value": "Type: `Astronomer.Astro/organizations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25,7 +25,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Dynatrace.Observability/monitors`  \n`"
+      "value": "Type: `Dynatrace.Observability/monitors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46,7 +46,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Dynatrace.Observability/monitors/singleSignOnConfigurations`  \n`"
+      "value": "Type: `Dynatrace.Observability/monitors/singleSignOnConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -67,7 +67,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Dynatrace.Observability/monitors/tagRules`  \n`"
+      "value": "Type: `Dynatrace.Observability/monitors/tagRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -88,7 +88,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AAD/domainServices`  \n`"
+      "value": "Type: `Microsoft.AAD/domainServices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -109,7 +109,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AVS/privateClouds`  \n`"
+      "value": "Type: `Microsoft.AVS/privateClouds`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -130,7 +130,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AVS/privateClouds/addons`  \n`"
+      "value": "Type: `Microsoft.AVS/privateClouds/addons`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -151,7 +151,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AVS/privateClouds/authorizations`  \n`"
+      "value": "Type: `Microsoft.AVS/privateClouds/authorizations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -172,7 +172,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AVS/privateClouds/cloudLinks`  \n`"
+      "value": "Type: `Microsoft.AVS/privateClouds/cloudLinks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -193,7 +193,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AVS/privateClouds/clusters`  \n`"
+      "value": "Type: `Microsoft.AVS/privateClouds/clusters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -214,7 +214,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AVS/privateClouds/clusters/datastores`  \n`"
+      "value": "Type: `Microsoft.AVS/privateClouds/clusters/datastores`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -235,7 +235,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AVS/privateClouds/clusters/placementPolicies`  \n`"
+      "value": "Type: `Microsoft.AVS/privateClouds/clusters/placementPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -256,7 +256,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AVS/privateClouds/clusters/virtualMachines`  \n`"
+      "value": "Type: `Microsoft.AVS/privateClouds/clusters/virtualMachines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -277,7 +277,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AVS/privateClouds/globalReachConnections`  \n`"
+      "value": "Type: `Microsoft.AVS/privateClouds/globalReachConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -298,7 +298,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AVS/privateClouds/hcxEnterpriseSites`  \n`"
+      "value": "Type: `Microsoft.AVS/privateClouds/hcxEnterpriseSites`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -319,7 +319,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AVS/privateClouds/scriptExecutions`  \n`"
+      "value": "Type: `Microsoft.AVS/privateClouds/scriptExecutions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -340,7 +340,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AVS/privateClouds/scriptPackages`  \n`"
+      "value": "Type: `Microsoft.AVS/privateClouds/scriptPackages`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -361,7 +361,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AVS/privateClouds/scriptPackages/scriptCmdlets`  \n`"
+      "value": "Type: `Microsoft.AVS/privateClouds/scriptPackages/scriptCmdlets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -382,7 +382,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AVS/privateClouds/workloadNetworks`  \n`"
+      "value": "Type: `Microsoft.AVS/privateClouds/workloadNetworks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -403,7 +403,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AVS/privateClouds/workloadNetworks/dhcpConfigurations`  \n`"
+      "value": "Type: `Microsoft.AVS/privateClouds/workloadNetworks/dhcpConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -424,7 +424,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AVS/privateClouds/workloadNetworks/dnsServices`  \n`"
+      "value": "Type: `Microsoft.AVS/privateClouds/workloadNetworks/dnsServices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -445,7 +445,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AVS/privateClouds/workloadNetworks/dnsZones`  \n`"
+      "value": "Type: `Microsoft.AVS/privateClouds/workloadNetworks/dnsZones`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -466,7 +466,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AVS/privateClouds/workloadNetworks/gateways`  \n`"
+      "value": "Type: `Microsoft.AVS/privateClouds/workloadNetworks/gateways`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -487,7 +487,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AVS/privateClouds/workloadNetworks/portMirroringProfiles`  \n`"
+      "value": "Type: `Microsoft.AVS/privateClouds/workloadNetworks/portMirroringProfiles`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -508,7 +508,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AVS/privateClouds/workloadNetworks/publicIPs`  \n`"
+      "value": "Type: `Microsoft.AVS/privateClouds/workloadNetworks/publicIPs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -529,7 +529,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AVS/privateClouds/workloadNetworks/segments`  \n`"
+      "value": "Type: `Microsoft.AVS/privateClouds/workloadNetworks/segments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -550,7 +550,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AVS/privateClouds/workloadNetworks/virtualMachines`  \n`"
+      "value": "Type: `Microsoft.AVS/privateClouds/workloadNetworks/virtualMachines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -571,7 +571,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AVS/privateClouds/workloadNetworks/vmGroups`  \n`"
+      "value": "Type: `Microsoft.AVS/privateClouds/workloadNetworks/vmGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -592,7 +592,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Aad/domainServices/ouContainer`  \n`"
+      "value": "Type: `Microsoft.Aad/domainServices/ouContainer`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -613,7 +613,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Addons/supportProviders/supportPlanTypes`  \n`"
+      "value": "Type: `Microsoft.Addons/supportProviders/supportPlanTypes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -634,7 +634,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Advisor/advisorScore`  \n`"
+      "value": "Type: `Microsoft.Advisor/advisorScore`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -655,7 +655,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Advisor/configurations`  \n`"
+      "value": "Type: `Microsoft.Advisor/configurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -676,7 +676,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Advisor/recommendations`  \n`"
+      "value": "Type: `Microsoft.Advisor/recommendations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -697,7 +697,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Advisor/recommendations/suppressions`  \n`"
+      "value": "Type: `Microsoft.Advisor/recommendations/suppressions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -718,7 +718,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AgFoodPlatform/farmBeats`  \n`"
+      "value": "Type: `Microsoft.AgFoodPlatform/farmBeats`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -739,7 +739,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AgFoodPlatform/farmBeats/dataConnectors`  \n`"
+      "value": "Type: `Microsoft.AgFoodPlatform/farmBeats/dataConnectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -760,7 +760,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AgFoodPlatform/farmBeats/extensions`  \n`"
+      "value": "Type: `Microsoft.AgFoodPlatform/farmBeats/extensions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -781,7 +781,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AgFoodPlatform/farmBeats/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.AgFoodPlatform/farmBeats/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -802,7 +802,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AgFoodPlatform/farmBeats/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.AgFoodPlatform/farmBeats/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -823,7 +823,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AgFoodPlatform/farmBeats/solutions`  \n`"
+      "value": "Type: `Microsoft.AgFoodPlatform/farmBeats/solutions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -844,7 +844,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AgFoodPlatform/farmBeatsExtensionDefinitions`  \n`"
+      "value": "Type: `Microsoft.AgFoodPlatform/farmBeatsExtensionDefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -865,7 +865,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AgFoodPlatform/farmBeatsSolutionDefinitions`  \n`"
+      "value": "Type: `Microsoft.AgFoodPlatform/farmBeatsSolutionDefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -886,7 +886,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AlertsManagement/actionRules`  \n`"
+      "value": "Type: `Microsoft.AlertsManagement/actionRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -907,7 +907,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AlertsManagement/alerts`  \n`"
+      "value": "Type: `Microsoft.AlertsManagement/alerts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -928,7 +928,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AlertsManagement/alerts/enrichments`  \n`"
+      "value": "Type: `Microsoft.AlertsManagement/alerts/enrichments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -949,7 +949,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AlertsManagement/prometheusRuleGroups`  \n`"
+      "value": "Type: `Microsoft.AlertsManagement/prometheusRuleGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -970,7 +970,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AlertsManagement/smartGroups`  \n`"
+      "value": "Type: `Microsoft.AlertsManagement/smartGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -991,7 +991,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AlertsManagement/tenantActivityLogAlerts`  \n`"
+      "value": "Type: `Microsoft.AlertsManagement/tenantActivityLogAlerts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1012,7 +1012,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AnalysisServices/servers`  \n`"
+      "value": "Type: `Microsoft.AnalysisServices/servers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1033,7 +1033,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiCenter/services`  \n`"
+      "value": "Type: `Microsoft.ApiCenter/services`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1054,7 +1054,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiCenter/services/metadataSchemas`  \n`"
+      "value": "Type: `Microsoft.ApiCenter/services/metadataSchemas`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1075,7 +1075,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiCenter/services/workspaces`  \n`"
+      "value": "Type: `Microsoft.ApiCenter/services/workspaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1096,7 +1096,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiCenter/services/workspaces/apis`  \n`"
+      "value": "Type: `Microsoft.ApiCenter/services/workspaces/apis`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1117,7 +1117,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiCenter/services/workspaces/apis/deployments`  \n`"
+      "value": "Type: `Microsoft.ApiCenter/services/workspaces/apis/deployments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1138,7 +1138,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiCenter/services/workspaces/apis/versions`  \n`"
+      "value": "Type: `Microsoft.ApiCenter/services/workspaces/apis/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1159,7 +1159,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiCenter/services/workspaces/apis/versions/definitions`  \n`"
+      "value": "Type: `Microsoft.ApiCenter/services/workspaces/apis/versions/definitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1180,7 +1180,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiCenter/services/workspaces/environments`  \n`"
+      "value": "Type: `Microsoft.ApiCenter/services/workspaces/environments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1201,7 +1201,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/locations/deletedservices`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/locations/deletedservices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1222,7 +1222,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1243,7 +1243,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/api-version-sets`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/api-version-sets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1264,7 +1264,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/apiVersionSets`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/apiVersionSets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1285,7 +1285,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/apis`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/apis`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1306,7 +1306,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/apis/diagnostics`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/apis/diagnostics`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1327,7 +1327,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/apis/diagnostics/loggers`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/apis/diagnostics/loggers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1348,7 +1348,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/apis/issues`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/apis/issues`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1369,7 +1369,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/apis/issues/attachments`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/apis/issues/attachments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1390,7 +1390,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/apis/issues/comments`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/apis/issues/comments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1411,7 +1411,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/apis/operations`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/apis/operations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1432,7 +1432,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/apis/operations/policies`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/apis/operations/policies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1453,7 +1453,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/apis/operations/tags`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/apis/operations/tags`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1474,7 +1474,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/apis/policies`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/apis/policies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1495,7 +1495,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/apis/releases`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/apis/releases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1516,7 +1516,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/apis/resolvers`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/apis/resolvers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1537,7 +1537,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/apis/resolvers/policies`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/apis/resolvers/policies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1558,7 +1558,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/apis/schemas`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/apis/schemas`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1579,7 +1579,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/apis/tagDescriptions`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/apis/tagDescriptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1600,7 +1600,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/apis/tags`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/apis/tags`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1621,7 +1621,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/apis/wikis`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/apis/wikis`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1642,7 +1642,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/authorizationProviders`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/authorizationProviders`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1663,7 +1663,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/authorizationProviders/authorizations`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/authorizationProviders/authorizations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1684,7 +1684,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/authorizationProviders/authorizations/accessPolicies`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/authorizationProviders/authorizations/accessPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1705,7 +1705,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/authorizationServers`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/authorizationServers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1726,7 +1726,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/backends`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/backends`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1747,7 +1747,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/caches`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/caches`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1768,7 +1768,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/certificates`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/certificates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1789,7 +1789,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/contentTypes`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/contentTypes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1810,7 +1810,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/contentTypes/contentItems`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/contentTypes/contentItems`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1831,7 +1831,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/diagnostics`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/diagnostics`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1852,7 +1852,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/diagnostics/loggers`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/diagnostics/loggers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1873,7 +1873,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/documentations`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/documentations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1894,7 +1894,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/gateways`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/gateways`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1915,7 +1915,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/gateways/apis`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/gateways/apis`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1936,7 +1936,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/gateways/certificateAuthorities`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/gateways/certificateAuthorities`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1957,7 +1957,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/gateways/hostnameConfigurations`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/gateways/hostnameConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1978,7 +1978,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/groups`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/groups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1999,7 +1999,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/groups/users`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/groups/users`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2020,7 +2020,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/identityProviders`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/identityProviders`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2041,7 +2041,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/issues`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/issues`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2062,7 +2062,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/loggers`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/loggers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2083,7 +2083,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/namedValues`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/namedValues`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2104,7 +2104,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/notifications`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/notifications`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2125,7 +2125,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/notifications/recipientEmails`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/notifications/recipientEmails`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2146,7 +2146,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/notifications/recipientUsers`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/notifications/recipientUsers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2167,7 +2167,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/openidConnectProviders`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/openidConnectProviders`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2188,7 +2188,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/policies`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/policies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2209,7 +2209,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/policyFragments`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/policyFragments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2230,7 +2230,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/portalRevisions`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/portalRevisions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2251,7 +2251,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/portalconfigs`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/portalconfigs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2272,7 +2272,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/portalsettings`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/portalsettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2293,7 +2293,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2314,7 +2314,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2335,7 +2335,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/products`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/products`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2356,7 +2356,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/products/apiLinks`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/products/apiLinks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2377,7 +2377,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/products/apis`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/products/apis`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2398,7 +2398,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/products/groupLinks`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/products/groupLinks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2419,7 +2419,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/products/groups`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/products/groups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2440,7 +2440,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/products/policies`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/products/policies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2461,7 +2461,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/products/tags`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/products/tags`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2482,7 +2482,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/products/wikis`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/products/wikis`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2503,7 +2503,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/properties`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/properties`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2524,7 +2524,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/schemas`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/schemas`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2545,7 +2545,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/settings`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/settings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2566,7 +2566,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/subscriptions`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/subscriptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2587,7 +2587,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/tags`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/tags`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2608,7 +2608,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/tags/apiLinks`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/tags/apiLinks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2629,7 +2629,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/tags/operationLinks`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/tags/operationLinks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2650,7 +2650,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/tags/productLinks`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/tags/productLinks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2671,7 +2671,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/templates`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/templates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2692,7 +2692,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/tenant`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/tenant`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2713,7 +2713,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/users`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/users`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2734,7 +2734,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/users/subscriptions`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/users/subscriptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2755,7 +2755,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/workspaces`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/workspaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2776,7 +2776,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/workspaces/apiVersionSets`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/workspaces/apiVersionSets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2797,7 +2797,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/workspaces/apis`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/workspaces/apis`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2818,7 +2818,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/workspaces/apis/operations`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/workspaces/apis/operations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2839,7 +2839,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/workspaces/apis/operations/policies`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/workspaces/apis/operations/policies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2860,7 +2860,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/workspaces/apis/policies`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/workspaces/apis/policies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2881,7 +2881,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/workspaces/apis/releases`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/workspaces/apis/releases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2902,7 +2902,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/workspaces/apis/schemas`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/workspaces/apis/schemas`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2923,7 +2923,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/workspaces/groups`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/workspaces/groups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2944,7 +2944,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/workspaces/groups/users`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/workspaces/groups/users`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2965,7 +2965,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/workspaces/namedValues`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/workspaces/namedValues`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2986,7 +2986,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/workspaces/notifications`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/workspaces/notifications`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3007,7 +3007,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/workspaces/notifications/recipientEmails`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/workspaces/notifications/recipientEmails`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3028,7 +3028,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/workspaces/notifications/recipientUsers`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/workspaces/notifications/recipientUsers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3049,7 +3049,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/workspaces/policies`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/workspaces/policies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3070,7 +3070,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/workspaces/policyFragments`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/workspaces/policyFragments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3091,7 +3091,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/workspaces/products`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/workspaces/products`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3112,7 +3112,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/workspaces/products/apiLinks`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/workspaces/products/apiLinks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3133,7 +3133,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/workspaces/products/groupLinks`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/workspaces/products/groupLinks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3154,7 +3154,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/workspaces/products/policies`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/workspaces/products/policies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3175,7 +3175,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/workspaces/schemas`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/workspaces/schemas`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3196,7 +3196,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/workspaces/subscriptions`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/workspaces/subscriptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3217,7 +3217,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/workspaces/tags`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/workspaces/tags`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3238,7 +3238,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/workspaces/tags/apiLinks`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/workspaces/tags/apiLinks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3259,7 +3259,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/workspaces/tags/operationLinks`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/workspaces/tags/operationLinks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3280,7 +3280,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ApiManagement/service/workspaces/tags/productLinks`  \n`"
+      "value": "Type: `Microsoft.ApiManagement/service/workspaces/tags/productLinks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3301,7 +3301,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.App/connectedEnvironments`  \n`"
+      "value": "Type: `Microsoft.App/connectedEnvironments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3322,7 +3322,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.App/connectedEnvironments/certificates`  \n`"
+      "value": "Type: `Microsoft.App/connectedEnvironments/certificates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3343,7 +3343,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.App/connectedEnvironments/daprComponents`  \n`"
+      "value": "Type: `Microsoft.App/connectedEnvironments/daprComponents`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3364,7 +3364,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.App/connectedEnvironments/storages`  \n`"
+      "value": "Type: `Microsoft.App/connectedEnvironments/storages`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3385,7 +3385,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.App/containerApps`  \n`"
+      "value": "Type: `Microsoft.App/containerApps`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3406,7 +3406,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.App/containerApps/authConfigs`  \n`"
+      "value": "Type: `Microsoft.App/containerApps/authConfigs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3427,7 +3427,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.App/containerApps/detectorProperties`  \n`"
+      "value": "Type: `Microsoft.App/containerApps/detectorProperties`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3448,7 +3448,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.App/containerApps/detectorProperties/revisions`  \n`"
+      "value": "Type: `Microsoft.App/containerApps/detectorProperties/revisions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3469,7 +3469,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.App/containerApps/detectors`  \n`"
+      "value": "Type: `Microsoft.App/containerApps/detectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3490,7 +3490,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.App/containerApps/revisions`  \n`"
+      "value": "Type: `Microsoft.App/containerApps/revisions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3511,7 +3511,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.App/containerApps/revisions/replicas`  \n`"
+      "value": "Type: `Microsoft.App/containerApps/revisions/replicas`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3532,7 +3532,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.App/containerApps/sourcecontrols`  \n`"
+      "value": "Type: `Microsoft.App/containerApps/sourcecontrols`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3553,7 +3553,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.App/jobs`  \n`"
+      "value": "Type: `Microsoft.App/jobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3574,7 +3574,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.App/managedEnvironments`  \n`"
+      "value": "Type: `Microsoft.App/managedEnvironments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3595,7 +3595,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.App/managedEnvironments/certificates`  \n`"
+      "value": "Type: `Microsoft.App/managedEnvironments/certificates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3616,7 +3616,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.App/managedEnvironments/daprComponents`  \n`"
+      "value": "Type: `Microsoft.App/managedEnvironments/daprComponents`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3637,7 +3637,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.App/managedEnvironments/detectorProperties`  \n`"
+      "value": "Type: `Microsoft.App/managedEnvironments/detectorProperties`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3658,7 +3658,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.App/managedEnvironments/detectors`  \n`"
+      "value": "Type: `Microsoft.App/managedEnvironments/detectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3679,7 +3679,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.App/managedEnvironments/managedCertificates`  \n`"
+      "value": "Type: `Microsoft.App/managedEnvironments/managedCertificates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3700,7 +3700,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.App/managedEnvironments/storages`  \n`"
+      "value": "Type: `Microsoft.App/managedEnvironments/storages`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3721,7 +3721,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppComplianceAutomation/reports`  \n`"
+      "value": "Type: `Microsoft.AppComplianceAutomation/reports`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3742,7 +3742,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppComplianceAutomation/reports/snapshots`  \n`"
+      "value": "Type: `Microsoft.AppComplianceAutomation/reports/snapshots`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3763,7 +3763,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppConfiguration/configurationStores`  \n`"
+      "value": "Type: `Microsoft.AppConfiguration/configurationStores`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3784,7 +3784,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppConfiguration/configurationStores/keyValues`  \n`"
+      "value": "Type: `Microsoft.AppConfiguration/configurationStores/keyValues`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3805,7 +3805,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppConfiguration/configurationStores/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.AppConfiguration/configurationStores/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3826,7 +3826,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppConfiguration/configurationStores/replicas`  \n`"
+      "value": "Type: `Microsoft.AppConfiguration/configurationStores/replicas`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3847,7 +3847,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3868,7 +3868,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/DevToolPortals`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/DevToolPortals`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3889,7 +3889,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/apiPortals`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/apiPortals`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3910,7 +3910,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/apiPortals/domains`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/apiPortals/domains`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3931,7 +3931,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/apms`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/apms`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3952,7 +3952,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/applicationAccelerators`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/applicationAccelerators`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3973,7 +3973,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/applicationAccelerators/customizedAccelerators`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/applicationAccelerators/customizedAccelerators`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3994,7 +3994,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/applicationAccelerators/predefinedAccelerators`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/applicationAccelerators/predefinedAccelerators`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4015,7 +4015,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/applicationLiveViews`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/applicationLiveViews`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4036,7 +4036,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/apps`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/apps`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4057,7 +4057,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/apps/bindings`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/apps/bindings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4078,7 +4078,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/apps/deployments`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/apps/deployments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4099,7 +4099,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/apps/domains`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/apps/domains`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4120,7 +4120,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/buildServices`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/buildServices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4141,7 +4141,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/buildServices/agentPools`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/buildServices/agentPools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4162,7 +4162,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/buildServices/builders`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/buildServices/builders`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4183,7 +4183,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/buildServices/builders/buildpackBindings`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/buildServices/builders/buildpackBindings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4204,7 +4204,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/buildServices/builds`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/buildServices/builds`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4225,7 +4225,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/buildServices/builds/results`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/buildServices/builds/results`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4246,7 +4246,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/buildServices/supportedBuildpacks`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/buildServices/supportedBuildpacks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4267,7 +4267,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/buildServices/supportedStacks`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/buildServices/supportedStacks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4288,7 +4288,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/certificates`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/certificates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4309,7 +4309,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/configServers`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/configServers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4330,7 +4330,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/configurationServices`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/configurationServices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4351,7 +4351,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/containerRegistries`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/containerRegistries`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4372,7 +4372,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/eurekaServers`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/eurekaServers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4393,7 +4393,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/gateways`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/gateways`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4414,7 +4414,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/gateways/domains`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/gateways/domains`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4435,7 +4435,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/gateways/routeConfigs`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/gateways/routeConfigs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4456,7 +4456,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/monitoringSettings`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/monitoringSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4477,7 +4477,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/serviceRegistries`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/serviceRegistries`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4498,7 +4498,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AppPlatform/Spring/storages`  \n`"
+      "value": "Type: `Microsoft.AppPlatform/Spring/storages`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4519,7 +4519,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Attestation/attestationProviders`  \n`"
+      "value": "Type: `Microsoft.Attestation/attestationProviders`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4540,7 +4540,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Attestation/attestationProviders/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Attestation/attestationProviders/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4561,7 +4561,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Authorization/accessReviewHistoryDefinitions`  \n`"
+      "value": "Type: `Microsoft.Authorization/accessReviewHistoryDefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4582,7 +4582,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Authorization/accessReviewScheduleDefinitions`  \n`"
+      "value": "Type: `Microsoft.Authorization/accessReviewScheduleDefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4603,7 +4603,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Authorization/accessReviewScheduleDefinitions/instances`  \n`"
+      "value": "Type: `Microsoft.Authorization/accessReviewScheduleDefinitions/instances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4624,7 +4624,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Authorization/accessReviewScheduleDefinitions/instances/decisions`  \n`"
+      "value": "Type: `Microsoft.Authorization/accessReviewScheduleDefinitions/instances/decisions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4645,7 +4645,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Authorization/accessReviewScheduleSettings`  \n`"
+      "value": "Type: `Microsoft.Authorization/accessReviewScheduleSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4666,7 +4666,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Authorization/dataPolicyManifests`  \n`"
+      "value": "Type: `Microsoft.Authorization/dataPolicyManifests`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4687,7 +4687,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Authorization/locks`  \n`"
+      "value": "Type: `Microsoft.Authorization/locks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4708,7 +4708,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Authorization/policyAssignments`  \n`"
+      "value": "Type: `Microsoft.Authorization/policyAssignments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4729,7 +4729,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Authorization/policyDefinitions`  \n`"
+      "value": "Type: `Microsoft.Authorization/policyDefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4750,7 +4750,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Authorization/policyDefinitions/versions`  \n`"
+      "value": "Type: `Microsoft.Authorization/policyDefinitions/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4771,7 +4771,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Authorization/policyExemptions`  \n`"
+      "value": "Type: `Microsoft.Authorization/policyExemptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4792,7 +4792,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Authorization/policySetDefinitions`  \n`"
+      "value": "Type: `Microsoft.Authorization/policySetDefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4813,7 +4813,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Authorization/policySetDefinitions/versions`  \n`"
+      "value": "Type: `Microsoft.Authorization/policySetDefinitions/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4834,7 +4834,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Authorization/privateLinkAssociations`  \n`"
+      "value": "Type: `Microsoft.Authorization/privateLinkAssociations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4855,7 +4855,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Authorization/resourceManagementPrivateLinks`  \n`"
+      "value": "Type: `Microsoft.Authorization/resourceManagementPrivateLinks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4876,7 +4876,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Authorization/roleAssignmentApprovals`  \n`"
+      "value": "Type: `Microsoft.Authorization/roleAssignmentApprovals`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4897,7 +4897,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Authorization/roleAssignmentApprovals/stages`  \n`"
+      "value": "Type: `Microsoft.Authorization/roleAssignmentApprovals/stages`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4918,7 +4918,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Authorization/roleAssignmentScheduleRequests`  \n`"
+      "value": "Type: `Microsoft.Authorization/roleAssignmentScheduleRequests`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4939,7 +4939,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Authorization/roleAssignments`  \n`"
+      "value": "Type: `Microsoft.Authorization/roleAssignments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4960,7 +4960,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Authorization/roleDefinitions`  \n`"
+      "value": "Type: `Microsoft.Authorization/roleDefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4981,7 +4981,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Authorization/roleEligibilityScheduleRequests`  \n`"
+      "value": "Type: `Microsoft.Authorization/roleEligibilityScheduleRequests`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5002,7 +5002,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Authorization/roleManagementPolicyAssignments`  \n`"
+      "value": "Type: `Microsoft.Authorization/roleManagementPolicyAssignments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5023,7 +5023,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Authorization/variables`  \n`"
+      "value": "Type: `Microsoft.Authorization/variables`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5044,7 +5044,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Authorization/variables/values`  \n`"
+      "value": "Type: `Microsoft.Authorization/variables/values`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5065,7 +5065,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automanage/accounts`  \n`"
+      "value": "Type: `Microsoft.Automanage/accounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5086,7 +5086,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automanage/bestPractices`  \n`"
+      "value": "Type: `Microsoft.Automanage/bestPractices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5107,7 +5107,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automanage/bestPractices/versions`  \n`"
+      "value": "Type: `Microsoft.Automanage/bestPractices/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5128,7 +5128,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automanage/configurationProfileAssignments`  \n`"
+      "value": "Type: `Microsoft.Automanage/configurationProfileAssignments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5149,7 +5149,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automanage/configurationProfileAssignments/reports`  \n`"
+      "value": "Type: `Microsoft.Automanage/configurationProfileAssignments/reports`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5170,7 +5170,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automanage/configurationProfilePreferences`  \n`"
+      "value": "Type: `Microsoft.Automanage/configurationProfilePreferences`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5191,7 +5191,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automanage/configurationProfiles`  \n`"
+      "value": "Type: `Microsoft.Automanage/configurationProfiles`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5212,7 +5212,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automanage/configurationProfiles/versions`  \n`"
+      "value": "Type: `Microsoft.Automanage/configurationProfiles/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5233,7 +5233,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automanage/servicePrincipals`  \n`"
+      "value": "Type: `Microsoft.Automanage/servicePrincipals`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5254,7 +5254,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automation/automationAccounts`  \n`"
+      "value": "Type: `Microsoft.Automation/automationAccounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5275,7 +5275,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automation/automationAccounts/certificates`  \n`"
+      "value": "Type: `Microsoft.Automation/automationAccounts/certificates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5296,7 +5296,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automation/automationAccounts/compilationjobs`  \n`"
+      "value": "Type: `Microsoft.Automation/automationAccounts/compilationjobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5317,7 +5317,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automation/automationAccounts/configurations`  \n`"
+      "value": "Type: `Microsoft.Automation/automationAccounts/configurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5338,7 +5338,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automation/automationAccounts/connectionTypes`  \n`"
+      "value": "Type: `Microsoft.Automation/automationAccounts/connectionTypes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5359,7 +5359,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automation/automationAccounts/connections`  \n`"
+      "value": "Type: `Microsoft.Automation/automationAccounts/connections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5380,7 +5380,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automation/automationAccounts/credentials`  \n`"
+      "value": "Type: `Microsoft.Automation/automationAccounts/credentials`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5401,7 +5401,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automation/automationAccounts/hybridRunbookWorkerGroups`  \n`"
+      "value": "Type: `Microsoft.Automation/automationAccounts/hybridRunbookWorkerGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5422,7 +5422,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automation/automationAccounts/hybridRunbookWorkerGroups/hybridRunbookWorkers`  \n`"
+      "value": "Type: `Microsoft.Automation/automationAccounts/hybridRunbookWorkerGroups/hybridRunbookWorkers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5443,7 +5443,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automation/automationAccounts/jobSchedules`  \n`"
+      "value": "Type: `Microsoft.Automation/automationAccounts/jobSchedules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5464,7 +5464,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automation/automationAccounts/jobs`  \n`"
+      "value": "Type: `Microsoft.Automation/automationAccounts/jobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5485,7 +5485,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automation/automationAccounts/modules`  \n`"
+      "value": "Type: `Microsoft.Automation/automationAccounts/modules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5506,7 +5506,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automation/automationAccounts/nodeConfigurations`  \n`"
+      "value": "Type: `Microsoft.Automation/automationAccounts/nodeConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5527,7 +5527,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automation/automationAccounts/nodes`  \n`"
+      "value": "Type: `Microsoft.Automation/automationAccounts/nodes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5548,7 +5548,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automation/automationAccounts/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Automation/automationAccounts/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5569,7 +5569,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automation/automationAccounts/python2Packages`  \n`"
+      "value": "Type: `Microsoft.Automation/automationAccounts/python2Packages`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5590,7 +5590,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automation/automationAccounts/python3Packages`  \n`"
+      "value": "Type: `Microsoft.Automation/automationAccounts/python3Packages`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5611,7 +5611,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automation/automationAccounts/runbooks`  \n`"
+      "value": "Type: `Microsoft.Automation/automationAccounts/runbooks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5632,7 +5632,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automation/automationAccounts/runbooks/draft`  \n`"
+      "value": "Type: `Microsoft.Automation/automationAccounts/runbooks/draft`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5653,7 +5653,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automation/automationAccounts/schedules`  \n`"
+      "value": "Type: `Microsoft.Automation/automationAccounts/schedules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5674,7 +5674,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automation/automationAccounts/softwareUpdateConfigurations`  \n`"
+      "value": "Type: `Microsoft.Automation/automationAccounts/softwareUpdateConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5695,7 +5695,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automation/automationAccounts/sourceControls`  \n`"
+      "value": "Type: `Microsoft.Automation/automationAccounts/sourceControls`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5716,7 +5716,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automation/automationAccounts/sourceControls/sourceControlSyncJobs`  \n`"
+      "value": "Type: `Microsoft.Automation/automationAccounts/sourceControls/sourceControlSyncJobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5737,7 +5737,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automation/automationAccounts/variables`  \n`"
+      "value": "Type: `Microsoft.Automation/automationAccounts/variables`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5758,7 +5758,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automation/automationAccounts/watchers`  \n`"
+      "value": "Type: `Microsoft.Automation/automationAccounts/watchers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5779,7 +5779,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Automation/automationAccounts/webhooks`  \n`"
+      "value": "Type: `Microsoft.Automation/automationAccounts/webhooks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5800,7 +5800,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AutonomousDevelopmentPlatform/accounts`  \n`"
+      "value": "Type: `Microsoft.AutonomousDevelopmentPlatform/accounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5821,7 +5821,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AutonomousDevelopmentPlatform/accounts/dataPools`  \n`"
+      "value": "Type: `Microsoft.AutonomousDevelopmentPlatform/accounts/dataPools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5842,7 +5842,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureActiveDirectory/b2cDirectories`  \n`"
+      "value": "Type: `Microsoft.AzureActiveDirectory/b2cDirectories`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5863,7 +5863,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureActiveDirectory/guestUsages`  \n`"
+      "value": "Type: `Microsoft.AzureActiveDirectory/guestUsages`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5884,7 +5884,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureArcData/dataControllers`  \n`"
+      "value": "Type: `Microsoft.AzureArcData/dataControllers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5905,7 +5905,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureArcData/dataControllers/activeDirectoryConnectors`  \n`"
+      "value": "Type: `Microsoft.AzureArcData/dataControllers/activeDirectoryConnectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5926,7 +5926,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureArcData/postgresInstances`  \n`"
+      "value": "Type: `Microsoft.AzureArcData/postgresInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5947,7 +5947,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureArcData/sqlManagedInstances`  \n`"
+      "value": "Type: `Microsoft.AzureArcData/sqlManagedInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5968,7 +5968,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureArcData/sqlManagedInstances/failoverGroups`  \n`"
+      "value": "Type: `Microsoft.AzureArcData/sqlManagedInstances/failoverGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5989,7 +5989,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureArcData/sqlServerInstances`  \n`"
+      "value": "Type: `Microsoft.AzureArcData/sqlServerInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6010,7 +6010,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureArcData/sqlServerInstances/databases`  \n`"
+      "value": "Type: `Microsoft.AzureArcData/sqlServerInstances/databases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6031,7 +6031,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureBridge.Admin/activations`  \n`"
+      "value": "Type: `Microsoft.AzureBridge.Admin/activations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6052,7 +6052,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureBridge.Admin/activations/downloadedProducts`  \n`"
+      "value": "Type: `Microsoft.AzureBridge.Admin/activations/downloadedProducts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6073,7 +6073,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureBridge.Admin/activations/products`  \n`"
+      "value": "Type: `Microsoft.AzureBridge.Admin/activations/products`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6094,7 +6094,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureData/sqlServerRegistrations`  \n`"
+      "value": "Type: `Microsoft.AzureData/sqlServerRegistrations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6115,7 +6115,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureData/sqlServerRegistrations/sqlServers`  \n`"
+      "value": "Type: `Microsoft.AzureData/sqlServerRegistrations/sqlServers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6136,7 +6136,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureLargeInstance/azureLargeInstances`  \n`"
+      "value": "Type: `Microsoft.AzureLargeInstance/azureLargeInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6157,7 +6157,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureLargeInstance/azureLargeStorageInstances`  \n`"
+      "value": "Type: `Microsoft.AzureLargeInstance/azureLargeStorageInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6178,7 +6178,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzurePlaywrightService/accounts`  \n`"
+      "value": "Type: `Microsoft.AzurePlaywrightService/accounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6199,7 +6199,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzurePlaywrightService/locations/quotas`  \n`"
+      "value": "Type: `Microsoft.AzurePlaywrightService/locations/quotas`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6220,7 +6220,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureSphere/catalogs`  \n`"
+      "value": "Type: `Microsoft.AzureSphere/catalogs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6241,7 +6241,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureSphere/catalogs/certificates`  \n`"
+      "value": "Type: `Microsoft.AzureSphere/catalogs/certificates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6262,7 +6262,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureSphere/catalogs/images`  \n`"
+      "value": "Type: `Microsoft.AzureSphere/catalogs/images`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6283,7 +6283,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureSphere/catalogs/products`  \n`"
+      "value": "Type: `Microsoft.AzureSphere/catalogs/products`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6304,7 +6304,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureSphere/catalogs/products/deviceGroups`  \n`"
+      "value": "Type: `Microsoft.AzureSphere/catalogs/products/deviceGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6325,7 +6325,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureSphere/catalogs/products/deviceGroups/deployments`  \n`"
+      "value": "Type: `Microsoft.AzureSphere/catalogs/products/deviceGroups/deployments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6346,7 +6346,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureSphere/catalogs/products/deviceGroups/devices`  \n`"
+      "value": "Type: `Microsoft.AzureSphere/catalogs/products/deviceGroups/devices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6367,7 +6367,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureStack/cloudManifestFiles`  \n`"
+      "value": "Type: `Microsoft.AzureStack/cloudManifestFiles`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6388,7 +6388,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureStack/linkedSubscriptions`  \n`"
+      "value": "Type: `Microsoft.AzureStack/linkedSubscriptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6409,7 +6409,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureStack/registrations`  \n`"
+      "value": "Type: `Microsoft.AzureStack/registrations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6430,7 +6430,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureStack/registrations/customerSubscriptions`  \n`"
+      "value": "Type: `Microsoft.AzureStack/registrations/customerSubscriptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6451,7 +6451,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureStack/registrations/products`  \n`"
+      "value": "Type: `Microsoft.AzureStack/registrations/products`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6472,7 +6472,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureStackHCI/clusters`  \n`"
+      "value": "Type: `Microsoft.AzureStackHCI/clusters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6493,7 +6493,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureStackHCI/clusters/arcSettings`  \n`"
+      "value": "Type: `Microsoft.AzureStackHCI/clusters/arcSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6514,7 +6514,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureStackHCI/clusters/arcSettings/extensions`  \n`"
+      "value": "Type: `Microsoft.AzureStackHCI/clusters/arcSettings/extensions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6535,7 +6535,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureStackHCI/clusters/publishers`  \n`"
+      "value": "Type: `Microsoft.AzureStackHCI/clusters/publishers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6556,7 +6556,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureStackHCI/clusters/publishers/offers`  \n`"
+      "value": "Type: `Microsoft.AzureStackHCI/clusters/publishers/offers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6577,7 +6577,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureStackHCI/clusters/publishers/offers/skus`  \n`"
+      "value": "Type: `Microsoft.AzureStackHCI/clusters/publishers/offers/skus`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6598,7 +6598,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureStackHCI/clusters/updateSummaries`  \n`"
+      "value": "Type: `Microsoft.AzureStackHCI/clusters/updateSummaries`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6619,7 +6619,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureStackHCI/clusters/updates`  \n`"
+      "value": "Type: `Microsoft.AzureStackHCI/clusters/updates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6640,7 +6640,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureStackHCI/clusters/updates/updateRuns`  \n`"
+      "value": "Type: `Microsoft.AzureStackHCI/clusters/updates/updateRuns`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6661,7 +6661,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureStackHCI/galleryImages`  \n`"
+      "value": "Type: `Microsoft.AzureStackHCI/galleryImages`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6682,7 +6682,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureStackHCI/logicalNetworks`  \n`"
+      "value": "Type: `Microsoft.AzureStackHCI/logicalNetworks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6703,7 +6703,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureStackHCI/marketplaceGalleryImages`  \n`"
+      "value": "Type: `Microsoft.AzureStackHCI/marketplaceGalleryImages`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6724,7 +6724,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureStackHCI/networkInterfaces`  \n`"
+      "value": "Type: `Microsoft.AzureStackHCI/networkInterfaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6745,7 +6745,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureStackHCI/storageContainers`  \n`"
+      "value": "Type: `Microsoft.AzureStackHCI/storageContainers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6766,7 +6766,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureStackHCI/virtualHardDisks`  \n`"
+      "value": "Type: `Microsoft.AzureStackHCI/virtualHardDisks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6787,7 +6787,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureStackHCI/virtualMachineInstances`  \n`"
+      "value": "Type: `Microsoft.AzureStackHCI/virtualMachineInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6808,7 +6808,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureStackHCI/virtualMachineInstances/guestAgents`  \n`"
+      "value": "Type: `Microsoft.AzureStackHCI/virtualMachineInstances/guestAgents`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6829,7 +6829,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureStackHCI/virtualMachineInstances/hybridIdentityMetadata`  \n`"
+      "value": "Type: `Microsoft.AzureStackHCI/virtualMachineInstances/hybridIdentityMetadata`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6850,7 +6850,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureStackHCI/virtualMachines`  \n`"
+      "value": "Type: `Microsoft.AzureStackHCI/virtualMachines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6871,7 +6871,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureStackHCI/virtualMachines/extensions`  \n`"
+      "value": "Type: `Microsoft.AzureStackHCI/virtualMachines/extensions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6892,7 +6892,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureStackHCI/virtualMachines/guestAgents`  \n`"
+      "value": "Type: `Microsoft.AzureStackHCI/virtualMachines/guestAgents`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6913,7 +6913,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureStackHCI/virtualMachines/hybridIdentityMetadata`  \n`"
+      "value": "Type: `Microsoft.AzureStackHCI/virtualMachines/hybridIdentityMetadata`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6934,7 +6934,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AzureStackHCI/virtualNetworks`  \n`"
+      "value": "Type: `Microsoft.AzureStackHCI/virtualNetworks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6955,7 +6955,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Backup.Admin/backupLocations`  \n`"
+      "value": "Type: `Microsoft.Backup.Admin/backupLocations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6976,7 +6976,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Backup.Admin/backupLocations/backups`  \n`"
+      "value": "Type: `Microsoft.Backup.Admin/backupLocations/backups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6997,7 +6997,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.BareMetalInfrastructure/bareMetalInstances`  \n`"
+      "value": "Type: `Microsoft.BareMetalInfrastructure/bareMetalInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7018,7 +7018,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.BareMetalInfrastructure/bareMetalStorageInstances`  \n`"
+      "value": "Type: `Microsoft.BareMetalInfrastructure/bareMetalStorageInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7039,7 +7039,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Batch/batchAccounts`  \n`"
+      "value": "Type: `Microsoft.Batch/batchAccounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7060,7 +7060,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Batch/batchAccounts/applications`  \n`"
+      "value": "Type: `Microsoft.Batch/batchAccounts/applications`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7081,7 +7081,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Batch/batchAccounts/applications/versions`  \n`"
+      "value": "Type: `Microsoft.Batch/batchAccounts/applications/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7102,7 +7102,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Batch/batchAccounts/certificates`  \n`"
+      "value": "Type: `Microsoft.Batch/batchAccounts/certificates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7123,7 +7123,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Batch/batchAccounts/detectors`  \n`"
+      "value": "Type: `Microsoft.Batch/batchAccounts/detectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7144,7 +7144,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Batch/batchAccounts/pools`  \n`"
+      "value": "Type: `Microsoft.Batch/batchAccounts/pools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7165,7 +7165,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Batch/batchAccounts/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Batch/batchAccounts/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7186,7 +7186,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Batch/batchAccounts/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.Batch/batchAccounts/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7207,7 +7207,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.BatchAI/clusters`  \n`"
+      "value": "Type: `Microsoft.BatchAI/clusters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7228,7 +7228,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.BatchAI/fileServers`  \n`"
+      "value": "Type: `Microsoft.BatchAI/fileServers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7249,7 +7249,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.BatchAI/jobs`  \n`"
+      "value": "Type: `Microsoft.BatchAI/jobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7270,7 +7270,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.BatchAI/workspaces`  \n`"
+      "value": "Type: `Microsoft.BatchAI/workspaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7291,7 +7291,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.BatchAI/workspaces/clusters`  \n`"
+      "value": "Type: `Microsoft.BatchAI/workspaces/clusters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7312,7 +7312,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.BatchAI/workspaces/experiments`  \n`"
+      "value": "Type: `Microsoft.BatchAI/workspaces/experiments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7333,7 +7333,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.BatchAI/workspaces/experiments/jobs`  \n`"
+      "value": "Type: `Microsoft.BatchAI/workspaces/experiments/jobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7354,7 +7354,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.BatchAI/workspaces/fileServers`  \n`"
+      "value": "Type: `Microsoft.BatchAI/workspaces/fileServers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7375,7 +7375,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7396,7 +7396,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/agreements`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/agreements`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7417,7 +7417,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/billingProfiles`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/billingProfiles`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7438,7 +7438,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/billingProfiles/availableBalance`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/billingProfiles/availableBalance`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7459,7 +7459,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/billingProfiles/billingRoleAssignments`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/billingProfiles/billingRoleAssignments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7480,7 +7480,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/billingProfiles/billingRoleDefinitions`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/billingProfiles/billingRoleDefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7501,7 +7501,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/billingProfiles/instructions`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/billingProfiles/instructions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7522,7 +7522,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/billingProfiles/invoiceSections`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/billingProfiles/invoiceSections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7543,7 +7543,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/billingProfiles/invoiceSections/billingRoleAssignments`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/billingProfiles/invoiceSections/billingRoleAssignments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7564,7 +7564,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/billingProfiles/invoiceSections/billingRoleDefinitions`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/billingProfiles/invoiceSections/billingRoleDefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7585,7 +7585,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/billingProfiles/invoiceSections/billingSubscriptions`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/billingProfiles/invoiceSections/billingSubscriptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7606,7 +7606,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/billingProfiles/invoiceSections/products`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/billingProfiles/invoiceSections/products`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7627,7 +7627,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/billingProfiles/invoices`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/billingProfiles/invoices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7648,7 +7648,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/billingProfiles/paymentMethodLinks`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/billingProfiles/paymentMethodLinks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7669,7 +7669,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/billingProfiles/policies`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/billingProfiles/policies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7690,7 +7690,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/billingRoleAssignments`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/billingRoleAssignments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7711,7 +7711,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/billingRoleDefinitions`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/billingRoleDefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7732,7 +7732,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/billingSubscriptionAliases`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/billingSubscriptionAliases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7753,7 +7753,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/billingSubscriptions`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/billingSubscriptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7774,7 +7774,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/billingSubscriptions/invoices`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/billingSubscriptions/invoices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7795,7 +7795,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/customers`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/customers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7816,7 +7816,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/customers/billingSubscriptions`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/customers/billingSubscriptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7837,7 +7837,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/customers/policies`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/customers/policies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7858,7 +7858,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/customers/products`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/customers/products`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7879,7 +7879,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/departments`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/departments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7900,7 +7900,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/departments/billingRoleAssignments`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/departments/billingRoleAssignments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7921,7 +7921,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/departments/billingRoleDefinitions`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/departments/billingRoleDefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7942,7 +7942,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/enrollmentAccounts`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/enrollmentAccounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7963,7 +7963,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/enrollmentAccounts/billingRoleAssignments`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/enrollmentAccounts/billingRoleAssignments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -7984,7 +7984,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/enrollmentAccounts/billingRoleDefinitions`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/enrollmentAccounts/billingRoleDefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8005,7 +8005,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/invoiceSections`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/invoiceSections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8026,7 +8026,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/invoiceSections/billingSubscriptions`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/invoiceSections/billingSubscriptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8047,7 +8047,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/invoiceSections/products`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/invoiceSections/products`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8068,7 +8068,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/invoices`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/invoices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8089,7 +8089,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/lineOfCredit`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/lineOfCredit`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8110,7 +8110,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/paymentMethods`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/paymentMethods`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8131,7 +8131,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingAccounts/products`  \n`"
+      "value": "Type: `Microsoft.Billing/billingAccounts/products`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8152,7 +8152,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingPeriods`  \n`"
+      "value": "Type: `Microsoft.Billing/billingPeriods`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8173,7 +8173,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingPeriods/Microsoft.Consumption`  \n`"
+      "value": "Type: `Microsoft.Billing/billingPeriods/Microsoft.Consumption`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8194,7 +8194,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingProperty`  \n`"
+      "value": "Type: `Microsoft.Billing/billingProperty`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8215,7 +8215,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingRoleAssignments`  \n`"
+      "value": "Type: `Microsoft.Billing/billingRoleAssignments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8236,7 +8236,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/billingRoleDefinitions`  \n`"
+      "value": "Type: `Microsoft.Billing/billingRoleDefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8257,7 +8257,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/enrollmentAccounts`  \n`"
+      "value": "Type: `Microsoft.Billing/enrollmentAccounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8278,7 +8278,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/invoices`  \n`"
+      "value": "Type: `Microsoft.Billing/invoices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8299,7 +8299,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/paymentMethods`  \n`"
+      "value": "Type: `Microsoft.Billing/paymentMethods`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8320,7 +8320,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Billing/promotions`  \n`"
+      "value": "Type: `Microsoft.Billing/promotions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8341,7 +8341,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.BillingBenefits/reservationOrderAliases`  \n`"
+      "value": "Type: `Microsoft.BillingBenefits/reservationOrderAliases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8362,7 +8362,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.BillingBenefits/savingsPlanOrderAliases`  \n`"
+      "value": "Type: `Microsoft.BillingBenefits/savingsPlanOrderAliases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8383,7 +8383,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.BillingBenefits/savingsPlanOrders`  \n`"
+      "value": "Type: `Microsoft.BillingBenefits/savingsPlanOrders`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8404,7 +8404,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.BillingBenefits/savingsPlanOrders/savingsPlans`  \n`"
+      "value": "Type: `Microsoft.BillingBenefits/savingsPlanOrders/savingsPlans`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8425,7 +8425,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Blockchain/blockchainMembers`  \n`"
+      "value": "Type: `Microsoft.Blockchain/blockchainMembers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8446,7 +8446,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Blockchain/blockchainMembers/transactionNodes`  \n`"
+      "value": "Type: `Microsoft.Blockchain/blockchainMembers/transactionNodes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8467,7 +8467,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Blueprint/blueprintAssignments`  \n`"
+      "value": "Type: `Microsoft.Blueprint/blueprintAssignments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8488,7 +8488,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Blueprint/blueprintAssignments/assignmentOperations`  \n`"
+      "value": "Type: `Microsoft.Blueprint/blueprintAssignments/assignmentOperations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8509,7 +8509,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Blueprint/blueprints`  \n`"
+      "value": "Type: `Microsoft.Blueprint/blueprints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8530,7 +8530,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Blueprint/blueprints/artifacts`  \n`"
+      "value": "Type: `Microsoft.Blueprint/blueprints/artifacts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8551,7 +8551,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Blueprint/blueprints/versions`  \n`"
+      "value": "Type: `Microsoft.Blueprint/blueprints/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8572,7 +8572,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Blueprint/blueprints/versions/artifacts`  \n`"
+      "value": "Type: `Microsoft.Blueprint/blueprints/versions/artifacts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8593,7 +8593,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.BotService/botServices`  \n`"
+      "value": "Type: `Microsoft.BotService/botServices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8614,7 +8614,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.BotService/botServices/channels`  \n`"
+      "value": "Type: `Microsoft.BotService/botServices/channels`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8635,7 +8635,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.BotService/botServices/connections`  \n`"
+      "value": "Type: `Microsoft.BotService/botServices/connections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8656,7 +8656,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.BotService/botServices/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.BotService/botServices/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8677,7 +8677,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.BotService/enterpriseChannels`  \n`"
+      "value": "Type: `Microsoft.BotService/enterpriseChannels`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8698,7 +8698,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Cache/redis`  \n`"
+      "value": "Type: `Microsoft.Cache/redis`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8719,7 +8719,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Cache/redis/accessPolicies`  \n`"
+      "value": "Type: `Microsoft.Cache/redis/accessPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8740,7 +8740,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Cache/redis/accessPolicyAssignments`  \n`"
+      "value": "Type: `Microsoft.Cache/redis/accessPolicyAssignments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8761,7 +8761,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Cache/redis/firewallRules`  \n`"
+      "value": "Type: `Microsoft.Cache/redis/firewallRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8782,7 +8782,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Cache/redis/linkedServers`  \n`"
+      "value": "Type: `Microsoft.Cache/redis/linkedServers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8803,7 +8803,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Cache/redis/patchSchedules`  \n`"
+      "value": "Type: `Microsoft.Cache/redis/patchSchedules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8824,7 +8824,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Cache/redis/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Cache/redis/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8845,7 +8845,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Cache/redisEnterprise`  \n`"
+      "value": "Type: `Microsoft.Cache/redisEnterprise`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8866,7 +8866,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Cache/redisEnterprise/databases`  \n`"
+      "value": "Type: `Microsoft.Cache/redisEnterprise/databases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8887,7 +8887,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Cache/redisEnterprise/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Cache/redisEnterprise/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8908,7 +8908,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Capacity/reservationOrders`  \n`"
+      "value": "Type: `Microsoft.Capacity/reservationOrders`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8929,7 +8929,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Capacity/reservationOrders/reservations`  \n`"
+      "value": "Type: `Microsoft.Capacity/reservationOrders/reservations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8950,7 +8950,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Capacity/resourceProviders/locations/serviceLimits`  \n`"
+      "value": "Type: `Microsoft.Capacity/resourceProviders/locations/serviceLimits`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8971,7 +8971,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Capacity/resourceProviders/locations/serviceLimitsRequests`  \n`"
+      "value": "Type: `Microsoft.Capacity/resourceProviders/locations/serviceLimitsRequests`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -8992,7 +8992,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Cdn/cdnWebApplicationFirewallPolicies`  \n`"
+      "value": "Type: `Microsoft.Cdn/cdnWebApplicationFirewallPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9013,7 +9013,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Cdn/profiles`  \n`"
+      "value": "Type: `Microsoft.Cdn/profiles`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9034,7 +9034,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Cdn/profiles/afdEndpoints`  \n`"
+      "value": "Type: `Microsoft.Cdn/profiles/afdEndpoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9055,7 +9055,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Cdn/profiles/afdEndpoints/routes`  \n`"
+      "value": "Type: `Microsoft.Cdn/profiles/afdEndpoints/routes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9076,7 +9076,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Cdn/profiles/customDomains`  \n`"
+      "value": "Type: `Microsoft.Cdn/profiles/customDomains`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9097,7 +9097,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Cdn/profiles/endpoints`  \n`"
+      "value": "Type: `Microsoft.Cdn/profiles/endpoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9118,7 +9118,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Cdn/profiles/endpoints/customDomains`  \n`"
+      "value": "Type: `Microsoft.Cdn/profiles/endpoints/customDomains`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9139,7 +9139,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Cdn/profiles/endpoints/originGroups`  \n`"
+      "value": "Type: `Microsoft.Cdn/profiles/endpoints/originGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9160,7 +9160,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Cdn/profiles/endpoints/origins`  \n`"
+      "value": "Type: `Microsoft.Cdn/profiles/endpoints/origins`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9181,7 +9181,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Cdn/profiles/keyGroups`  \n`"
+      "value": "Type: `Microsoft.Cdn/profiles/keyGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9202,7 +9202,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Cdn/profiles/originGroups`  \n`"
+      "value": "Type: `Microsoft.Cdn/profiles/originGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9223,7 +9223,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Cdn/profiles/originGroups/origins`  \n`"
+      "value": "Type: `Microsoft.Cdn/profiles/originGroups/origins`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9244,7 +9244,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Cdn/profiles/ruleSets`  \n`"
+      "value": "Type: `Microsoft.Cdn/profiles/ruleSets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9265,7 +9265,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Cdn/profiles/ruleSets/rules`  \n`"
+      "value": "Type: `Microsoft.Cdn/profiles/ruleSets/rules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9286,7 +9286,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Cdn/profiles/secrets`  \n`"
+      "value": "Type: `Microsoft.Cdn/profiles/secrets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9307,7 +9307,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Cdn/profiles/securityPolicies`  \n`"
+      "value": "Type: `Microsoft.Cdn/profiles/securityPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9328,7 +9328,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CertificateRegistration/certificateOrders`  \n`"
+      "value": "Type: `Microsoft.CertificateRegistration/certificateOrders`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9349,7 +9349,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CertificateRegistration/certificateOrders/certificates`  \n`"
+      "value": "Type: `Microsoft.CertificateRegistration/certificateOrders/certificates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9370,7 +9370,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CertificateRegistration/certificateOrders/detectors`  \n`"
+      "value": "Type: `Microsoft.CertificateRegistration/certificateOrders/detectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9391,7 +9391,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ChangeAnalysis/profile`  \n`"
+      "value": "Type: `Microsoft.ChangeAnalysis/profile`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9412,7 +9412,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Chaos/experiments`  \n`"
+      "value": "Type: `Microsoft.Chaos/experiments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9433,7 +9433,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Chaos/locations/targetTypes`  \n`"
+      "value": "Type: `Microsoft.Chaos/locations/targetTypes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9454,7 +9454,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Chaos/locations/targetTypes/capabilityTypes`  \n`"
+      "value": "Type: `Microsoft.Chaos/locations/targetTypes/capabilityTypes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9475,7 +9475,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Chaos/privateAccesses`  \n`"
+      "value": "Type: `Microsoft.Chaos/privateAccesses`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9496,7 +9496,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Chaos/privateAccesses/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Chaos/privateAccesses/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9517,7 +9517,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Chaos/targets`  \n`"
+      "value": "Type: `Microsoft.Chaos/targets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9538,7 +9538,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Chaos/targets/capabilities`  \n`"
+      "value": "Type: `Microsoft.Chaos/targets/capabilities`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9559,7 +9559,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CognitiveServices/accounts`  \n`"
+      "value": "Type: `Microsoft.CognitiveServices/accounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9580,7 +9580,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CognitiveServices/accounts/commitmentPlans`  \n`"
+      "value": "Type: `Microsoft.CognitiveServices/accounts/commitmentPlans`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9601,7 +9601,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CognitiveServices/accounts/deployments`  \n`"
+      "value": "Type: `Microsoft.CognitiveServices/accounts/deployments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9622,7 +9622,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CognitiveServices/accounts/encryptionScopes`  \n`"
+      "value": "Type: `Microsoft.CognitiveServices/accounts/encryptionScopes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9643,7 +9643,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CognitiveServices/accounts/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.CognitiveServices/accounts/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9664,7 +9664,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CognitiveServices/accounts/raiBlocklists`  \n`"
+      "value": "Type: `Microsoft.CognitiveServices/accounts/raiBlocklists`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9685,7 +9685,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CognitiveServices/accounts/raiBlocklists/raiBlocklistItems`  \n`"
+      "value": "Type: `Microsoft.CognitiveServices/accounts/raiBlocklists/raiBlocklistItems`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9706,7 +9706,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CognitiveServices/accounts/raiPolicies`  \n`"
+      "value": "Type: `Microsoft.CognitiveServices/accounts/raiPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9727,7 +9727,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CognitiveServices/commitmentPlans`  \n`"
+      "value": "Type: `Microsoft.CognitiveServices/commitmentPlans`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9748,7 +9748,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CognitiveServices/commitmentPlans/accountAssociations`  \n`"
+      "value": "Type: `Microsoft.CognitiveServices/commitmentPlans/accountAssociations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9769,7 +9769,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CognitiveServices/locations/resourceGroups/deletedAccounts`  \n`"
+      "value": "Type: `Microsoft.CognitiveServices/locations/resourceGroups/deletedAccounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9790,7 +9790,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Communication/communicationServices`  \n`"
+      "value": "Type: `Microsoft.Communication/communicationServices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9811,7 +9811,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Communication/emailServices`  \n`"
+      "value": "Type: `Microsoft.Communication/emailServices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9832,7 +9832,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Communication/emailServices/domains`  \n`"
+      "value": "Type: `Microsoft.Communication/emailServices/domains`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9853,7 +9853,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Communication/emailServices/domains/senderUsernames`  \n`"
+      "value": "Type: `Microsoft.Communication/emailServices/domains/senderUsernames`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9874,7 +9874,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Communication/emailServices/domains/suppressionLists`  \n`"
+      "value": "Type: `Microsoft.Communication/emailServices/domains/suppressionLists`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9895,7 +9895,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Communication/emailServices/domains/suppressionLists/suppressionListAddresses`  \n`"
+      "value": "Type: `Microsoft.Communication/emailServices/domains/suppressionLists/suppressionListAddresses`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9916,7 +9916,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute.Admin/locations/artifactTypes/publishers/offers/skus/versions`  \n`"
+      "value": "Type: `Microsoft.Compute.Admin/locations/artifactTypes/publishers/offers/skus/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9937,7 +9937,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute.Admin/locations/artifactTypes/publishers/types/versions`  \n`"
+      "value": "Type: `Microsoft.Compute.Admin/locations/artifactTypes/publishers/types/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9958,7 +9958,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute.Admin/locations/computeScaleUnits`  \n`"
+      "value": "Type: `Microsoft.Compute.Admin/locations/computeScaleUnits`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -9979,7 +9979,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute.Admin/locations/diskmigrationjobs`  \n`"
+      "value": "Type: `Microsoft.Compute.Admin/locations/diskmigrationjobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10000,7 +10000,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute.Admin/locations/disks`  \n`"
+      "value": "Type: `Microsoft.Compute.Admin/locations/disks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10021,7 +10021,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute.Admin/locations/features`  \n`"
+      "value": "Type: `Microsoft.Compute.Admin/locations/features`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10042,7 +10042,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute.Admin/locations/quotas`  \n`"
+      "value": "Type: `Microsoft.Compute.Admin/locations/quotas`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10063,7 +10063,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/availabilitySets`  \n`"
+      "value": "Type: `Microsoft.Compute/availabilitySets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10084,7 +10084,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/capacityReservationGroups`  \n`"
+      "value": "Type: `Microsoft.Compute/capacityReservationGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10105,7 +10105,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/capacityReservationGroups/capacityReservations`  \n`"
+      "value": "Type: `Microsoft.Compute/capacityReservationGroups/capacityReservations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10126,7 +10126,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/cloudServices`  \n`"
+      "value": "Type: `Microsoft.Compute/cloudServices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10147,7 +10147,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/cloudServices/roleInstances/networkInterfaces`  \n`"
+      "value": "Type: `Microsoft.Compute/cloudServices/roleInstances/networkInterfaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10168,7 +10168,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/cloudServices/roleInstances/networkInterfaces/ipconfigurations/publicipaddresses`  \n`"
+      "value": "Type: `Microsoft.Compute/cloudServices/roleInstances/networkInterfaces/ipconfigurations/publicipaddresses`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10189,7 +10189,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/cloudServices/updateDomains`  \n`"
+      "value": "Type: `Microsoft.Compute/cloudServices/updateDomains`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10210,7 +10210,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/diskAccesses`  \n`"
+      "value": "Type: `Microsoft.Compute/diskAccesses`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10231,7 +10231,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/diskAccesses/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Compute/diskAccesses/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10252,7 +10252,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/diskEncryptionSets`  \n`"
+      "value": "Type: `Microsoft.Compute/diskEncryptionSets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10273,7 +10273,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/disks`  \n`"
+      "value": "Type: `Microsoft.Compute/disks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10294,7 +10294,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/galleries`  \n`"
+      "value": "Type: `Microsoft.Compute/galleries`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10315,7 +10315,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/galleries/applications`  \n`"
+      "value": "Type: `Microsoft.Compute/galleries/applications`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10336,7 +10336,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/galleries/applications/versions`  \n`"
+      "value": "Type: `Microsoft.Compute/galleries/applications/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10357,7 +10357,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/galleries/images`  \n`"
+      "value": "Type: `Microsoft.Compute/galleries/images`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10378,7 +10378,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/galleries/images/versions`  \n`"
+      "value": "Type: `Microsoft.Compute/galleries/images/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10399,7 +10399,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/hostGroups`  \n`"
+      "value": "Type: `Microsoft.Compute/hostGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10420,7 +10420,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/hostGroups/hosts`  \n`"
+      "value": "Type: `Microsoft.Compute/hostGroups/hosts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10441,7 +10441,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/images`  \n`"
+      "value": "Type: `Microsoft.Compute/images`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10462,7 +10462,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/locations/edgeZones/publishers/artifacttypes/offers/skus/versions`  \n`"
+      "value": "Type: `Microsoft.Compute/locations/edgeZones/publishers/artifacttypes/offers/skus/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10483,7 +10483,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/locations/publishers/artifacttypes/offers/skus/versions`  \n`"
+      "value": "Type: `Microsoft.Compute/locations/publishers/artifacttypes/offers/skus/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10504,7 +10504,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/locations/publishers/artifacttypes/types/versions`  \n`"
+      "value": "Type: `Microsoft.Compute/locations/publishers/artifacttypes/types/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10525,7 +10525,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/proximityPlacementGroups`  \n`"
+      "value": "Type: `Microsoft.Compute/proximityPlacementGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10546,7 +10546,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/restorePointCollections`  \n`"
+      "value": "Type: `Microsoft.Compute/restorePointCollections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10567,7 +10567,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/restorePointCollections/restorePoints`  \n`"
+      "value": "Type: `Microsoft.Compute/restorePointCollections/restorePoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10588,7 +10588,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/snapshots`  \n`"
+      "value": "Type: `Microsoft.Compute/snapshots`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10609,7 +10609,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/sshPublicKeys`  \n`"
+      "value": "Type: `Microsoft.Compute/sshPublicKeys`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10630,7 +10630,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/virtualMachineScaleSets`  \n`"
+      "value": "Type: `Microsoft.Compute/virtualMachineScaleSets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10651,7 +10651,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/virtualMachineScaleSets/extensions`  \n`"
+      "value": "Type: `Microsoft.Compute/virtualMachineScaleSets/extensions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10672,7 +10672,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/virtualMachineScaleSets/rollingUpgrades`  \n`"
+      "value": "Type: `Microsoft.Compute/virtualMachineScaleSets/rollingUpgrades`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10693,7 +10693,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/virtualMachineScaleSets/virtualMachines`  \n`"
+      "value": "Type: `Microsoft.Compute/virtualMachineScaleSets/virtualMachines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10714,7 +10714,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/virtualMachineScaleSets/virtualMachines/extensions`  \n`"
+      "value": "Type: `Microsoft.Compute/virtualMachineScaleSets/virtualMachines/extensions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10735,7 +10735,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/virtualMachineScaleSets/virtualMachines/networkInterfaces/ipconfigurations/publicipaddresses`  \n`"
+      "value": "Type: `Microsoft.Compute/virtualMachineScaleSets/virtualMachines/networkInterfaces/ipconfigurations/publicipaddresses`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10756,7 +10756,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/virtualMachineScaleSets/virtualMachines/runCommands`  \n`"
+      "value": "Type: `Microsoft.Compute/virtualMachineScaleSets/virtualMachines/runCommands`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10777,7 +10777,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/virtualMachines`  \n`"
+      "value": "Type: `Microsoft.Compute/virtualMachines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10798,7 +10798,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/virtualMachines/extensions`  \n`"
+      "value": "Type: `Microsoft.Compute/virtualMachines/extensions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10819,7 +10819,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Compute/virtualMachines/runCommands`  \n`"
+      "value": "Type: `Microsoft.Compute/virtualMachines/runCommands`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10840,7 +10840,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ConfidentialLedger/ledgers`  \n`"
+      "value": "Type: `Microsoft.ConfidentialLedger/ledgers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10861,7 +10861,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ConfidentialLedger/managedCCFs`  \n`"
+      "value": "Type: `Microsoft.ConfidentialLedger/managedCCFs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10882,7 +10882,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Confluent/agreements`  \n`"
+      "value": "Type: `Microsoft.Confluent/agreements`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10903,7 +10903,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Confluent/organizations`  \n`"
+      "value": "Type: `Microsoft.Confluent/organizations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10924,7 +10924,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ConnectedVMwarevSphere/clusters`  \n`"
+      "value": "Type: `Microsoft.ConnectedVMwarevSphere/clusters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10945,7 +10945,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ConnectedVMwarevSphere/datastores`  \n`"
+      "value": "Type: `Microsoft.ConnectedVMwarevSphere/datastores`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10966,7 +10966,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ConnectedVMwarevSphere/hosts`  \n`"
+      "value": "Type: `Microsoft.ConnectedVMwarevSphere/hosts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -10987,7 +10987,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ConnectedVMwarevSphere/resourcePools`  \n`"
+      "value": "Type: `Microsoft.ConnectedVMwarevSphere/resourcePools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11008,7 +11008,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ConnectedVMwarevSphere/vcenters`  \n`"
+      "value": "Type: `Microsoft.ConnectedVMwarevSphere/vcenters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11029,7 +11029,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ConnectedVMwarevSphere/vcenters/inventoryItems`  \n`"
+      "value": "Type: `Microsoft.ConnectedVMwarevSphere/vcenters/inventoryItems`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11050,7 +11050,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ConnectedVMwarevSphere/virtualMachineInstances`  \n`"
+      "value": "Type: `Microsoft.ConnectedVMwarevSphere/virtualMachineInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11071,7 +11071,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ConnectedVMwarevSphere/virtualMachineInstances/guestAgents`  \n`"
+      "value": "Type: `Microsoft.ConnectedVMwarevSphere/virtualMachineInstances/guestAgents`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11092,7 +11092,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ConnectedVMwarevSphere/virtualMachineInstances/hybridIdentityMetadata`  \n`"
+      "value": "Type: `Microsoft.ConnectedVMwarevSphere/virtualMachineInstances/hybridIdentityMetadata`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11113,7 +11113,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ConnectedVMwarevSphere/virtualMachineTemplates`  \n`"
+      "value": "Type: `Microsoft.ConnectedVMwarevSphere/virtualMachineTemplates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11134,7 +11134,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ConnectedVMwarevSphere/virtualMachines`  \n`"
+      "value": "Type: `Microsoft.ConnectedVMwarevSphere/virtualMachines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11155,7 +11155,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ConnectedVMwarevSphere/virtualMachines/extensions`  \n`"
+      "value": "Type: `Microsoft.ConnectedVMwarevSphere/virtualMachines/extensions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11176,7 +11176,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ConnectedVMwarevSphere/virtualMachines/guestAgents`  \n`"
+      "value": "Type: `Microsoft.ConnectedVMwarevSphere/virtualMachines/guestAgents`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11197,7 +11197,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ConnectedVMwarevSphere/virtualMachines/hybridIdentityMetadata`  \n`"
+      "value": "Type: `Microsoft.ConnectedVMwarevSphere/virtualMachines/hybridIdentityMetadata`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11218,7 +11218,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ConnectedVMwarevSphere/virtualNetworks`  \n`"
+      "value": "Type: `Microsoft.ConnectedVMwarevSphere/virtualNetworks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11239,7 +11239,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Consumption/budgets`  \n`"
+      "value": "Type: `Microsoft.Consumption/budgets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11260,7 +11260,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Consumption/credits`  \n`"
+      "value": "Type: `Microsoft.Consumption/credits`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11281,7 +11281,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Consumption/pricesheets`  \n`"
+      "value": "Type: `Microsoft.Consumption/pricesheets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11302,7 +11302,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerInstance/containerGroups`  \n`"
+      "value": "Type: `Microsoft.ContainerInstance/containerGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11323,7 +11323,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerRegistry.Admin/locations/capacities`  \n`"
+      "value": "Type: `Microsoft.ContainerRegistry.Admin/locations/capacities`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11344,7 +11344,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerRegistry.Admin/locations/configurations`  \n`"
+      "value": "Type: `Microsoft.ContainerRegistry.Admin/locations/configurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11365,7 +11365,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerRegistry.Admin/locations/quotas`  \n`"
+      "value": "Type: `Microsoft.ContainerRegistry.Admin/locations/quotas`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11386,7 +11386,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerRegistry/registries`  \n`"
+      "value": "Type: `Microsoft.ContainerRegistry/registries`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11407,7 +11407,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerRegistry/registries/agentPools`  \n`"
+      "value": "Type: `Microsoft.ContainerRegistry/registries/agentPools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11428,7 +11428,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerRegistry/registries/buildTasks`  \n`"
+      "value": "Type: `Microsoft.ContainerRegistry/registries/buildTasks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11449,7 +11449,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerRegistry/registries/buildTasks/steps`  \n`"
+      "value": "Type: `Microsoft.ContainerRegistry/registries/buildTasks/steps`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11470,7 +11470,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerRegistry/registries/builds`  \n`"
+      "value": "Type: `Microsoft.ContainerRegistry/registries/builds`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11491,7 +11491,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerRegistry/registries/cacheRules`  \n`"
+      "value": "Type: `Microsoft.ContainerRegistry/registries/cacheRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11512,7 +11512,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerRegistry/registries/connectedRegistries`  \n`"
+      "value": "Type: `Microsoft.ContainerRegistry/registries/connectedRegistries`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11533,7 +11533,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerRegistry/registries/credentialSets`  \n`"
+      "value": "Type: `Microsoft.ContainerRegistry/registries/credentialSets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11554,7 +11554,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerRegistry/registries/exportPipelines`  \n`"
+      "value": "Type: `Microsoft.ContainerRegistry/registries/exportPipelines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11575,7 +11575,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerRegistry/registries/importPipelines`  \n`"
+      "value": "Type: `Microsoft.ContainerRegistry/registries/importPipelines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11596,7 +11596,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerRegistry/registries/packages/archives`  \n`"
+      "value": "Type: `Microsoft.ContainerRegistry/registries/packages/archives`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11617,7 +11617,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerRegistry/registries/packages/archives/versions`  \n`"
+      "value": "Type: `Microsoft.ContainerRegistry/registries/packages/archives/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11638,7 +11638,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerRegistry/registries/pipelineRuns`  \n`"
+      "value": "Type: `Microsoft.ContainerRegistry/registries/pipelineRuns`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11659,7 +11659,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerRegistry/registries/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.ContainerRegistry/registries/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11680,7 +11680,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerRegistry/registries/replications`  \n`"
+      "value": "Type: `Microsoft.ContainerRegistry/registries/replications`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11701,7 +11701,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerRegistry/registries/runs`  \n`"
+      "value": "Type: `Microsoft.ContainerRegistry/registries/runs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11722,7 +11722,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerRegistry/registries/scopeMaps`  \n`"
+      "value": "Type: `Microsoft.ContainerRegistry/registries/scopeMaps`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11743,7 +11743,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerRegistry/registries/taskRuns`  \n`"
+      "value": "Type: `Microsoft.ContainerRegistry/registries/taskRuns`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11764,7 +11764,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerRegistry/registries/tasks`  \n`"
+      "value": "Type: `Microsoft.ContainerRegistry/registries/tasks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11785,7 +11785,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerRegistry/registries/tokens`  \n`"
+      "value": "Type: `Microsoft.ContainerRegistry/registries/tokens`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11806,7 +11806,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerRegistry/registries/webhooks`  \n`"
+      "value": "Type: `Microsoft.ContainerRegistry/registries/webhooks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11827,7 +11827,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerService/containerServices`  \n`"
+      "value": "Type: `Microsoft.ContainerService/containerServices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11848,7 +11848,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerService/fleets`  \n`"
+      "value": "Type: `Microsoft.ContainerService/fleets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11869,7 +11869,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerService/fleets/members`  \n`"
+      "value": "Type: `Microsoft.ContainerService/fleets/members`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11890,7 +11890,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerService/fleets/updateRuns`  \n`"
+      "value": "Type: `Microsoft.ContainerService/fleets/updateRuns`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11911,7 +11911,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerService/fleets/updateStrategies`  \n`"
+      "value": "Type: `Microsoft.ContainerService/fleets/updateStrategies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11932,7 +11932,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerService/locations/guardrailsVersions`  \n`"
+      "value": "Type: `Microsoft.ContainerService/locations/guardrailsVersions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11953,7 +11953,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerService/locations/meshRevisionProfiles`  \n`"
+      "value": "Type: `Microsoft.ContainerService/locations/meshRevisionProfiles`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11974,7 +11974,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerService/managedClusters`  \n`"
+      "value": "Type: `Microsoft.ContainerService/managedClusters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -11995,7 +11995,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerService/managedClusters/accessProfiles`  \n`"
+      "value": "Type: `Microsoft.ContainerService/managedClusters/accessProfiles`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12016,7 +12016,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerService/managedClusters/agentPools`  \n`"
+      "value": "Type: `Microsoft.ContainerService/managedClusters/agentPools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12037,7 +12037,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerService/managedClusters/agentPools/machines`  \n`"
+      "value": "Type: `Microsoft.ContainerService/managedClusters/agentPools/machines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12058,7 +12058,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerService/managedClusters/maintenanceConfigurations`  \n`"
+      "value": "Type: `Microsoft.ContainerService/managedClusters/maintenanceConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12079,7 +12079,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerService/managedClusters/meshUpgradeProfiles`  \n`"
+      "value": "Type: `Microsoft.ContainerService/managedClusters/meshUpgradeProfiles`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12100,7 +12100,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerService/managedClusters/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.ContainerService/managedClusters/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12121,7 +12121,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerService/managedClusters/trustedAccessRoleBindings`  \n`"
+      "value": "Type: `Microsoft.ContainerService/managedClusters/trustedAccessRoleBindings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12142,7 +12142,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerService/managedclustersnapshots`  \n`"
+      "value": "Type: `Microsoft.ContainerService/managedclustersnapshots`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12163,7 +12163,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerService/openShiftManagedClusters`  \n`"
+      "value": "Type: `Microsoft.ContainerService/openShiftManagedClusters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12184,7 +12184,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerService/snapshots`  \n`"
+      "value": "Type: `Microsoft.ContainerService/snapshots`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12205,7 +12205,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerStorage/pools`  \n`"
+      "value": "Type: `Microsoft.ContainerStorage/pools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12226,7 +12226,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerStorage/pools/snapshots`  \n`"
+      "value": "Type: `Microsoft.ContainerStorage/pools/snapshots`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12247,7 +12247,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ContainerStorage/pools/volumes`  \n`"
+      "value": "Type: `Microsoft.ContainerStorage/pools/volumes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12268,7 +12268,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CostManagement/alerts`  \n`"
+      "value": "Type: `Microsoft.CostManagement/alerts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12289,7 +12289,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CostManagement/budgets`  \n`"
+      "value": "Type: `Microsoft.CostManagement/budgets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12310,7 +12310,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CostManagement/cloudConnectors`  \n`"
+      "value": "Type: `Microsoft.CostManagement/cloudConnectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12331,7 +12331,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CostManagement/connectors`  \n`"
+      "value": "Type: `Microsoft.CostManagement/connectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12352,7 +12352,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CostManagement/costAllocationRules`  \n`"
+      "value": "Type: `Microsoft.CostManagement/costAllocationRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12373,7 +12373,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CostManagement/exports`  \n`"
+      "value": "Type: `Microsoft.CostManagement/exports`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12394,7 +12394,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CostManagement/externalBillingAccounts`  \n`"
+      "value": "Type: `Microsoft.CostManagement/externalBillingAccounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12415,7 +12415,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CostManagement/externalSubscriptions`  \n`"
+      "value": "Type: `Microsoft.CostManagement/externalSubscriptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12436,7 +12436,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CostManagement/markupRules`  \n`"
+      "value": "Type: `Microsoft.CostManagement/markupRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12457,7 +12457,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CostManagement/reportconfigs`  \n`"
+      "value": "Type: `Microsoft.CostManagement/reportconfigs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12478,7 +12478,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CostManagement/reports`  \n`"
+      "value": "Type: `Microsoft.CostManagement/reports`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12499,7 +12499,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CostManagement/scheduledActions`  \n`"
+      "value": "Type: `Microsoft.CostManagement/scheduledActions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12520,7 +12520,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CostManagement/settings`  \n`"
+      "value": "Type: `Microsoft.CostManagement/settings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12541,7 +12541,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CostManagement/showbackRules`  \n`"
+      "value": "Type: `Microsoft.CostManagement/showbackRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12562,7 +12562,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CostManagement/views`  \n`"
+      "value": "Type: `Microsoft.CostManagement/views`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12583,7 +12583,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CustomProviders/associations`  \n`"
+      "value": "Type: `Microsoft.CustomProviders/associations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12604,7 +12604,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CustomProviders/resourceProviders`  \n`"
+      "value": "Type: `Microsoft.CustomProviders/resourceProviders`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12625,7 +12625,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CustomerInsights/hubs`  \n`"
+      "value": "Type: `Microsoft.CustomerInsights/hubs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12646,7 +12646,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CustomerInsights/hubs/authorizationPolicies`  \n`"
+      "value": "Type: `Microsoft.CustomerInsights/hubs/authorizationPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12667,7 +12667,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CustomerInsights/hubs/connectors`  \n`"
+      "value": "Type: `Microsoft.CustomerInsights/hubs/connectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12688,7 +12688,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CustomerInsights/hubs/connectors/mappings`  \n`"
+      "value": "Type: `Microsoft.CustomerInsights/hubs/connectors/mappings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12709,7 +12709,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CustomerInsights/hubs/interactions`  \n`"
+      "value": "Type: `Microsoft.CustomerInsights/hubs/interactions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12730,7 +12730,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CustomerInsights/hubs/kpi`  \n`"
+      "value": "Type: `Microsoft.CustomerInsights/hubs/kpi`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12751,7 +12751,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CustomerInsights/hubs/links`  \n`"
+      "value": "Type: `Microsoft.CustomerInsights/hubs/links`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12772,7 +12772,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CustomerInsights/hubs/predictions`  \n`"
+      "value": "Type: `Microsoft.CustomerInsights/hubs/predictions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12793,7 +12793,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CustomerInsights/hubs/profiles`  \n`"
+      "value": "Type: `Microsoft.CustomerInsights/hubs/profiles`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12814,7 +12814,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CustomerInsights/hubs/relationshipLinks`  \n`"
+      "value": "Type: `Microsoft.CustomerInsights/hubs/relationshipLinks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12835,7 +12835,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CustomerInsights/hubs/relationships`  \n`"
+      "value": "Type: `Microsoft.CustomerInsights/hubs/relationships`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12856,7 +12856,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CustomerInsights/hubs/roleAssignments`  \n`"
+      "value": "Type: `Microsoft.CustomerInsights/hubs/roleAssignments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12877,7 +12877,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CustomerInsights/hubs/views`  \n`"
+      "value": "Type: `Microsoft.CustomerInsights/hubs/views`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12898,7 +12898,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.CustomerInsights/hubs/widgetTypes`  \n`"
+      "value": "Type: `Microsoft.CustomerInsights/hubs/widgetTypes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12919,7 +12919,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBForMySql/flexibleServers/keys`  \n`"
+      "value": "Type: `Microsoft.DBForMySql/flexibleServers/keys`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12940,7 +12940,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMariaDB/servers`  \n`"
+      "value": "Type: `Microsoft.DBforMariaDB/servers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12961,7 +12961,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMariaDB/servers/advisors`  \n`"
+      "value": "Type: `Microsoft.DBforMariaDB/servers/advisors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -12982,7 +12982,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMariaDB/servers/advisors/recommendedActions`  \n`"
+      "value": "Type: `Microsoft.DBforMariaDB/servers/advisors/recommendedActions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13003,7 +13003,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMariaDB/servers/configurations`  \n`"
+      "value": "Type: `Microsoft.DBforMariaDB/servers/configurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13024,7 +13024,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMariaDB/servers/databases`  \n`"
+      "value": "Type: `Microsoft.DBforMariaDB/servers/databases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13045,7 +13045,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMariaDB/servers/firewallRules`  \n`"
+      "value": "Type: `Microsoft.DBforMariaDB/servers/firewallRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13066,7 +13066,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMariaDB/servers/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.DBforMariaDB/servers/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13087,7 +13087,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMariaDB/servers/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.DBforMariaDB/servers/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13108,7 +13108,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMariaDB/servers/queryTexts`  \n`"
+      "value": "Type: `Microsoft.DBforMariaDB/servers/queryTexts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13129,7 +13129,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMariaDB/servers/securityAlertPolicies`  \n`"
+      "value": "Type: `Microsoft.DBforMariaDB/servers/securityAlertPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13150,7 +13150,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMariaDB/servers/topQueryStatistics`  \n`"
+      "value": "Type: `Microsoft.DBforMariaDB/servers/topQueryStatistics`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13171,7 +13171,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMariaDB/servers/virtualNetworkRules`  \n`"
+      "value": "Type: `Microsoft.DBforMariaDB/servers/virtualNetworkRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13192,7 +13192,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMariaDB/servers/waitStatistics`  \n`"
+      "value": "Type: `Microsoft.DBforMariaDB/servers/waitStatistics`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13213,7 +13213,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMySQL/flexibleServers`  \n`"
+      "value": "Type: `Microsoft.DBforMySQL/flexibleServers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13234,7 +13234,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMySQL/flexibleServers/administrators`  \n`"
+      "value": "Type: `Microsoft.DBforMySQL/flexibleServers/administrators`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13255,7 +13255,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMySQL/flexibleServers/backups`  \n`"
+      "value": "Type: `Microsoft.DBforMySQL/flexibleServers/backups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13276,7 +13276,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMySQL/flexibleServers/configurations`  \n`"
+      "value": "Type: `Microsoft.DBforMySQL/flexibleServers/configurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13297,7 +13297,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMySQL/flexibleServers/databases`  \n`"
+      "value": "Type: `Microsoft.DBforMySQL/flexibleServers/databases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13318,7 +13318,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMySQL/flexibleServers/firewallRules`  \n`"
+      "value": "Type: `Microsoft.DBforMySQL/flexibleServers/firewallRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13339,7 +13339,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMySQL/flexibleServers/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.DBforMySQL/flexibleServers/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13360,7 +13360,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMySQL/flexibleServers/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.DBforMySQL/flexibleServers/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13381,7 +13381,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMySQL/locations/capabilitySets`  \n`"
+      "value": "Type: `Microsoft.DBforMySQL/locations/capabilitySets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13402,7 +13402,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMySQL/servers`  \n`"
+      "value": "Type: `Microsoft.DBforMySQL/servers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13423,7 +13423,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMySQL/servers/administrators`  \n`"
+      "value": "Type: `Microsoft.DBforMySQL/servers/administrators`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13444,7 +13444,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMySQL/servers/advisors`  \n`"
+      "value": "Type: `Microsoft.DBforMySQL/servers/advisors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13465,7 +13465,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMySQL/servers/advisors/recommendedActions`  \n`"
+      "value": "Type: `Microsoft.DBforMySQL/servers/advisors/recommendedActions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13486,7 +13486,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMySQL/servers/configurations`  \n`"
+      "value": "Type: `Microsoft.DBforMySQL/servers/configurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13507,7 +13507,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMySQL/servers/databases`  \n`"
+      "value": "Type: `Microsoft.DBforMySQL/servers/databases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13528,7 +13528,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMySQL/servers/firewallRules`  \n`"
+      "value": "Type: `Microsoft.DBforMySQL/servers/firewallRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13549,7 +13549,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMySQL/servers/keys`  \n`"
+      "value": "Type: `Microsoft.DBforMySQL/servers/keys`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13570,7 +13570,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMySQL/servers/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.DBforMySQL/servers/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13591,7 +13591,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMySQL/servers/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.DBforMySQL/servers/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13612,7 +13612,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMySQL/servers/queryTexts`  \n`"
+      "value": "Type: `Microsoft.DBforMySQL/servers/queryTexts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13633,7 +13633,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMySQL/servers/securityAlertPolicies`  \n`"
+      "value": "Type: `Microsoft.DBforMySQL/servers/securityAlertPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13654,7 +13654,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMySQL/servers/topQueryStatistics`  \n`"
+      "value": "Type: `Microsoft.DBforMySQL/servers/topQueryStatistics`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13675,7 +13675,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMySQL/servers/virtualNetworkRules`  \n`"
+      "value": "Type: `Microsoft.DBforMySQL/servers/virtualNetworkRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13696,7 +13696,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforMySQL/servers/waitStatistics`  \n`"
+      "value": "Type: `Microsoft.DBforMySQL/servers/waitStatistics`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13717,7 +13717,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/flexibleServers`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/flexibleServers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13738,7 +13738,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/flexibleServers/administrators`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/flexibleServers/administrators`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13759,7 +13759,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/flexibleServers/advisors`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/flexibleServers/advisors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13780,7 +13780,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/flexibleServers/backups`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/flexibleServers/backups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13801,7 +13801,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/flexibleServers/configurations`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/flexibleServers/configurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13822,7 +13822,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/flexibleServers/databases`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/flexibleServers/databases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13843,7 +13843,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/flexibleServers/firewallRules`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/flexibleServers/firewallRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13864,7 +13864,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/flexibleServers/ltrBackupOperations`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/flexibleServers/ltrBackupOperations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13885,7 +13885,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/flexibleServers/migrations`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/flexibleServers/migrations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13906,7 +13906,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/flexibleServers/queryTexts`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/flexibleServers/queryTexts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13927,7 +13927,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/serverGroupsv2`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/serverGroupsv2`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13948,7 +13948,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/serverGroupsv2/configurations`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/serverGroupsv2/configurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13969,7 +13969,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/serverGroupsv2/coordinatorConfigurations`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/serverGroupsv2/coordinatorConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -13990,7 +13990,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/serverGroupsv2/firewallRules`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/serverGroupsv2/firewallRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14011,7 +14011,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/serverGroupsv2/nodeConfigurations`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/serverGroupsv2/nodeConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14032,7 +14032,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/serverGroupsv2/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/serverGroupsv2/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14053,7 +14053,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/serverGroupsv2/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/serverGroupsv2/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14074,7 +14074,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/serverGroupsv2/roles`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/serverGroupsv2/roles`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14095,7 +14095,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/serverGroupsv2/servers`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/serverGroupsv2/servers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14116,7 +14116,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/servers`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/servers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14137,7 +14137,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/servers/administrators`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/servers/administrators`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14158,7 +14158,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/servers/advisors`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/servers/advisors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14179,7 +14179,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/servers/advisors/recommendedActions`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/servers/advisors/recommendedActions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14200,7 +14200,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/servers/configurations`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/servers/configurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14221,7 +14221,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/servers/databases`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/servers/databases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14242,7 +14242,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/servers/firewallRules`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/servers/firewallRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14263,7 +14263,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/servers/keys`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/servers/keys`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14284,7 +14284,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/servers/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/servers/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14305,7 +14305,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/servers/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/servers/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14326,7 +14326,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/servers/queryTexts`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/servers/queryTexts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14347,7 +14347,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/servers/securityAlertPolicies`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/servers/securityAlertPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14368,7 +14368,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/servers/topQueryStatistics`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/servers/topQueryStatistics`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14389,7 +14389,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/servers/virtualNetworkRules`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/servers/virtualNetworkRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14410,7 +14410,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DBforPostgreSQL/servers/waitStatistics`  \n`"
+      "value": "Type: `Microsoft.DBforPostgreSQL/servers/waitStatistics`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14431,7 +14431,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Dashboard/grafana`  \n`"
+      "value": "Type: `Microsoft.Dashboard/grafana`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14452,7 +14452,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Dashboard/grafana/managedPrivateEndpoints`  \n`"
+      "value": "Type: `Microsoft.Dashboard/grafana/managedPrivateEndpoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14473,7 +14473,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Dashboard/grafana/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Dashboard/grafana/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14494,7 +14494,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Dashboard/grafana/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.Dashboard/grafana/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14515,7 +14515,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataBox/jobs`  \n`"
+      "value": "Type: `Microsoft.DataBox/jobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14536,7 +14536,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices`  \n`"
+      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14557,7 +14557,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/alerts`  \n`"
+      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/alerts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14578,7 +14578,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/bandwidthSchedules`  \n`"
+      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/bandwidthSchedules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14599,7 +14599,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/deviceCapacityInfo`  \n`"
+      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/deviceCapacityInfo`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14620,7 +14620,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/diagnosticProactiveLogCollectionSettings`  \n`"
+      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/diagnosticProactiveLogCollectionSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14641,7 +14641,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/diagnosticRemoteSupportSettings`  \n`"
+      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/diagnosticRemoteSupportSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14662,7 +14662,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/networkSettings`  \n`"
+      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/networkSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14683,7 +14683,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/orders`  \n`"
+      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/orders`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14704,7 +14704,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/publishers/offers/skus/versions`  \n`"
+      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/publishers/offers/skus/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14725,7 +14725,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/roles`  \n`"
+      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/roles`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14746,7 +14746,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/roles/addons`  \n`"
+      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/roles/addons`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14767,7 +14767,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/roles/monitoringConfig`  \n`"
+      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/roles/monitoringConfig`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14788,7 +14788,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/shares`  \n`"
+      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/shares`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14809,7 +14809,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/storageAccountCredentials`  \n`"
+      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/storageAccountCredentials`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14830,7 +14830,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/storageAccounts`  \n`"
+      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/storageAccounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14851,7 +14851,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/storageAccounts/containers`  \n`"
+      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/storageAccounts/containers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14872,7 +14872,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/triggers`  \n`"
+      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/triggers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14893,7 +14893,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/updateSummary`  \n`"
+      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/updateSummary`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14914,7 +14914,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/users`  \n`"
+      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/users`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14935,7 +14935,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataCatalog/catalogs`  \n`"
+      "value": "Type: `Microsoft.DataCatalog/catalogs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14956,7 +14956,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataFactory/factories`  \n`"
+      "value": "Type: `Microsoft.DataFactory/factories`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14977,7 +14977,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataFactory/factories/adfcdcs`  \n`"
+      "value": "Type: `Microsoft.DataFactory/factories/adfcdcs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -14998,7 +14998,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataFactory/factories/credentials`  \n`"
+      "value": "Type: `Microsoft.DataFactory/factories/credentials`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15019,7 +15019,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataFactory/factories/dataflows`  \n`"
+      "value": "Type: `Microsoft.DataFactory/factories/dataflows`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15040,7 +15040,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataFactory/factories/datasets`  \n`"
+      "value": "Type: `Microsoft.DataFactory/factories/datasets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15061,7 +15061,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataFactory/factories/globalParameters`  \n`"
+      "value": "Type: `Microsoft.DataFactory/factories/globalParameters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15082,7 +15082,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataFactory/factories/integrationRuntimes`  \n`"
+      "value": "Type: `Microsoft.DataFactory/factories/integrationRuntimes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15103,7 +15103,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataFactory/factories/linkedservices`  \n`"
+      "value": "Type: `Microsoft.DataFactory/factories/linkedservices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15124,7 +15124,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataFactory/factories/managedVirtualNetworks`  \n`"
+      "value": "Type: `Microsoft.DataFactory/factories/managedVirtualNetworks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15145,7 +15145,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataFactory/factories/managedVirtualNetworks/managedPrivateEndpoints`  \n`"
+      "value": "Type: `Microsoft.DataFactory/factories/managedVirtualNetworks/managedPrivateEndpoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15166,7 +15166,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataFactory/factories/pipelines`  \n`"
+      "value": "Type: `Microsoft.DataFactory/factories/pipelines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15187,7 +15187,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataFactory/factories/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.DataFactory/factories/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15208,7 +15208,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataFactory/factories/triggers`  \n`"
+      "value": "Type: `Microsoft.DataFactory/factories/triggers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15229,7 +15229,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataLakeAnalytics/accounts`  \n`"
+      "value": "Type: `Microsoft.DataLakeAnalytics/accounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15250,7 +15250,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataLakeAnalytics/accounts/computePolicies`  \n`"
+      "value": "Type: `Microsoft.DataLakeAnalytics/accounts/computePolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15271,7 +15271,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataLakeAnalytics/accounts/dataLakeStoreAccounts`  \n`"
+      "value": "Type: `Microsoft.DataLakeAnalytics/accounts/dataLakeStoreAccounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15292,7 +15292,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataLakeAnalytics/accounts/firewallRules`  \n`"
+      "value": "Type: `Microsoft.DataLakeAnalytics/accounts/firewallRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15313,7 +15313,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataLakeAnalytics/accounts/storageAccounts`  \n`"
+      "value": "Type: `Microsoft.DataLakeAnalytics/accounts/storageAccounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15334,7 +15334,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataLakeAnalytics/accounts/storageAccounts/containers`  \n`"
+      "value": "Type: `Microsoft.DataLakeAnalytics/accounts/storageAccounts/containers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15355,7 +15355,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataLakeStore/accounts`  \n`"
+      "value": "Type: `Microsoft.DataLakeStore/accounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15376,7 +15376,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataLakeStore/accounts/firewallRules`  \n`"
+      "value": "Type: `Microsoft.DataLakeStore/accounts/firewallRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15397,7 +15397,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataLakeStore/accounts/trustedIdProviders`  \n`"
+      "value": "Type: `Microsoft.DataLakeStore/accounts/trustedIdProviders`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15418,7 +15418,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataLakeStore/accounts/virtualNetworkRules`  \n`"
+      "value": "Type: `Microsoft.DataLakeStore/accounts/virtualNetworkRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15439,7 +15439,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataMigration/databaseMigrations`  \n`"
+      "value": "Type: `Microsoft.DataMigration/databaseMigrations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15460,7 +15460,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataMigration/services`  \n`"
+      "value": "Type: `Microsoft.DataMigration/services`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15481,7 +15481,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataMigration/services/projects`  \n`"
+      "value": "Type: `Microsoft.DataMigration/services/projects`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15502,7 +15502,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataMigration/services/projects/files`  \n`"
+      "value": "Type: `Microsoft.DataMigration/services/projects/files`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15523,7 +15523,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataMigration/services/projects/tasks`  \n`"
+      "value": "Type: `Microsoft.DataMigration/services/projects/tasks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15544,7 +15544,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataMigration/services/serviceTasks`  \n`"
+      "value": "Type: `Microsoft.DataMigration/services/serviceTasks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15565,7 +15565,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataMigration/sqlMigrationServices`  \n`"
+      "value": "Type: `Microsoft.DataMigration/sqlMigrationServices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15586,7 +15586,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataProtection/backupVaults`  \n`"
+      "value": "Type: `Microsoft.DataProtection/backupVaults`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15607,7 +15607,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataProtection/backupVaults/backupInstances`  \n`"
+      "value": "Type: `Microsoft.DataProtection/backupVaults/backupInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15628,7 +15628,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataProtection/backupVaults/backupInstances/operationResults`  \n`"
+      "value": "Type: `Microsoft.DataProtection/backupVaults/backupInstances/operationResults`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15649,7 +15649,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataProtection/backupVaults/backupInstances/recoveryPoints`  \n`"
+      "value": "Type: `Microsoft.DataProtection/backupVaults/backupInstances/recoveryPoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15670,7 +15670,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataProtection/backupVaults/backupJobs`  \n`"
+      "value": "Type: `Microsoft.DataProtection/backupVaults/backupJobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15691,7 +15691,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataProtection/backupVaults/backupPolicies`  \n`"
+      "value": "Type: `Microsoft.DataProtection/backupVaults/backupPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15712,7 +15712,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataProtection/backupVaults/backupResourceGuardProxies`  \n`"
+      "value": "Type: `Microsoft.DataProtection/backupVaults/backupResourceGuardProxies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15733,7 +15733,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataProtection/backupVaults/deletedBackupInstances`  \n`"
+      "value": "Type: `Microsoft.DataProtection/backupVaults/deletedBackupInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15754,7 +15754,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataProtection/backupVaults/operationResults`  \n`"
+      "value": "Type: `Microsoft.DataProtection/backupVaults/operationResults`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15775,7 +15775,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataProtection/resourceGuards`  \n`"
+      "value": "Type: `Microsoft.DataProtection/resourceGuards`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15796,7 +15796,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataReplication/replicationFabrics`  \n`"
+      "value": "Type: `Microsoft.DataReplication/replicationFabrics`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15817,7 +15817,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataReplication/replicationFabrics/fabricAgents`  \n`"
+      "value": "Type: `Microsoft.DataReplication/replicationFabrics/fabricAgents`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15838,7 +15838,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataReplication/replicationVaults`  \n`"
+      "value": "Type: `Microsoft.DataReplication/replicationVaults`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15859,7 +15859,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataReplication/replicationVaults/alertSettings`  \n`"
+      "value": "Type: `Microsoft.DataReplication/replicationVaults/alertSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15880,7 +15880,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataReplication/replicationVaults/jobs`  \n`"
+      "value": "Type: `Microsoft.DataReplication/replicationVaults/jobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15901,7 +15901,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataReplication/replicationVaults/protectedItems`  \n`"
+      "value": "Type: `Microsoft.DataReplication/replicationVaults/protectedItems`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15922,7 +15922,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataReplication/replicationVaults/replicationExtensions`  \n`"
+      "value": "Type: `Microsoft.DataReplication/replicationVaults/replicationExtensions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15943,7 +15943,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataReplication/replicationVaults/replicationPolicies`  \n`"
+      "value": "Type: `Microsoft.DataReplication/replicationVaults/replicationPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15964,7 +15964,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataShare/accounts`  \n`"
+      "value": "Type: `Microsoft.DataShare/accounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -15985,7 +15985,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataShare/accounts/shareSubscriptions`  \n`"
+      "value": "Type: `Microsoft.DataShare/accounts/shareSubscriptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16006,7 +16006,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataShare/accounts/shareSubscriptions/dataSetMappings`  \n`"
+      "value": "Type: `Microsoft.DataShare/accounts/shareSubscriptions/dataSetMappings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16027,7 +16027,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataShare/accounts/shareSubscriptions/triggers`  \n`"
+      "value": "Type: `Microsoft.DataShare/accounts/shareSubscriptions/triggers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16048,7 +16048,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataShare/accounts/shares`  \n`"
+      "value": "Type: `Microsoft.DataShare/accounts/shares`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16069,7 +16069,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataShare/accounts/shares/dataSets`  \n`"
+      "value": "Type: `Microsoft.DataShare/accounts/shares/dataSets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16090,7 +16090,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataShare/accounts/shares/invitations`  \n`"
+      "value": "Type: `Microsoft.DataShare/accounts/shares/invitations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16111,7 +16111,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataShare/accounts/shares/providerShareSubscriptions`  \n`"
+      "value": "Type: `Microsoft.DataShare/accounts/shares/providerShareSubscriptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16132,7 +16132,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataShare/accounts/shares/synchronizationSettings`  \n`"
+      "value": "Type: `Microsoft.DataShare/accounts/shares/synchronizationSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16153,7 +16153,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DataShare/locations/consumerInvitations`  \n`"
+      "value": "Type: `Microsoft.DataShare/locations/consumerInvitations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16174,7 +16174,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Databricks/accessConnectors`  \n`"
+      "value": "Type: `Microsoft.Databricks/accessConnectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16195,7 +16195,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Databricks/workspaces`  \n`"
+      "value": "Type: `Microsoft.Databricks/workspaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16216,7 +16216,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Databricks/workspaces/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Databricks/workspaces/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16237,7 +16237,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Databricks/workspaces/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.Databricks/workspaces/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16258,7 +16258,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Databricks/workspaces/virtualNetworkPeerings`  \n`"
+      "value": "Type: `Microsoft.Databricks/workspaces/virtualNetworkPeerings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16279,7 +16279,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Datadog/agreements`  \n`"
+      "value": "Type: `Microsoft.Datadog/agreements`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16300,7 +16300,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Datadog/monitors`  \n`"
+      "value": "Type: `Microsoft.Datadog/monitors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16321,7 +16321,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Datadog/monitors/monitoredSubscriptions`  \n`"
+      "value": "Type: `Microsoft.Datadog/monitors/monitoredSubscriptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16342,7 +16342,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Datadog/monitors/singleSignOnConfigurations`  \n`"
+      "value": "Type: `Microsoft.Datadog/monitors/singleSignOnConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16363,7 +16363,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Datadog/monitors/tagRules`  \n`"
+      "value": "Type: `Microsoft.Datadog/monitors/tagRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16384,7 +16384,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DelegatedNetwork/controller`  \n`"
+      "value": "Type: `Microsoft.DelegatedNetwork/controller`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16405,7 +16405,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DelegatedNetwork/delegatedSubnets`  \n`"
+      "value": "Type: `Microsoft.DelegatedNetwork/delegatedSubnets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16426,7 +16426,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DelegatedNetwork/orchestrators`  \n`"
+      "value": "Type: `Microsoft.DelegatedNetwork/orchestrators`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16447,7 +16447,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Deployment.Admin/locations`  \n`"
+      "value": "Type: `Microsoft.Deployment.Admin/locations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16468,7 +16468,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Deployment.Admin/locations/actionPlans`  \n`"
+      "value": "Type: `Microsoft.Deployment.Admin/locations/actionPlans`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16489,7 +16489,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Deployment.Admin/locations/actionPlans/operations`  \n`"
+      "value": "Type: `Microsoft.Deployment.Admin/locations/actionPlans/operations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16510,7 +16510,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Deployment.Admin/locations/fileContainers`  \n`"
+      "value": "Type: `Microsoft.Deployment.Admin/locations/fileContainers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16531,7 +16531,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Deployment.Admin/locations/productDeployments`  \n`"
+      "value": "Type: `Microsoft.Deployment.Admin/locations/productDeployments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16552,7 +16552,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Deployment.Admin/locations/productPackages`  \n`"
+      "value": "Type: `Microsoft.Deployment.Admin/locations/productPackages`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16573,7 +16573,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Deployment.Admin/locations/productPackages/secrets`  \n`"
+      "value": "Type: `Microsoft.Deployment.Admin/locations/productPackages/secrets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16594,7 +16594,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DeploymentManager/artifactSources`  \n`"
+      "value": "Type: `Microsoft.DeploymentManager/artifactSources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16615,7 +16615,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DeploymentManager/rollouts`  \n`"
+      "value": "Type: `Microsoft.DeploymentManager/rollouts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16636,7 +16636,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DeploymentManager/serviceTopologies`  \n`"
+      "value": "Type: `Microsoft.DeploymentManager/serviceTopologies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16657,7 +16657,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DeploymentManager/serviceTopologies/services`  \n`"
+      "value": "Type: `Microsoft.DeploymentManager/serviceTopologies/services`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16678,7 +16678,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DeploymentManager/serviceTopologies/services/serviceUnits`  \n`"
+      "value": "Type: `Microsoft.DeploymentManager/serviceTopologies/services/serviceUnits`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16699,7 +16699,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DeploymentManager/steps`  \n`"
+      "value": "Type: `Microsoft.DeploymentManager/steps`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16720,7 +16720,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DesktopVirtualization/applicationGroups`  \n`"
+      "value": "Type: `Microsoft.DesktopVirtualization/applicationGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16741,7 +16741,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DesktopVirtualization/applicationGroups/applications`  \n`"
+      "value": "Type: `Microsoft.DesktopVirtualization/applicationGroups/applications`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16762,7 +16762,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DesktopVirtualization/applicationGroups/desktops`  \n`"
+      "value": "Type: `Microsoft.DesktopVirtualization/applicationGroups/desktops`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16783,7 +16783,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DesktopVirtualization/hostPools`  \n`"
+      "value": "Type: `Microsoft.DesktopVirtualization/hostPools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16804,7 +16804,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DesktopVirtualization/hostPools/msixPackages`  \n`"
+      "value": "Type: `Microsoft.DesktopVirtualization/hostPools/msixPackages`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16825,7 +16825,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DesktopVirtualization/hostPools/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.DesktopVirtualization/hostPools/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16846,7 +16846,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DesktopVirtualization/hostPools/sessionHosts`  \n`"
+      "value": "Type: `Microsoft.DesktopVirtualization/hostPools/sessionHosts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16867,7 +16867,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DesktopVirtualization/hostPools/sessionHosts/userSessions`  \n`"
+      "value": "Type: `Microsoft.DesktopVirtualization/hostPools/sessionHosts/userSessions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16888,7 +16888,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DesktopVirtualization/scalingPlans`  \n`"
+      "value": "Type: `Microsoft.DesktopVirtualization/scalingPlans`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16909,7 +16909,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DesktopVirtualization/scalingPlans/personalSchedules`  \n`"
+      "value": "Type: `Microsoft.DesktopVirtualization/scalingPlans/personalSchedules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16930,7 +16930,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DesktopVirtualization/scalingPlans/pooledSchedules`  \n`"
+      "value": "Type: `Microsoft.DesktopVirtualization/scalingPlans/pooledSchedules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16951,7 +16951,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DesktopVirtualization/workspaces`  \n`"
+      "value": "Type: `Microsoft.DesktopVirtualization/workspaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16972,7 +16972,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DesktopVirtualization/workspaces/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.DesktopVirtualization/workspaces/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -16993,7 +16993,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevCenter/devcenters`  \n`"
+      "value": "Type: `Microsoft.DevCenter/devcenters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17014,7 +17014,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevCenter/devcenters/attachednetworks`  \n`"
+      "value": "Type: `Microsoft.DevCenter/devcenters/attachednetworks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17035,7 +17035,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevCenter/devcenters/catalogs`  \n`"
+      "value": "Type: `Microsoft.DevCenter/devcenters/catalogs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17056,7 +17056,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevCenter/devcenters/catalogs/devboxdefinitions`  \n`"
+      "value": "Type: `Microsoft.DevCenter/devcenters/catalogs/devboxdefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17077,7 +17077,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevCenter/devcenters/catalogs/environmentDefinitions`  \n`"
+      "value": "Type: `Microsoft.DevCenter/devcenters/catalogs/environmentDefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17098,7 +17098,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevCenter/devcenters/catalogs/tasks`  \n`"
+      "value": "Type: `Microsoft.DevCenter/devcenters/catalogs/tasks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17119,7 +17119,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevCenter/devcenters/devboxdefinitions`  \n`"
+      "value": "Type: `Microsoft.DevCenter/devcenters/devboxdefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17140,7 +17140,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevCenter/devcenters/environmentTypes`  \n`"
+      "value": "Type: `Microsoft.DevCenter/devcenters/environmentTypes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17161,7 +17161,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevCenter/devcenters/galleries`  \n`"
+      "value": "Type: `Microsoft.DevCenter/devcenters/galleries`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17182,7 +17182,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevCenter/devcenters/galleries/images`  \n`"
+      "value": "Type: `Microsoft.DevCenter/devcenters/galleries/images`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17203,7 +17203,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevCenter/devcenters/galleries/images/versions`  \n`"
+      "value": "Type: `Microsoft.DevCenter/devcenters/galleries/images/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17224,7 +17224,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevCenter/networkConnections`  \n`"
+      "value": "Type: `Microsoft.DevCenter/networkConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17245,7 +17245,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevCenter/networkConnections/healthChecks`  \n`"
+      "value": "Type: `Microsoft.DevCenter/networkConnections/healthChecks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17266,7 +17266,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevCenter/projects`  \n`"
+      "value": "Type: `Microsoft.DevCenter/projects`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17287,7 +17287,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevCenter/projects/allowedEnvironmentTypes`  \n`"
+      "value": "Type: `Microsoft.DevCenter/projects/allowedEnvironmentTypes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17308,7 +17308,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevCenter/projects/attachednetworks`  \n`"
+      "value": "Type: `Microsoft.DevCenter/projects/attachednetworks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17329,7 +17329,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevCenter/projects/devboxdefinitions`  \n`"
+      "value": "Type: `Microsoft.DevCenter/projects/devboxdefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17350,7 +17350,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevCenter/projects/environmentTypes`  \n`"
+      "value": "Type: `Microsoft.DevCenter/projects/environmentTypes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17371,7 +17371,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevCenter/projects/pools`  \n`"
+      "value": "Type: `Microsoft.DevCenter/projects/pools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17392,7 +17392,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevCenter/projects/pools/schedules`  \n`"
+      "value": "Type: `Microsoft.DevCenter/projects/pools/schedules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17413,7 +17413,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevHub/workflows`  \n`"
+      "value": "Type: `Microsoft.DevHub/workflows`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17434,7 +17434,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevOps/pipelines`  \n`"
+      "value": "Type: `Microsoft.DevOps/pipelines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17455,7 +17455,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevSpaces/controllers`  \n`"
+      "value": "Type: `Microsoft.DevSpaces/controllers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17476,7 +17476,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevTestLab/labs`  \n`"
+      "value": "Type: `Microsoft.DevTestLab/labs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17497,7 +17497,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevTestLab/labs/artifactsources`  \n`"
+      "value": "Type: `Microsoft.DevTestLab/labs/artifactsources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17518,7 +17518,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevTestLab/labs/artifactsources/armtemplates`  \n`"
+      "value": "Type: `Microsoft.DevTestLab/labs/artifactsources/armtemplates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17539,7 +17539,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevTestLab/labs/artifactsources/artifacts`  \n`"
+      "value": "Type: `Microsoft.DevTestLab/labs/artifactsources/artifacts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17560,7 +17560,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevTestLab/labs/costinsights`  \n`"
+      "value": "Type: `Microsoft.DevTestLab/labs/costinsights`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17581,7 +17581,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevTestLab/labs/costs`  \n`"
+      "value": "Type: `Microsoft.DevTestLab/labs/costs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17602,7 +17602,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevTestLab/labs/customimages`  \n`"
+      "value": "Type: `Microsoft.DevTestLab/labs/customimages`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17623,7 +17623,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevTestLab/labs/formulas`  \n`"
+      "value": "Type: `Microsoft.DevTestLab/labs/formulas`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17644,7 +17644,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevTestLab/labs/notificationchannels`  \n`"
+      "value": "Type: `Microsoft.DevTestLab/labs/notificationchannels`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17665,7 +17665,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevTestLab/labs/policysets/policies`  \n`"
+      "value": "Type: `Microsoft.DevTestLab/labs/policysets/policies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17686,7 +17686,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevTestLab/labs/schedules`  \n`"
+      "value": "Type: `Microsoft.DevTestLab/labs/schedules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17707,7 +17707,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevTestLab/labs/servicerunners`  \n`"
+      "value": "Type: `Microsoft.DevTestLab/labs/servicerunners`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17728,7 +17728,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevTestLab/labs/users`  \n`"
+      "value": "Type: `Microsoft.DevTestLab/labs/users`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17749,7 +17749,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevTestLab/labs/users/disks`  \n`"
+      "value": "Type: `Microsoft.DevTestLab/labs/users/disks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17770,7 +17770,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevTestLab/labs/users/environments`  \n`"
+      "value": "Type: `Microsoft.DevTestLab/labs/users/environments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17791,7 +17791,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevTestLab/labs/users/secrets`  \n`"
+      "value": "Type: `Microsoft.DevTestLab/labs/users/secrets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17812,7 +17812,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevTestLab/labs/users/servicefabrics`  \n`"
+      "value": "Type: `Microsoft.DevTestLab/labs/users/servicefabrics`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17833,7 +17833,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevTestLab/labs/users/servicefabrics/schedules`  \n`"
+      "value": "Type: `Microsoft.DevTestLab/labs/users/servicefabrics/schedules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17854,7 +17854,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevTestLab/labs/virtualmachines`  \n`"
+      "value": "Type: `Microsoft.DevTestLab/labs/virtualmachines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17875,7 +17875,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevTestLab/labs/virtualmachines/schedules`  \n`"
+      "value": "Type: `Microsoft.DevTestLab/labs/virtualmachines/schedules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17896,7 +17896,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevTestLab/labs/virtualnetworks`  \n`"
+      "value": "Type: `Microsoft.DevTestLab/labs/virtualnetworks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17917,7 +17917,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DevTestLab/schedules`  \n`"
+      "value": "Type: `Microsoft.DevTestLab/schedules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17938,7 +17938,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DeviceRegistry/assetEndpointProfiles`  \n`"
+      "value": "Type: `Microsoft.DeviceRegistry/assetEndpointProfiles`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17959,7 +17959,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DeviceRegistry/assets`  \n`"
+      "value": "Type: `Microsoft.DeviceRegistry/assets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -17980,7 +17980,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DeviceUpdate/accounts`  \n`"
+      "value": "Type: `Microsoft.DeviceUpdate/accounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18001,7 +18001,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DeviceUpdate/accounts/instances`  \n`"
+      "value": "Type: `Microsoft.DeviceUpdate/accounts/instances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18022,7 +18022,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DeviceUpdate/accounts/privateEndpointConnectionProxies`  \n`"
+      "value": "Type: `Microsoft.DeviceUpdate/accounts/privateEndpointConnectionProxies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18043,7 +18043,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DeviceUpdate/accounts/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.DeviceUpdate/accounts/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18064,7 +18064,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DeviceUpdate/accounts/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.DeviceUpdate/accounts/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18085,7 +18085,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Devices/IotHubs`  \n`"
+      "value": "Type: `Microsoft.Devices/IotHubs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18106,7 +18106,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Devices/IotHubs/certificates`  \n`"
+      "value": "Type: `Microsoft.Devices/IotHubs/certificates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18127,7 +18127,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Devices/IotHubs/eventHubEndpoints/ConsumerGroups`  \n`"
+      "value": "Type: `Microsoft.Devices/IotHubs/eventHubEndpoints/ConsumerGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18148,7 +18148,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Devices/iotHubs/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Devices/iotHubs/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18169,7 +18169,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Devices/provisioningServices`  \n`"
+      "value": "Type: `Microsoft.Devices/provisioningServices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18190,7 +18190,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Devices/provisioningServices/certificates`  \n`"
+      "value": "Type: `Microsoft.Devices/provisioningServices/certificates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18211,7 +18211,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Devices/provisioningServices/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Devices/provisioningServices/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18232,7 +18232,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DigitalTwins/digitalTwinsInstances`  \n`"
+      "value": "Type: `Microsoft.DigitalTwins/digitalTwinsInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18253,7 +18253,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DigitalTwins/digitalTwinsInstances/endpoints`  \n`"
+      "value": "Type: `Microsoft.DigitalTwins/digitalTwinsInstances/endpoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18274,7 +18274,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DigitalTwins/digitalTwinsInstances/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.DigitalTwins/digitalTwinsInstances/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18295,7 +18295,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DigitalTwins/digitalTwinsInstances/timeSeriesDatabaseConnections`  \n`"
+      "value": "Type: `Microsoft.DigitalTwins/digitalTwinsInstances/timeSeriesDatabaseConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18316,7 +18316,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/cassandraClusters`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/cassandraClusters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18337,7 +18337,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/cassandraClusters/backups`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/cassandraClusters/backups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18358,7 +18358,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/cassandraClusters/dataCenters`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/cassandraClusters/dataCenters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18379,7 +18379,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18400,7 +18400,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/apis/databases`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/apis/databases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18421,7 +18421,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/apis/databases/collections`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/apis/databases/collections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18442,7 +18442,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/apis/databases/collections/settings`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/apis/databases/collections/settings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18463,7 +18463,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/apis/databases/containers`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/apis/databases/containers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18484,7 +18484,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/apis/databases/containers/settings`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/apis/databases/containers/settings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18505,7 +18505,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/apis/databases/graphs`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/apis/databases/graphs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18526,7 +18526,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/apis/databases/graphs/settings`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/apis/databases/graphs/settings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18547,7 +18547,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/apis/databases/settings`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/apis/databases/settings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18568,7 +18568,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/apis/keyspaces`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/apis/keyspaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18589,7 +18589,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/apis/keyspaces/settings`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/apis/keyspaces/settings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18610,7 +18610,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/apis/keyspaces/tables`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/apis/keyspaces/tables`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18631,7 +18631,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/apis/keyspaces/tables/settings`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/apis/keyspaces/tables/settings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18652,7 +18652,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/apis/tables`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/apis/tables`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18673,7 +18673,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/apis/tables/settings`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/apis/tables/settings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18694,7 +18694,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18715,7 +18715,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/tables`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/tables`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18736,7 +18736,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/tables/throughputSettings`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/tables/throughputSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18757,7 +18757,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/throughputSettings`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/throughputSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18778,7 +18778,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/views`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/views`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18799,7 +18799,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/views/throughputSettings`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/views/throughputSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18820,7 +18820,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/dataTransferJobs`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/dataTransferJobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18841,7 +18841,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/graphs`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/graphs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18862,7 +18862,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/gremlinDatabases`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/gremlinDatabases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18883,7 +18883,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/graphs`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/graphs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18904,7 +18904,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/graphs/throughputSettings`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/graphs/throughputSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18925,7 +18925,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/throughputSettings`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/throughputSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18946,7 +18946,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/mongodbDatabases`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/mongodbDatabases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18967,7 +18967,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -18988,7 +18988,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections/throughputSettings`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections/throughputSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19009,7 +19009,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/throughputSettings`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/throughputSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19030,7 +19030,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/mongodbRoleDefinitions`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/mongodbRoleDefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19051,7 +19051,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/mongodbUserDefinitions`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/mongodbUserDefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19072,7 +19072,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/notebookWorkspaces`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/notebookWorkspaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19093,7 +19093,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19114,7 +19114,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19135,7 +19135,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/services`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/services`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19156,7 +19156,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/sqlDatabases`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/sqlDatabases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19177,7 +19177,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/sqlDatabases/clientEncryptionKeys`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/sqlDatabases/clientEncryptionKeys`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19198,7 +19198,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19219,7 +19219,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/storedProcedures`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/storedProcedures`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19240,7 +19240,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/throughputSettings`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/throughputSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19261,7 +19261,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/triggers`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/triggers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19282,7 +19282,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/userDefinedFunctions`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/userDefinedFunctions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19303,7 +19303,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/sqlDatabases/throughputSettings`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/sqlDatabases/throughputSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19324,7 +19324,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19345,7 +19345,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19366,7 +19366,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/tables`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/tables`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19387,7 +19387,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/tables/throughputSettings`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/databaseAccounts/tables/throughputSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19408,7 +19408,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/locations`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/locations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19429,7 +19429,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/mongoClusters`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/mongoClusters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19450,7 +19450,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DocumentDB/mongoClusters/firewallRules`  \n`"
+      "value": "Type: `Microsoft.DocumentDB/mongoClusters/firewallRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19471,7 +19471,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DomainRegistration/domains`  \n`"
+      "value": "Type: `Microsoft.DomainRegistration/domains`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19492,7 +19492,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DomainRegistration/domains/domainOwnershipIdentifiers`  \n`"
+      "value": "Type: `Microsoft.DomainRegistration/domains/domainOwnershipIdentifiers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19513,7 +19513,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DomainRegistration/domains/operationresults`  \n`"
+      "value": "Type: `Microsoft.DomainRegistration/domains/operationresults`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19534,7 +19534,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.DomainRegistration/topLevelDomains`  \n`"
+      "value": "Type: `Microsoft.DomainRegistration/topLevelDomains`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19555,7 +19555,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Dynamics365FraudProtection/instances`  \n`"
+      "value": "Type: `Microsoft.Dynamics365FraudProtection/instances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19576,7 +19576,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Easm/workspaces`  \n`"
+      "value": "Type: `Microsoft.Easm/workspaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19597,7 +19597,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Easm/workspaces/labels`  \n`"
+      "value": "Type: `Microsoft.Easm/workspaces/labels`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19618,7 +19618,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Easm/workspaces/tasks`  \n`"
+      "value": "Type: `Microsoft.Easm/workspaces/tasks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19639,7 +19639,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EdgeMarketplace/offers`  \n`"
+      "value": "Type: `Microsoft.EdgeMarketplace/offers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19660,7 +19660,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EdgeMarketplace/publishers`  \n`"
+      "value": "Type: `Microsoft.EdgeMarketplace/publishers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19681,7 +19681,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EdgeOrder/addresses`  \n`"
+      "value": "Type: `Microsoft.EdgeOrder/addresses`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19702,7 +19702,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EdgeOrder/locations/orders`  \n`"
+      "value": "Type: `Microsoft.EdgeOrder/locations/orders`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19723,7 +19723,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EdgeOrder/orderItems`  \n`"
+      "value": "Type: `Microsoft.EdgeOrder/orderItems`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19744,7 +19744,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Education/grants`  \n`"
+      "value": "Type: `Microsoft.Education/grants`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19765,7 +19765,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Education/labs`  \n`"
+      "value": "Type: `Microsoft.Education/labs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19786,7 +19786,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Education/labs/joinRequests`  \n`"
+      "value": "Type: `Microsoft.Education/labs/joinRequests`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19807,7 +19807,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Education/labs/students`  \n`"
+      "value": "Type: `Microsoft.Education/labs/students`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19828,7 +19828,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Education/studentLabs`  \n`"
+      "value": "Type: `Microsoft.Education/studentLabs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19849,7 +19849,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Elastic/monitors`  \n`"
+      "value": "Type: `Microsoft.Elastic/monitors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19870,7 +19870,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Elastic/monitors/tagRules`  \n`"
+      "value": "Type: `Microsoft.Elastic/monitors/tagRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19891,7 +19891,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ElasticSan/elasticSans`  \n`"
+      "value": "Type: `Microsoft.ElasticSan/elasticSans`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19912,7 +19912,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ElasticSan/elasticSans/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.ElasticSan/elasticSans/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19933,7 +19933,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ElasticSan/elasticSans/volumegroups`  \n`"
+      "value": "Type: `Microsoft.ElasticSan/elasticSans/volumegroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19954,7 +19954,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ElasticSan/elasticSans/volumegroups/snapshots`  \n`"
+      "value": "Type: `Microsoft.ElasticSan/elasticSans/volumegroups/snapshots`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19975,7 +19975,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ElasticSan/elasticSans/volumegroups/volumes`  \n`"
+      "value": "Type: `Microsoft.ElasticSan/elasticSans/volumegroups/volumes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -19996,7 +19996,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EngagementFabric/Accounts`  \n`"
+      "value": "Type: `Microsoft.EngagementFabric/Accounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20017,7 +20017,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EngagementFabric/Accounts/Channels`  \n`"
+      "value": "Type: `Microsoft.EngagementFabric/Accounts/Channels`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20038,7 +20038,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EnterpriseKnowledgeGraph/services`  \n`"
+      "value": "Type: `Microsoft.EnterpriseKnowledgeGraph/services`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20059,7 +20059,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/domains`  \n`"
+      "value": "Type: `Microsoft.EventGrid/domains`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20080,7 +20080,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/domains/eventSubscriptions`  \n`"
+      "value": "Type: `Microsoft.EventGrid/domains/eventSubscriptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20101,7 +20101,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/domains/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.EventGrid/domains/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20122,7 +20122,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/domains/topics`  \n`"
+      "value": "Type: `Microsoft.EventGrid/domains/topics`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20143,7 +20143,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/domains/topics/eventSubscriptions`  \n`"
+      "value": "Type: `Microsoft.EventGrid/domains/topics/eventSubscriptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20164,7 +20164,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/eventSubscriptions`  \n`"
+      "value": "Type: `Microsoft.EventGrid/eventSubscriptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20185,7 +20185,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/extensionTopics`  \n`"
+      "value": "Type: `Microsoft.EventGrid/extensionTopics`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20206,7 +20206,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/namespaces`  \n`"
+      "value": "Type: `Microsoft.EventGrid/namespaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20227,7 +20227,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/namespaces/caCertificates`  \n`"
+      "value": "Type: `Microsoft.EventGrid/namespaces/caCertificates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20248,7 +20248,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/namespaces/clientGroups`  \n`"
+      "value": "Type: `Microsoft.EventGrid/namespaces/clientGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20269,7 +20269,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/namespaces/clients`  \n`"
+      "value": "Type: `Microsoft.EventGrid/namespaces/clients`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20290,7 +20290,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/namespaces/permissionBindings`  \n`"
+      "value": "Type: `Microsoft.EventGrid/namespaces/permissionBindings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20311,7 +20311,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/namespaces/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.EventGrid/namespaces/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20332,7 +20332,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/namespaces/topicSpaces`  \n`"
+      "value": "Type: `Microsoft.EventGrid/namespaces/topicSpaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20353,7 +20353,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/namespaces/topics`  \n`"
+      "value": "Type: `Microsoft.EventGrid/namespaces/topics`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20374,7 +20374,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/namespaces/topics/eventSubscriptions`  \n`"
+      "value": "Type: `Microsoft.EventGrid/namespaces/topics/eventSubscriptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20395,7 +20395,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/partnerConfigurations`  \n`"
+      "value": "Type: `Microsoft.EventGrid/partnerConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20416,7 +20416,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/partnerDestinations`  \n`"
+      "value": "Type: `Microsoft.EventGrid/partnerDestinations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20437,7 +20437,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/partnerNamespaces`  \n`"
+      "value": "Type: `Microsoft.EventGrid/partnerNamespaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20458,7 +20458,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/partnerNamespaces/channels`  \n`"
+      "value": "Type: `Microsoft.EventGrid/partnerNamespaces/channels`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20479,7 +20479,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/partnerNamespaces/eventChannels`  \n`"
+      "value": "Type: `Microsoft.EventGrid/partnerNamespaces/eventChannels`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20500,7 +20500,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/partnerNamespaces/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.EventGrid/partnerNamespaces/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20521,7 +20521,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/partnerRegistrations`  \n`"
+      "value": "Type: `Microsoft.EventGrid/partnerRegistrations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20542,7 +20542,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/partnerTopics`  \n`"
+      "value": "Type: `Microsoft.EventGrid/partnerTopics`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20563,7 +20563,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/partnerTopics/eventSubscriptions`  \n`"
+      "value": "Type: `Microsoft.EventGrid/partnerTopics/eventSubscriptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20584,7 +20584,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/systemTopics`  \n`"
+      "value": "Type: `Microsoft.EventGrid/systemTopics`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20605,7 +20605,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/systemTopics/eventSubscriptions`  \n`"
+      "value": "Type: `Microsoft.EventGrid/systemTopics/eventSubscriptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20626,7 +20626,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/topicTypes`  \n`"
+      "value": "Type: `Microsoft.EventGrid/topicTypes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20647,7 +20647,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/topics`  \n`"
+      "value": "Type: `Microsoft.EventGrid/topics`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20668,7 +20668,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/topics/eventSubscriptions`  \n`"
+      "value": "Type: `Microsoft.EventGrid/topics/eventSubscriptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20689,7 +20689,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/topics/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.EventGrid/topics/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20710,7 +20710,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventGrid/verifiedPartners`  \n`"
+      "value": "Type: `Microsoft.EventGrid/verifiedPartners`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20731,7 +20731,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventHub/clusters`  \n`"
+      "value": "Type: `Microsoft.EventHub/clusters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20752,7 +20752,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventHub/namespaces`  \n`"
+      "value": "Type: `Microsoft.EventHub/namespaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20773,7 +20773,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventHub/namespaces/applicationGroups`  \n`"
+      "value": "Type: `Microsoft.EventHub/namespaces/applicationGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20794,7 +20794,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventHub/namespaces/authorizationRules`  \n`"
+      "value": "Type: `Microsoft.EventHub/namespaces/authorizationRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20815,7 +20815,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventHub/namespaces/disasterRecoveryConfigs`  \n`"
+      "value": "Type: `Microsoft.EventHub/namespaces/disasterRecoveryConfigs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20836,7 +20836,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventHub/namespaces/disasterRecoveryConfigs/authorizationRules`  \n`"
+      "value": "Type: `Microsoft.EventHub/namespaces/disasterRecoveryConfigs/authorizationRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20857,7 +20857,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventHub/namespaces/eventhubs`  \n`"
+      "value": "Type: `Microsoft.EventHub/namespaces/eventhubs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20878,7 +20878,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventHub/namespaces/eventhubs/authorizationRules`  \n`"
+      "value": "Type: `Microsoft.EventHub/namespaces/eventhubs/authorizationRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20899,7 +20899,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventHub/namespaces/eventhubs/consumergroups`  \n`"
+      "value": "Type: `Microsoft.EventHub/namespaces/eventhubs/consumergroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20920,7 +20920,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventHub/namespaces/ipfilterrules`  \n`"
+      "value": "Type: `Microsoft.EventHub/namespaces/ipfilterrules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20941,7 +20941,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventHub/namespaces/networkRuleSets`  \n`"
+      "value": "Type: `Microsoft.EventHub/namespaces/networkRuleSets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20962,7 +20962,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventHub/namespaces/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.EventHub/namespaces/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -20983,7 +20983,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventHub/namespaces/schemagroups`  \n`"
+      "value": "Type: `Microsoft.EventHub/namespaces/schemagroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21004,7 +21004,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.EventHub/namespaces/virtualnetworkrules`  \n`"
+      "value": "Type: `Microsoft.EventHub/namespaces/virtualnetworkrules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21025,7 +21025,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ExtendedLocation/customLocations`  \n`"
+      "value": "Type: `Microsoft.ExtendedLocation/customLocations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21046,7 +21046,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ExtendedLocation/customLocations/resourceSyncRules`  \n`"
+      "value": "Type: `Microsoft.ExtendedLocation/customLocations/resourceSyncRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21067,7 +21067,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations`  \n`"
+      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21088,7 +21088,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/applicationOperationResults`  \n`"
+      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/applicationOperationResults`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21109,7 +21109,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/computeOperationResults`  \n`"
+      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/computeOperationResults`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21130,7 +21130,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/edgeGatewayPools`  \n`"
+      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/edgeGatewayPools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21151,7 +21151,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/edgeGateways`  \n`"
+      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/edgeGateways`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21172,7 +21172,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/fileShares`  \n`"
+      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/fileShares`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21193,7 +21193,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/infraRoleInstances`  \n`"
+      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/infraRoleInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21214,7 +21214,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/infraRoles`  \n`"
+      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/infraRoles`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21235,7 +21235,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/ipPools`  \n`"
+      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/ipPools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21256,7 +21256,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/logicalNetworks`  \n`"
+      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/logicalNetworks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21277,7 +21277,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/logicalNetworks/logicalSubnets`  \n`"
+      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/logicalNetworks/logicalSubnets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21298,7 +21298,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/macAddressPools`  \n`"
+      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/macAddressPools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21319,7 +21319,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/nasClusters`  \n`"
+      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/nasClusters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21340,7 +21340,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/networkOperationResults`  \n`"
+      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/networkOperationResults`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21361,7 +21361,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/scaleUnitNodes`  \n`"
+      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/scaleUnitNodes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21382,7 +21382,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/scaleUnits`  \n`"
+      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/scaleUnits`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21403,7 +21403,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/scaleUnits/storageSubSystems`  \n`"
+      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/scaleUnits/storageSubSystems`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21424,7 +21424,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/scaleUnits/storageSubSystems/drives`  \n`"
+      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/scaleUnits/storageSubSystems/drives`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21445,7 +21445,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/scaleUnits/storageSubSystems/volumes`  \n`"
+      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/scaleUnits/storageSubSystems/volumes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21466,7 +21466,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/slbMuxInstances`  \n`"
+      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/slbMuxInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21487,7 +21487,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/storageOperationResults`  \n`"
+      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/storageOperationResults`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21508,7 +21508,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/storageSubSystems`  \n`"
+      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/storageSubSystems`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21529,7 +21529,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/storageSubSystems/storagePools`  \n`"
+      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/storageSubSystems/storagePools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21550,7 +21550,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/storageSubSystems/storagePools/volumes`  \n`"
+      "value": "Type: `Microsoft.Fabric.Admin/fabricLocations/storageSubSystems/storagePools/volumes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21571,7 +21571,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Features/featureProviders/subscriptionFeatureRegistrations`  \n`"
+      "value": "Type: `Microsoft.Features/featureProviders/subscriptionFeatureRegistrations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21592,7 +21592,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.FluidRelay/fluidRelayServers`  \n`"
+      "value": "Type: `Microsoft.FluidRelay/fluidRelayServers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21613,7 +21613,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.FluidRelay/fluidRelayServers/fluidRelayContainers`  \n`"
+      "value": "Type: `Microsoft.FluidRelay/fluidRelayServers/fluidRelayContainers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21634,7 +21634,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.GraphServices/accounts`  \n`"
+      "value": "Type: `Microsoft.GraphServices/accounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21655,7 +21655,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.GuestConfiguration/guestConfigurationAssignments`  \n`"
+      "value": "Type: `Microsoft.GuestConfiguration/guestConfigurationAssignments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21676,7 +21676,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HDInsight/clusterpools`  \n`"
+      "value": "Type: `Microsoft.HDInsight/clusterpools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21697,7 +21697,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HDInsight/clusterpools/clusters`  \n`"
+      "value": "Type: `Microsoft.HDInsight/clusterpools/clusters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21718,7 +21718,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HDInsight/clusters`  \n`"
+      "value": "Type: `Microsoft.HDInsight/clusters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21739,7 +21739,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HDInsight/clusters/applications`  \n`"
+      "value": "Type: `Microsoft.HDInsight/clusters/applications`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21760,7 +21760,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HDInsight/clusters/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.HDInsight/clusters/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21781,7 +21781,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HDInsight/clusters/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.HDInsight/clusters/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21802,7 +21802,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HanaOnAzure/hanaInstances`  \n`"
+      "value": "Type: `Microsoft.HanaOnAzure/hanaInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21823,7 +21823,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HanaOnAzure/sapMonitors`  \n`"
+      "value": "Type: `Microsoft.HanaOnAzure/sapMonitors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21844,7 +21844,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HanaOnAzure/sapMonitors/providerInstances`  \n`"
+      "value": "Type: `Microsoft.HanaOnAzure/sapMonitors/providerInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21865,7 +21865,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HardwareSecurityModules/cloudHsmClusters`  \n`"
+      "value": "Type: `Microsoft.HardwareSecurityModules/cloudHsmClusters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21886,7 +21886,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HardwareSecurityModules/cloudHsmClusters/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.HardwareSecurityModules/cloudHsmClusters/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21907,7 +21907,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HardwareSecurityModules/dedicatedHSMs`  \n`"
+      "value": "Type: `Microsoft.HardwareSecurityModules/dedicatedHSMs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21928,7 +21928,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HealthBot/healthBots`  \n`"
+      "value": "Type: `Microsoft.HealthBot/healthBots`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21949,7 +21949,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HealthcareApis/services`  \n`"
+      "value": "Type: `Microsoft.HealthcareApis/services`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21970,7 +21970,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HealthcareApis/services/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.HealthcareApis/services/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21991,7 +21991,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HealthcareApis/services/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.HealthcareApis/services/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22012,7 +22012,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HealthcareApis/workspaces`  \n`"
+      "value": "Type: `Microsoft.HealthcareApis/workspaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22033,7 +22033,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HealthcareApis/workspaces/analyticsconnectors`  \n`"
+      "value": "Type: `Microsoft.HealthcareApis/workspaces/analyticsconnectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22054,7 +22054,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HealthcareApis/workspaces/dicomservices`  \n`"
+      "value": "Type: `Microsoft.HealthcareApis/workspaces/dicomservices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22075,7 +22075,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HealthcareApis/workspaces/fhirservices`  \n`"
+      "value": "Type: `Microsoft.HealthcareApis/workspaces/fhirservices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22096,7 +22096,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HealthcareApis/workspaces/iotconnectors`  \n`"
+      "value": "Type: `Microsoft.HealthcareApis/workspaces/iotconnectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22117,7 +22117,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HealthcareApis/workspaces/iotconnectors/fhirdestinations`  \n`"
+      "value": "Type: `Microsoft.HealthcareApis/workspaces/iotconnectors/fhirdestinations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22138,7 +22138,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HealthcareApis/workspaces/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.HealthcareApis/workspaces/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22159,7 +22159,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HealthcareApis/workspaces/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.HealthcareApis/workspaces/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22180,7 +22180,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Help/diagnostics`  \n`"
+      "value": "Type: `Microsoft.Help/diagnostics`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22201,7 +22201,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Help/solutions`  \n`"
+      "value": "Type: `Microsoft.Help/solutions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22222,7 +22222,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Help/troubleshooters`  \n`"
+      "value": "Type: `Microsoft.Help/troubleshooters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22243,7 +22243,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridCloud/cloudConnections`  \n`"
+      "value": "Type: `Microsoft.HybridCloud/cloudConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22264,7 +22264,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridCloud/cloudConnectors`  \n`"
+      "value": "Type: `Microsoft.HybridCloud/cloudConnectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22285,7 +22285,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridCompute/licenses`  \n`"
+      "value": "Type: `Microsoft.HybridCompute/licenses`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22306,7 +22306,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridCompute/locations/publishers/extensionTypes/versions`  \n`"
+      "value": "Type: `Microsoft.HybridCompute/locations/publishers/extensionTypes/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22327,7 +22327,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridCompute/machines`  \n`"
+      "value": "Type: `Microsoft.HybridCompute/machines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22348,7 +22348,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridCompute/machines/extensions`  \n`"
+      "value": "Type: `Microsoft.HybridCompute/machines/extensions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22369,7 +22369,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridCompute/machines/hybridIdentityMetadata`  \n`"
+      "value": "Type: `Microsoft.HybridCompute/machines/hybridIdentityMetadata`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22390,7 +22390,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridCompute/machines/licenseProfiles`  \n`"
+      "value": "Type: `Microsoft.HybridCompute/machines/licenseProfiles`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22411,7 +22411,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridCompute/privateLinkScopes`  \n`"
+      "value": "Type: `Microsoft.HybridCompute/privateLinkScopes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22432,7 +22432,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridCompute/privateLinkScopes/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.HybridCompute/privateLinkScopes/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22453,7 +22453,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridCompute/privateLinkScopes/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.HybridCompute/privateLinkScopes/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22474,7 +22474,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridCompute/privateLinkScopes/scopedResources`  \n`"
+      "value": "Type: `Microsoft.HybridCompute/privateLinkScopes/scopedResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22495,7 +22495,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridConnectivity/endpoints`  \n`"
+      "value": "Type: `Microsoft.HybridConnectivity/endpoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22516,7 +22516,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridConnectivity/endpoints/serviceConfigurations`  \n`"
+      "value": "Type: `Microsoft.HybridConnectivity/endpoints/serviceConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22537,7 +22537,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridContainerService/kubernetesVersions`  \n`"
+      "value": "Type: `Microsoft.HybridContainerService/kubernetesVersions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22558,7 +22558,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridContainerService/provisionedClusterInstances`  \n`"
+      "value": "Type: `Microsoft.HybridContainerService/provisionedClusterInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22579,7 +22579,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridContainerService/provisionedClusterInstances/agentPools`  \n`"
+      "value": "Type: `Microsoft.HybridContainerService/provisionedClusterInstances/agentPools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22600,7 +22600,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridContainerService/provisionedClusterInstances/hybridIdentityMetadata`  \n`"
+      "value": "Type: `Microsoft.HybridContainerService/provisionedClusterInstances/hybridIdentityMetadata`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22621,7 +22621,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridContainerService/provisionedClusterInstances/upgradeProfiles`  \n`"
+      "value": "Type: `Microsoft.HybridContainerService/provisionedClusterInstances/upgradeProfiles`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22642,7 +22642,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridContainerService/provisionedClusters`  \n`"
+      "value": "Type: `Microsoft.HybridContainerService/provisionedClusters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22663,7 +22663,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridContainerService/provisionedClusters/agentPools`  \n`"
+      "value": "Type: `Microsoft.HybridContainerService/provisionedClusters/agentPools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22684,7 +22684,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridContainerService/provisionedClusters/hybridIdentityMetadata`  \n`"
+      "value": "Type: `Microsoft.HybridContainerService/provisionedClusters/hybridIdentityMetadata`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22705,7 +22705,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridContainerService/provisionedClusters/upgradeProfiles`  \n`"
+      "value": "Type: `Microsoft.HybridContainerService/provisionedClusters/upgradeProfiles`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22726,7 +22726,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridContainerService/skus`  \n`"
+      "value": "Type: `Microsoft.HybridContainerService/skus`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22747,7 +22747,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridContainerService/storageSpaces`  \n`"
+      "value": "Type: `Microsoft.HybridContainerService/storageSpaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22768,7 +22768,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridContainerService/virtualNetworks`  \n`"
+      "value": "Type: `Microsoft.HybridContainerService/virtualNetworks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22789,7 +22789,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridData/dataManagers`  \n`"
+      "value": "Type: `Microsoft.HybridData/dataManagers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22810,7 +22810,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridData/dataManagers/dataServices/jobDefinitions`  \n`"
+      "value": "Type: `Microsoft.HybridData/dataManagers/dataServices/jobDefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22831,7 +22831,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridData/dataManagers/dataStores`  \n`"
+      "value": "Type: `Microsoft.HybridData/dataManagers/dataStores`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22852,7 +22852,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridNetwork/configurationGroupValues`  \n`"
+      "value": "Type: `Microsoft.HybridNetwork/configurationGroupValues`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22873,7 +22873,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridNetwork/devices`  \n`"
+      "value": "Type: `Microsoft.HybridNetwork/devices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22894,7 +22894,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridNetwork/locations/vendors/networkFunctions`  \n`"
+      "value": "Type: `Microsoft.HybridNetwork/locations/vendors/networkFunctions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22915,7 +22915,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridNetwork/locations/vendors/networkFunctions/roleInstances`  \n`"
+      "value": "Type: `Microsoft.HybridNetwork/locations/vendors/networkFunctions/roleInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22936,7 +22936,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridNetwork/networkFunctions`  \n`"
+      "value": "Type: `Microsoft.HybridNetwork/networkFunctions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22957,7 +22957,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridNetwork/networkFunctions/components`  \n`"
+      "value": "Type: `Microsoft.HybridNetwork/networkFunctions/components`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22978,7 +22978,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridNetwork/publishers`  \n`"
+      "value": "Type: `Microsoft.HybridNetwork/publishers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22999,7 +22999,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridNetwork/publishers/artifactStores`  \n`"
+      "value": "Type: `Microsoft.HybridNetwork/publishers/artifactStores`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23020,7 +23020,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridNetwork/publishers/artifactStores/artifactManifests`  \n`"
+      "value": "Type: `Microsoft.HybridNetwork/publishers/artifactStores/artifactManifests`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23041,7 +23041,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridNetwork/publishers/configurationGroupSchemas`  \n`"
+      "value": "Type: `Microsoft.HybridNetwork/publishers/configurationGroupSchemas`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23062,7 +23062,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridNetwork/publishers/networkFunctionDefinitionGroups`  \n`"
+      "value": "Type: `Microsoft.HybridNetwork/publishers/networkFunctionDefinitionGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23083,7 +23083,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridNetwork/publishers/networkFunctionDefinitionGroups/networkFunctionDefinitionVersions`  \n`"
+      "value": "Type: `Microsoft.HybridNetwork/publishers/networkFunctionDefinitionGroups/networkFunctionDefinitionVersions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23104,7 +23104,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridNetwork/publishers/networkServiceDesignGroups`  \n`"
+      "value": "Type: `Microsoft.HybridNetwork/publishers/networkServiceDesignGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23125,7 +23125,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridNetwork/publishers/networkServiceDesignGroups/networkServiceDesignVersions`  \n`"
+      "value": "Type: `Microsoft.HybridNetwork/publishers/networkServiceDesignGroups/networkServiceDesignVersions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23146,7 +23146,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridNetwork/siteNetworkServices`  \n`"
+      "value": "Type: `Microsoft.HybridNetwork/siteNetworkServices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23167,7 +23167,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridNetwork/sites`  \n`"
+      "value": "Type: `Microsoft.HybridNetwork/sites`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23188,7 +23188,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridNetwork/vendors`  \n`"
+      "value": "Type: `Microsoft.HybridNetwork/vendors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23209,7 +23209,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridNetwork/vendors/vendorSkus`  \n`"
+      "value": "Type: `Microsoft.HybridNetwork/vendors/vendorSkus`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23230,7 +23230,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.HybridNetwork/vendors/vendorSkus/previewSubscriptions`  \n`"
+      "value": "Type: `Microsoft.HybridNetwork/vendors/vendorSkus/previewSubscriptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23251,7 +23251,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ImportExport/jobs`  \n`"
+      "value": "Type: `Microsoft.ImportExport/jobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23272,7 +23272,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.InfrastructureInsights.Admin/regionHealths`  \n`"
+      "value": "Type: `Microsoft.InfrastructureInsights.Admin/regionHealths`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23293,7 +23293,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.InfrastructureInsights.Admin/regionHealths/alerts`  \n`"
+      "value": "Type: `Microsoft.InfrastructureInsights.Admin/regionHealths/alerts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23314,7 +23314,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.InfrastructureInsights.Admin/regionHealths/serviceHealths`  \n`"
+      "value": "Type: `Microsoft.InfrastructureInsights.Admin/regionHealths/serviceHealths`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23335,7 +23335,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.InfrastructureInsights.Admin/regionHealths/serviceHealths/resourceHealths`  \n`"
+      "value": "Type: `Microsoft.InfrastructureInsights.Admin/regionHealths/serviceHealths/resourceHealths`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23356,7 +23356,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Insights/actionGroups`  \n`"
+      "value": "Type: `Microsoft.Insights/actionGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23377,7 +23377,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Insights/activityLogAlerts`  \n`"
+      "value": "Type: `Microsoft.Insights/activityLogAlerts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23398,7 +23398,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Insights/alertrules`  \n`"
+      "value": "Type: `Microsoft.Insights/alertrules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23419,7 +23419,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Insights/autoscalesettings`  \n`"
+      "value": "Type: `Microsoft.Insights/autoscalesettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23440,7 +23440,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Insights/components`  \n`"
+      "value": "Type: `Microsoft.Insights/components`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23461,7 +23461,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Insights/components/ProactiveDetectionConfigs`  \n`"
+      "value": "Type: `Microsoft.Insights/components/ProactiveDetectionConfigs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23482,7 +23482,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Insights/components/exportconfiguration`  \n`"
+      "value": "Type: `Microsoft.Insights/components/exportconfiguration`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23503,7 +23503,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Insights/components/favorites`  \n`"
+      "value": "Type: `Microsoft.Insights/components/favorites`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23524,7 +23524,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Insights/dataCollectionEndpoints`  \n`"
+      "value": "Type: `Microsoft.Insights/dataCollectionEndpoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23545,7 +23545,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Insights/dataCollectionRuleAssociations`  \n`"
+      "value": "Type: `Microsoft.Insights/dataCollectionRuleAssociations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23566,7 +23566,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Insights/dataCollectionRules`  \n`"
+      "value": "Type: `Microsoft.Insights/dataCollectionRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23587,7 +23587,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Insights/diagnosticSettings`  \n`"
+      "value": "Type: `Microsoft.Insights/diagnosticSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23608,7 +23608,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Insights/diagnosticSettingsCategories`  \n`"
+      "value": "Type: `Microsoft.Insights/diagnosticSettingsCategories`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23629,7 +23629,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Insights/logprofiles`  \n`"
+      "value": "Type: `Microsoft.Insights/logprofiles`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23650,7 +23650,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Insights/metricAlerts`  \n`"
+      "value": "Type: `Microsoft.Insights/metricAlerts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23671,7 +23671,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Insights/myWorkbooks`  \n`"
+      "value": "Type: `Microsoft.Insights/myWorkbooks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23692,7 +23692,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Insights/privateLinkScopes/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Insights/privateLinkScopes/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23713,7 +23713,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Insights/privateLinkScopes/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.Insights/privateLinkScopes/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23734,7 +23734,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Insights/privateLinkScopes/scopedResources`  \n`"
+      "value": "Type: `Microsoft.Insights/privateLinkScopes/scopedResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23755,7 +23755,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Insights/scheduledQueryRules`  \n`"
+      "value": "Type: `Microsoft.Insights/scheduledQueryRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23776,7 +23776,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Insights/vmInsightsOnboardingStatuses`  \n`"
+      "value": "Type: `Microsoft.Insights/vmInsightsOnboardingStatuses`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23797,7 +23797,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Insights/webtests`  \n`"
+      "value": "Type: `Microsoft.Insights/webtests`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23818,7 +23818,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Insights/workbooks`  \n`"
+      "value": "Type: `Microsoft.Insights/workbooks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23839,7 +23839,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Insights/workbooks/revisions`  \n`"
+      "value": "Type: `Microsoft.Insights/workbooks/revisions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23860,7 +23860,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Insights/workbooktemplates`  \n`"
+      "value": "Type: `Microsoft.Insights/workbooktemplates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23881,7 +23881,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.IntegrationSpaces/spaces`  \n`"
+      "value": "Type: `Microsoft.IntegrationSpaces/spaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23902,7 +23902,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.IntegrationSpaces/spaces/applications`  \n`"
+      "value": "Type: `Microsoft.IntegrationSpaces/spaces/applications`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23923,7 +23923,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.IntegrationSpaces/spaces/applications/businessProcesses`  \n`"
+      "value": "Type: `Microsoft.IntegrationSpaces/spaces/applications/businessProcesses`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23944,7 +23944,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.IntegrationSpaces/spaces/applications/businessProcesses/versions`  \n`"
+      "value": "Type: `Microsoft.IntegrationSpaces/spaces/applications/businessProcesses/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23965,7 +23965,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.IntegrationSpaces/spaces/applications/resources`  \n`"
+      "value": "Type: `Microsoft.IntegrationSpaces/spaces/applications/resources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23986,7 +23986,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.IntegrationSpaces/spaces/infrastructureResources`  \n`"
+      "value": "Type: `Microsoft.IntegrationSpaces/spaces/infrastructureResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24007,7 +24007,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Intune/locations`  \n`"
+      "value": "Type: `Microsoft.Intune/locations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24028,7 +24028,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Intune/locations/androidPolicies`  \n`"
+      "value": "Type: `Microsoft.Intune/locations/androidPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24049,7 +24049,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Intune/locations/androidPolicies/apps`  \n`"
+      "value": "Type: `Microsoft.Intune/locations/androidPolicies/apps`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24070,7 +24070,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Intune/locations/androidPolicies/groups`  \n`"
+      "value": "Type: `Microsoft.Intune/locations/androidPolicies/groups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24091,7 +24091,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Intune/locations/flaggedUsers`  \n`"
+      "value": "Type: `Microsoft.Intune/locations/flaggedUsers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24112,7 +24112,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Intune/locations/iosPolicies`  \n`"
+      "value": "Type: `Microsoft.Intune/locations/iosPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24133,7 +24133,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Intune/locations/iosPolicies/apps`  \n`"
+      "value": "Type: `Microsoft.Intune/locations/iosPolicies/apps`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24154,7 +24154,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Intune/locations/iosPolicies/groups`  \n`"
+      "value": "Type: `Microsoft.Intune/locations/iosPolicies/groups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24175,7 +24175,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Intune/locations/statuses`  \n`"
+      "value": "Type: `Microsoft.Intune/locations/statuses`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24196,7 +24196,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Intune/locations/users/devices`  \n`"
+      "value": "Type: `Microsoft.Intune/locations/users/devices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24217,7 +24217,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.IoTCentral/iotApps`  \n`"
+      "value": "Type: `Microsoft.IoTCentral/iotApps`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24238,7 +24238,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.IoTCentral/iotApps/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.IoTCentral/iotApps/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24259,7 +24259,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.IoTCentral/iotApps/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.IoTCentral/iotApps/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24280,7 +24280,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.IoTFirmwareDefense/workspaces`  \n`"
+      "value": "Type: `Microsoft.IoTFirmwareDefense/workspaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24301,7 +24301,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.IoTFirmwareDefense/workspaces/firmwares`  \n`"
+      "value": "Type: `Microsoft.IoTFirmwareDefense/workspaces/firmwares`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24322,7 +24322,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.IoTSecurity/defenderSettings`  \n`"
+      "value": "Type: `Microsoft.IoTSecurity/defenderSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24343,7 +24343,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.IoTSecurity/locations`  \n`"
+      "value": "Type: `Microsoft.IoTSecurity/locations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24364,7 +24364,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.IoTSecurity/locations/deviceGroups`  \n`"
+      "value": "Type: `Microsoft.IoTSecurity/locations/deviceGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24385,7 +24385,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.IoTSecurity/locations/deviceGroups/devices`  \n`"
+      "value": "Type: `Microsoft.IoTSecurity/locations/deviceGroups/devices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24406,7 +24406,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.IoTSecurity/onPremiseSensors`  \n`"
+      "value": "Type: `Microsoft.IoTSecurity/onPremiseSensors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24427,7 +24427,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.IoTSecurity/sensors`  \n`"
+      "value": "Type: `Microsoft.IoTSecurity/sensors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24448,7 +24448,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.IoTSecurity/sites`  \n`"
+      "value": "Type: `Microsoft.IoTSecurity/sites`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24469,7 +24469,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.KeyVault/managedHSMs`  \n`"
+      "value": "Type: `Microsoft.KeyVault/managedHSMs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24490,7 +24490,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.KeyVault/managedHSMs/keys`  \n`"
+      "value": "Type: `Microsoft.KeyVault/managedHSMs/keys`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24511,7 +24511,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.KeyVault/managedHSMs/keys/versions`  \n`"
+      "value": "Type: `Microsoft.KeyVault/managedHSMs/keys/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24532,7 +24532,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.KeyVault/managedHSMs/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.KeyVault/managedHSMs/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24553,7 +24553,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.KeyVault/vaults`  \n`"
+      "value": "Type: `Microsoft.KeyVault/vaults`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24574,7 +24574,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.KeyVault/vaults/accessPolicies`  \n`"
+      "value": "Type: `Microsoft.KeyVault/vaults/accessPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24595,7 +24595,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.KeyVault/vaults/keys`  \n`"
+      "value": "Type: `Microsoft.KeyVault/vaults/keys`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24616,7 +24616,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.KeyVault/vaults/keys/versions`  \n`"
+      "value": "Type: `Microsoft.KeyVault/vaults/keys/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24637,7 +24637,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.KeyVault/vaults/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.KeyVault/vaults/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24658,7 +24658,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.KeyVault/vaults/secrets`  \n`"
+      "value": "Type: `Microsoft.KeyVault/vaults/secrets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24679,7 +24679,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Kubernetes/connectedClusters`  \n`"
+      "value": "Type: `Microsoft.Kubernetes/connectedClusters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24700,7 +24700,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.KubernetesConfiguration/extensionTypes`  \n`"
+      "value": "Type: `Microsoft.KubernetesConfiguration/extensionTypes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24721,7 +24721,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.KubernetesConfiguration/extensionTypes/versions`  \n`"
+      "value": "Type: `Microsoft.KubernetesConfiguration/extensionTypes/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24742,7 +24742,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.KubernetesConfiguration/extensions`  \n`"
+      "value": "Type: `Microsoft.KubernetesConfiguration/extensions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24763,7 +24763,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.KubernetesConfiguration/fluxConfigurations`  \n`"
+      "value": "Type: `Microsoft.KubernetesConfiguration/fluxConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24784,7 +24784,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.KubernetesConfiguration/locations/extensionTypes`  \n`"
+      "value": "Type: `Microsoft.KubernetesConfiguration/locations/extensionTypes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24805,7 +24805,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.KubernetesConfiguration/locations/extensionTypes/versions`  \n`"
+      "value": "Type: `Microsoft.KubernetesConfiguration/locations/extensionTypes/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24826,7 +24826,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.KubernetesConfiguration/privateLinkScopes`  \n`"
+      "value": "Type: `Microsoft.KubernetesConfiguration/privateLinkScopes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24847,7 +24847,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.KubernetesConfiguration/privateLinkScopes/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.KubernetesConfiguration/privateLinkScopes/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24868,7 +24868,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.KubernetesConfiguration/privateLinkScopes/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.KubernetesConfiguration/privateLinkScopes/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24889,7 +24889,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.KubernetesConfiguration/sourceControlConfigurations`  \n`"
+      "value": "Type: `Microsoft.KubernetesConfiguration/sourceControlConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24910,7 +24910,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Kusto/clusters`  \n`"
+      "value": "Type: `Microsoft.Kusto/clusters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24931,7 +24931,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Kusto/clusters/attachedDatabaseConfigurations`  \n`"
+      "value": "Type: `Microsoft.Kusto/clusters/attachedDatabaseConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24952,7 +24952,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Kusto/clusters/databases`  \n`"
+      "value": "Type: `Microsoft.Kusto/clusters/databases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24973,7 +24973,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Kusto/clusters/databases/dataConnections`  \n`"
+      "value": "Type: `Microsoft.Kusto/clusters/databases/dataConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24994,7 +24994,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Kusto/clusters/databases/eventhubconnections`  \n`"
+      "value": "Type: `Microsoft.Kusto/clusters/databases/eventhubconnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25015,7 +25015,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Kusto/clusters/databases/principalAssignments`  \n`"
+      "value": "Type: `Microsoft.Kusto/clusters/databases/principalAssignments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25036,7 +25036,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Kusto/clusters/databases/scripts`  \n`"
+      "value": "Type: `Microsoft.Kusto/clusters/databases/scripts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25057,7 +25057,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Kusto/clusters/managedPrivateEndpoints`  \n`"
+      "value": "Type: `Microsoft.Kusto/clusters/managedPrivateEndpoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25078,7 +25078,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Kusto/clusters/principalAssignments`  \n`"
+      "value": "Type: `Microsoft.Kusto/clusters/principalAssignments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25099,7 +25099,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Kusto/clusters/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Kusto/clusters/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25120,7 +25120,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Kusto/clusters/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.Kusto/clusters/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25141,7 +25141,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Kusto/clusters/sandboxCustomImages`  \n`"
+      "value": "Type: `Microsoft.Kusto/clusters/sandboxCustomImages`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25162,7 +25162,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.LabServices/labPlans`  \n`"
+      "value": "Type: `Microsoft.LabServices/labPlans`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25183,7 +25183,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.LabServices/labPlans/images`  \n`"
+      "value": "Type: `Microsoft.LabServices/labPlans/images`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25204,7 +25204,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.LabServices/labaccounts`  \n`"
+      "value": "Type: `Microsoft.LabServices/labaccounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25225,7 +25225,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.LabServices/labaccounts/galleryimages`  \n`"
+      "value": "Type: `Microsoft.LabServices/labaccounts/galleryimages`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25246,7 +25246,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.LabServices/labaccounts/labs`  \n`"
+      "value": "Type: `Microsoft.LabServices/labaccounts/labs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25267,7 +25267,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.LabServices/labaccounts/labs/environmentsettings`  \n`"
+      "value": "Type: `Microsoft.LabServices/labaccounts/labs/environmentsettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25288,7 +25288,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.LabServices/labaccounts/labs/environmentsettings/environments`  \n`"
+      "value": "Type: `Microsoft.LabServices/labaccounts/labs/environmentsettings/environments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25309,7 +25309,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.LabServices/labaccounts/labs/users`  \n`"
+      "value": "Type: `Microsoft.LabServices/labaccounts/labs/users`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25330,7 +25330,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.LabServices/labs`  \n`"
+      "value": "Type: `Microsoft.LabServices/labs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25351,7 +25351,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.LabServices/labs/schedules`  \n`"
+      "value": "Type: `Microsoft.LabServices/labs/schedules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25372,7 +25372,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.LabServices/labs/users`  \n`"
+      "value": "Type: `Microsoft.LabServices/labs/users`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25393,7 +25393,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.LabServices/labs/virtualMachines`  \n`"
+      "value": "Type: `Microsoft.LabServices/labs/virtualMachines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25414,7 +25414,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.LoadTestService/loadTests`  \n`"
+      "value": "Type: `Microsoft.LoadTestService/loadTests`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25435,7 +25435,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.LoadTestService/locations/quotas`  \n`"
+      "value": "Type: `Microsoft.LoadTestService/locations/quotas`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25456,7 +25456,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logic/integrationAccounts`  \n`"
+      "value": "Type: `Microsoft.Logic/integrationAccounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25477,7 +25477,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logic/integrationAccounts/agreements`  \n`"
+      "value": "Type: `Microsoft.Logic/integrationAccounts/agreements`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25498,7 +25498,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logic/integrationAccounts/assemblies`  \n`"
+      "value": "Type: `Microsoft.Logic/integrationAccounts/assemblies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25519,7 +25519,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logic/integrationAccounts/batchConfigurations`  \n`"
+      "value": "Type: `Microsoft.Logic/integrationAccounts/batchConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25540,7 +25540,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logic/integrationAccounts/certificates`  \n`"
+      "value": "Type: `Microsoft.Logic/integrationAccounts/certificates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25561,7 +25561,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logic/integrationAccounts/maps`  \n`"
+      "value": "Type: `Microsoft.Logic/integrationAccounts/maps`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25582,7 +25582,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logic/integrationAccounts/partners`  \n`"
+      "value": "Type: `Microsoft.Logic/integrationAccounts/partners`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25603,7 +25603,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logic/integrationAccounts/rosettanetprocessconfigurations`  \n`"
+      "value": "Type: `Microsoft.Logic/integrationAccounts/rosettanetprocessconfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25624,7 +25624,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logic/integrationAccounts/schemas`  \n`"
+      "value": "Type: `Microsoft.Logic/integrationAccounts/schemas`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25645,7 +25645,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logic/integrationAccounts/sessions`  \n`"
+      "value": "Type: `Microsoft.Logic/integrationAccounts/sessions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25666,7 +25666,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logic/integrationServiceEnvironments`  \n`"
+      "value": "Type: `Microsoft.Logic/integrationServiceEnvironments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25687,7 +25687,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logic/integrationServiceEnvironments/managedApis`  \n`"
+      "value": "Type: `Microsoft.Logic/integrationServiceEnvironments/managedApis`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25708,7 +25708,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logic/workflows`  \n`"
+      "value": "Type: `Microsoft.Logic/workflows`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25729,7 +25729,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logic/workflows/accessKeys`  \n`"
+      "value": "Type: `Microsoft.Logic/workflows/accessKeys`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25750,7 +25750,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logic/workflows/runs`  \n`"
+      "value": "Type: `Microsoft.Logic/workflows/runs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25771,7 +25771,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logic/workflows/runs/actions`  \n`"
+      "value": "Type: `Microsoft.Logic/workflows/runs/actions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25792,7 +25792,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logic/workflows/runs/actions/repetitions`  \n`"
+      "value": "Type: `Microsoft.Logic/workflows/runs/actions/repetitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25813,7 +25813,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logic/workflows/runs/actions/repetitions/requestHistories`  \n`"
+      "value": "Type: `Microsoft.Logic/workflows/runs/actions/repetitions/requestHistories`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25834,7 +25834,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logic/workflows/runs/actions/requestHistories`  \n`"
+      "value": "Type: `Microsoft.Logic/workflows/runs/actions/requestHistories`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25855,7 +25855,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logic/workflows/runs/actions/scopeRepetitions`  \n`"
+      "value": "Type: `Microsoft.Logic/workflows/runs/actions/scopeRepetitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25876,7 +25876,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logic/workflows/runs/operations`  \n`"
+      "value": "Type: `Microsoft.Logic/workflows/runs/operations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25897,7 +25897,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logic/workflows/triggers`  \n`"
+      "value": "Type: `Microsoft.Logic/workflows/triggers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25918,7 +25918,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logic/workflows/triggers/histories`  \n`"
+      "value": "Type: `Microsoft.Logic/workflows/triggers/histories`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25939,7 +25939,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logic/workflows/versions`  \n`"
+      "value": "Type: `Microsoft.Logic/workflows/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25960,7 +25960,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logz/monitors`  \n`"
+      "value": "Type: `Microsoft.Logz/monitors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25981,7 +25981,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logz/monitors/accounts`  \n`"
+      "value": "Type: `Microsoft.Logz/monitors/accounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26002,7 +26002,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logz/monitors/accounts/tagRules`  \n`"
+      "value": "Type: `Microsoft.Logz/monitors/accounts/tagRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26023,7 +26023,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logz/monitors/metricsSource`  \n`"
+      "value": "Type: `Microsoft.Logz/monitors/metricsSource`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26044,7 +26044,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logz/monitors/metricsSource/tagRules`  \n`"
+      "value": "Type: `Microsoft.Logz/monitors/metricsSource/tagRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26065,7 +26065,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logz/monitors/singleSignOnConfigurations`  \n`"
+      "value": "Type: `Microsoft.Logz/monitors/singleSignOnConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26086,7 +26086,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Logz/monitors/tagRules`  \n`"
+      "value": "Type: `Microsoft.Logz/monitors/tagRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26107,7 +26107,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForEDMUpload`  \n`"
+      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForEDMUpload`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26128,7 +26128,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForEDMUpload/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForEDMUpload/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26149,7 +26149,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForEDMUpload/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForEDMUpload/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26170,7 +26170,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForM365ComplianceCenter`  \n`"
+      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForM365ComplianceCenter`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26191,7 +26191,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForM365ComplianceCenter/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForM365ComplianceCenter/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26212,7 +26212,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForM365ComplianceCenter/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForM365ComplianceCenter/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26233,7 +26233,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForM365SecurityCenter`  \n`"
+      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForM365SecurityCenter`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26254,7 +26254,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForM365SecurityCenter/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForM365SecurityCenter/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26275,7 +26275,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForM365SecurityCenter/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForM365SecurityCenter/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26296,7 +26296,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForMIPPolicySync`  \n`"
+      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForMIPPolicySync`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26317,7 +26317,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForMIPPolicySync/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForMIPPolicySync/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26338,7 +26338,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForMIPPolicySync/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForMIPPolicySync/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26359,7 +26359,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForO365ManagementActivityAPI`  \n`"
+      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForO365ManagementActivityAPI`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26380,7 +26380,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForO365ManagementActivityAPI/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForO365ManagementActivityAPI/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26401,7 +26401,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForO365ManagementActivityAPI/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForO365ManagementActivityAPI/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26422,7 +26422,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForSCCPowershell`  \n`"
+      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForSCCPowershell`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26443,7 +26443,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForSCCPowershell/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForSCCPowershell/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26464,7 +26464,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForSCCPowershell/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.M365SecurityAndCompliance/privateLinkServicesForSCCPowershell/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26485,7 +26485,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearning/commitmentPlans`  \n`"
+      "value": "Type: `Microsoft.MachineLearning/commitmentPlans`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26506,7 +26506,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearning/commitmentPlans/commitmentAssociations`  \n`"
+      "value": "Type: `Microsoft.MachineLearning/commitmentPlans/commitmentAssociations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26527,7 +26527,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearning/webServices`  \n`"
+      "value": "Type: `Microsoft.MachineLearning/webServices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26548,7 +26548,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearning/workspaces`  \n`"
+      "value": "Type: `Microsoft.MachineLearning/workspaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26569,7 +26569,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningCompute/operationalizationClusters`  \n`"
+      "value": "Type: `Microsoft.MachineLearningCompute/operationalizationClusters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26590,7 +26590,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningExperimentation/accounts`  \n`"
+      "value": "Type: `Microsoft.MachineLearningExperimentation/accounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26611,7 +26611,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningExperimentation/accounts/workspaces`  \n`"
+      "value": "Type: `Microsoft.MachineLearningExperimentation/accounts/workspaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26632,7 +26632,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningExperimentation/accounts/workspaces/projects`  \n`"
+      "value": "Type: `Microsoft.MachineLearningExperimentation/accounts/workspaces/projects`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26653,7 +26653,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/capacityReserverationGroups`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/capacityReserverationGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26674,7 +26674,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/registries`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/registries`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26695,7 +26695,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/registries/codes`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/registries/codes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26716,7 +26716,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/registries/codes/versions`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/registries/codes/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26737,7 +26737,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/registries/components`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/registries/components`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26758,7 +26758,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/registries/components/versions`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/registries/components/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26779,7 +26779,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/registries/data`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/registries/data`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26800,7 +26800,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/registries/data/versions`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/registries/data/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26821,7 +26821,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/registries/environments`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/registries/environments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26842,7 +26842,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/registries/environments/versions`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/registries/environments/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26863,7 +26863,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/registries/models`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/registries/models`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26884,7 +26884,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/registries/models/versions`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/registries/models/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26905,7 +26905,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26926,7 +26926,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/batchEndpoints`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/batchEndpoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26947,7 +26947,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/batchEndpoints/deployments`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/batchEndpoints/deployments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26968,7 +26968,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/codes`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/codes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -26989,7 +26989,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/codes/versions`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/codes/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27010,7 +27010,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/components`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/components`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27031,7 +27031,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/components/versions`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/components/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27052,7 +27052,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/computes`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/computes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27073,7 +27073,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/connections`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/connections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27094,7 +27094,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/data`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/data`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27115,7 +27115,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/data/versions`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/data/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27136,7 +27136,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/datasets`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/datasets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27157,7 +27157,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/datastores`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/datastores`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27178,7 +27178,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/environments`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/environments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27199,7 +27199,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/environments/versions`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/environments/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27220,7 +27220,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/featuresets`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/featuresets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27241,7 +27241,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/featuresets/versions`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/featuresets/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27262,7 +27262,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/featuresets/versions/features`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/featuresets/versions/features`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27283,7 +27283,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/featurestoreEntities`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/featurestoreEntities`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27304,7 +27304,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/featurestoreEntities/versions`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/featurestoreEntities/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27325,7 +27325,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/inferencePools`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/inferencePools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27346,7 +27346,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/inferencePools/endpoints`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/inferencePools/endpoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27367,7 +27367,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/inferencePools/groups`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/inferencePools/groups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27388,7 +27388,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/jobs`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/jobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27409,7 +27409,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/labelingJobs`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/labelingJobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27430,7 +27430,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/linkedServices`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/linkedServices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27451,7 +27451,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/linkedWorkspaces`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/linkedWorkspaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27472,7 +27472,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/models`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/models`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27493,7 +27493,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/models/versions`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/models/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27514,7 +27514,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/onlineEndpoints`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/onlineEndpoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27535,7 +27535,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/onlineEndpoints/deployments`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/onlineEndpoints/deployments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27556,7 +27556,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/outboundRules`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/outboundRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27577,7 +27577,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27598,7 +27598,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/schedules`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/schedules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27619,7 +27619,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/serverlessEndpoints`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/serverlessEndpoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27640,7 +27640,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MachineLearningServices/workspaces/services`  \n`"
+      "value": "Type: `Microsoft.MachineLearningServices/workspaces/services`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27661,7 +27661,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Maintenance/applyUpdates`  \n`"
+      "value": "Type: `Microsoft.Maintenance/applyUpdates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27682,7 +27682,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Maintenance/configurationAssignments`  \n`"
+      "value": "Type: `Microsoft.Maintenance/configurationAssignments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27703,7 +27703,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Maintenance/maintenanceConfigurations`  \n`"
+      "value": "Type: `Microsoft.Maintenance/maintenanceConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27724,7 +27724,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Maintenance/publicMaintenanceConfigurations`  \n`"
+      "value": "Type: `Microsoft.Maintenance/publicMaintenanceConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27745,7 +27745,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedIdentity/identities`  \n`"
+      "value": "Type: `Microsoft.ManagedIdentity/identities`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27766,7 +27766,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedIdentity/userAssignedIdentities`  \n`"
+      "value": "Type: `Microsoft.ManagedIdentity/userAssignedIdentities`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27787,7 +27787,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials`  \n`"
+      "value": "Type: `Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27808,7 +27808,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedNetwork/managedNetworks`  \n`"
+      "value": "Type: `Microsoft.ManagedNetwork/managedNetworks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27829,7 +27829,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedNetwork/managedNetworks/managedNetworkGroups`  \n`"
+      "value": "Type: `Microsoft.ManagedNetwork/managedNetworks/managedNetworkGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27850,7 +27850,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedNetwork/managedNetworks/managedNetworkPeeringPolicies`  \n`"
+      "value": "Type: `Microsoft.ManagedNetwork/managedNetworks/managedNetworkPeeringPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27871,7 +27871,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedNetwork/scopeAssignments`  \n`"
+      "value": "Type: `Microsoft.ManagedNetwork/scopeAssignments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27892,7 +27892,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedNetworkFabric/accessControlLists`  \n`"
+      "value": "Type: `Microsoft.ManagedNetworkFabric/accessControlLists`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27913,7 +27913,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedNetworkFabric/internetGatewayRules`  \n`"
+      "value": "Type: `Microsoft.ManagedNetworkFabric/internetGatewayRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27934,7 +27934,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedNetworkFabric/internetGateways`  \n`"
+      "value": "Type: `Microsoft.ManagedNetworkFabric/internetGateways`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27955,7 +27955,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedNetworkFabric/ipCommunities`  \n`"
+      "value": "Type: `Microsoft.ManagedNetworkFabric/ipCommunities`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27976,7 +27976,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedNetworkFabric/ipExtendedCommunities`  \n`"
+      "value": "Type: `Microsoft.ManagedNetworkFabric/ipExtendedCommunities`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -27997,7 +27997,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedNetworkFabric/ipPrefixes`  \n`"
+      "value": "Type: `Microsoft.ManagedNetworkFabric/ipPrefixes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28018,7 +28018,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedNetworkFabric/l2IsolationDomains`  \n`"
+      "value": "Type: `Microsoft.ManagedNetworkFabric/l2IsolationDomains`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28039,7 +28039,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedNetworkFabric/l3IsolationDomains`  \n`"
+      "value": "Type: `Microsoft.ManagedNetworkFabric/l3IsolationDomains`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28060,7 +28060,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedNetworkFabric/l3IsolationDomains/externalNetworks`  \n`"
+      "value": "Type: `Microsoft.ManagedNetworkFabric/l3IsolationDomains/externalNetworks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28081,7 +28081,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedNetworkFabric/l3IsolationDomains/internalNetworks`  \n`"
+      "value": "Type: `Microsoft.ManagedNetworkFabric/l3IsolationDomains/internalNetworks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28102,7 +28102,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedNetworkFabric/neighborGroups`  \n`"
+      "value": "Type: `Microsoft.ManagedNetworkFabric/neighborGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28123,7 +28123,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedNetworkFabric/networkDeviceSkus`  \n`"
+      "value": "Type: `Microsoft.ManagedNetworkFabric/networkDeviceSkus`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28144,7 +28144,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedNetworkFabric/networkDevices`  \n`"
+      "value": "Type: `Microsoft.ManagedNetworkFabric/networkDevices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28165,7 +28165,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedNetworkFabric/networkDevices/networkInterfaces`  \n`"
+      "value": "Type: `Microsoft.ManagedNetworkFabric/networkDevices/networkInterfaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28186,7 +28186,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedNetworkFabric/networkFabricControllers`  \n`"
+      "value": "Type: `Microsoft.ManagedNetworkFabric/networkFabricControllers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28207,7 +28207,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedNetworkFabric/networkFabricSkus`  \n`"
+      "value": "Type: `Microsoft.ManagedNetworkFabric/networkFabricSkus`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28228,7 +28228,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedNetworkFabric/networkFabrics`  \n`"
+      "value": "Type: `Microsoft.ManagedNetworkFabric/networkFabrics`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28249,7 +28249,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedNetworkFabric/networkFabrics/networkToNetworkInterconnects`  \n`"
+      "value": "Type: `Microsoft.ManagedNetworkFabric/networkFabrics/networkToNetworkInterconnects`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28270,7 +28270,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedNetworkFabric/networkPacketBrokers`  \n`"
+      "value": "Type: `Microsoft.ManagedNetworkFabric/networkPacketBrokers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28291,7 +28291,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedNetworkFabric/networkRackSkus`  \n`"
+      "value": "Type: `Microsoft.ManagedNetworkFabric/networkRackSkus`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28312,7 +28312,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedNetworkFabric/networkRacks`  \n`"
+      "value": "Type: `Microsoft.ManagedNetworkFabric/networkRacks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28333,7 +28333,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedNetworkFabric/networkTapRules`  \n`"
+      "value": "Type: `Microsoft.ManagedNetworkFabric/networkTapRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28354,7 +28354,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedNetworkFabric/networkTaps`  \n`"
+      "value": "Type: `Microsoft.ManagedNetworkFabric/networkTaps`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28375,7 +28375,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedNetworkFabric/routePolicies`  \n`"
+      "value": "Type: `Microsoft.ManagedNetworkFabric/routePolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28396,7 +28396,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedServices/marketplaceRegistrationDefinitions`  \n`"
+      "value": "Type: `Microsoft.ManagedServices/marketplaceRegistrationDefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28417,7 +28417,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedServices/registrationAssignments`  \n`"
+      "value": "Type: `Microsoft.ManagedServices/registrationAssignments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28438,7 +28438,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagedServices/registrationDefinitions`  \n`"
+      "value": "Type: `Microsoft.ManagedServices/registrationDefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28459,7 +28459,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Management/managementGroups`  \n`"
+      "value": "Type: `Microsoft.Management/managementGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28480,7 +28480,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Management/managementGroups/settings`  \n`"
+      "value": "Type: `Microsoft.Management/managementGroups/settings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28501,7 +28501,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Management/managementGroups/subscriptions`  \n`"
+      "value": "Type: `Microsoft.Management/managementGroups/subscriptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28522,7 +28522,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ManagementPartner/partners`  \n`"
+      "value": "Type: `Microsoft.ManagementPartner/partners`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28543,7 +28543,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Maps/accounts`  \n`"
+      "value": "Type: `Microsoft.Maps/accounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28564,7 +28564,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Maps/accounts/creators`  \n`"
+      "value": "Type: `Microsoft.Maps/accounts/creators`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28585,7 +28585,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Maps/accounts/privateAtlases`  \n`"
+      "value": "Type: `Microsoft.Maps/accounts/privateAtlases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28606,7 +28606,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Marketplace/mysolutions`  \n`"
+      "value": "Type: `Microsoft.Marketplace/mysolutions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28627,7 +28627,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Marketplace/privateStores`  \n`"
+      "value": "Type: `Microsoft.Marketplace/privateStores`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28648,7 +28648,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Marketplace/privateStores/adminRequestApprovals`  \n`"
+      "value": "Type: `Microsoft.Marketplace/privateStores/adminRequestApprovals`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28669,7 +28669,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Marketplace/privateStores/collections`  \n`"
+      "value": "Type: `Microsoft.Marketplace/privateStores/collections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28690,7 +28690,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Marketplace/privateStores/collections/offers`  \n`"
+      "value": "Type: `Microsoft.Marketplace/privateStores/collections/offers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28711,7 +28711,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Marketplace/privateStores/offers`  \n`"
+      "value": "Type: `Microsoft.Marketplace/privateStores/offers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28732,7 +28732,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Marketplace/privateStores/requestApprovals`  \n`"
+      "value": "Type: `Microsoft.Marketplace/privateStores/requestApprovals`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28753,7 +28753,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MarketplaceOrdering/agreements/offers/plans`  \n`"
+      "value": "Type: `Microsoft.MarketplaceOrdering/agreements/offers/plans`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28774,7 +28774,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MarketplaceOrdering/offerTypes/publishers/offers/plans/agreements`  \n`"
+      "value": "Type: `Microsoft.MarketplaceOrdering/offerTypes/publishers/offers/plans/agreements`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28795,7 +28795,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/locations/mediaServicesOperationResults`  \n`"
+      "value": "Type: `Microsoft.Media/locations/mediaServicesOperationResults`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28816,7 +28816,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/locations/videoAnalyzerOperationResults`  \n`"
+      "value": "Type: `Microsoft.Media/locations/videoAnalyzerOperationResults`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28837,7 +28837,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/mediaServices/accountFilters`  \n`"
+      "value": "Type: `Microsoft.Media/mediaServices/accountFilters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28858,7 +28858,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/mediaServices/assets`  \n`"
+      "value": "Type: `Microsoft.Media/mediaServices/assets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28879,7 +28879,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/mediaServices/assets/assetFilters`  \n`"
+      "value": "Type: `Microsoft.Media/mediaServices/assets/assetFilters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28900,7 +28900,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/mediaServices/assets/tracks`  \n`"
+      "value": "Type: `Microsoft.Media/mediaServices/assets/tracks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28921,7 +28921,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/mediaServices/assets/tracks/operationResults`  \n`"
+      "value": "Type: `Microsoft.Media/mediaServices/assets/tracks/operationResults`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28942,7 +28942,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/mediaServices/contentKeyPolicies`  \n`"
+      "value": "Type: `Microsoft.Media/mediaServices/contentKeyPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28963,7 +28963,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/mediaServices/mediaGraphs`  \n`"
+      "value": "Type: `Microsoft.Media/mediaServices/mediaGraphs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -28984,7 +28984,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/mediaServices/streamingLocators`  \n`"
+      "value": "Type: `Microsoft.Media/mediaServices/streamingLocators`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29005,7 +29005,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/mediaServices/streamingPolicies`  \n`"
+      "value": "Type: `Microsoft.Media/mediaServices/streamingPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29026,7 +29026,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/mediaServices/transforms`  \n`"
+      "value": "Type: `Microsoft.Media/mediaServices/transforms`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29047,7 +29047,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/mediaServices/transforms/jobs`  \n`"
+      "value": "Type: `Microsoft.Media/mediaServices/transforms/jobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29068,7 +29068,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/mediaservices`  \n`"
+      "value": "Type: `Microsoft.Media/mediaservices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29089,7 +29089,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/mediaservices/liveEvents`  \n`"
+      "value": "Type: `Microsoft.Media/mediaservices/liveEvents`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29110,7 +29110,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/mediaservices/liveEvents/liveOutputs`  \n`"
+      "value": "Type: `Microsoft.Media/mediaservices/liveEvents/liveOutputs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29131,7 +29131,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/mediaservices/liveEvents/liveOutputs/operationLocations`  \n`"
+      "value": "Type: `Microsoft.Media/mediaservices/liveEvents/liveOutputs/operationLocations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29152,7 +29152,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/mediaservices/liveEvents/operationLocations`  \n`"
+      "value": "Type: `Microsoft.Media/mediaservices/liveEvents/operationLocations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29173,7 +29173,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/mediaservices/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Media/mediaservices/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29194,7 +29194,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/mediaservices/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.Media/mediaservices/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29215,7 +29215,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/mediaservices/streamingEndpoints`  \n`"
+      "value": "Type: `Microsoft.Media/mediaservices/streamingEndpoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29236,7 +29236,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/mediaservices/streamingEndpoints/operationLocations`  \n`"
+      "value": "Type: `Microsoft.Media/mediaservices/streamingEndpoints/operationLocations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29257,7 +29257,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/videoAnalyzers`  \n`"
+      "value": "Type: `Microsoft.Media/videoAnalyzers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29278,7 +29278,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/videoAnalyzers/accessPolicies`  \n`"
+      "value": "Type: `Microsoft.Media/videoAnalyzers/accessPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29299,7 +29299,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/videoAnalyzers/edgeModules`  \n`"
+      "value": "Type: `Microsoft.Media/videoAnalyzers/edgeModules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29320,7 +29320,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/videoAnalyzers/livePipelines`  \n`"
+      "value": "Type: `Microsoft.Media/videoAnalyzers/livePipelines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29341,7 +29341,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/videoAnalyzers/pipelineJobs`  \n`"
+      "value": "Type: `Microsoft.Media/videoAnalyzers/pipelineJobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29362,7 +29362,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/videoAnalyzers/pipelineTopologies`  \n`"
+      "value": "Type: `Microsoft.Media/videoAnalyzers/pipelineTopologies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29383,7 +29383,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/videoAnalyzers/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Media/videoAnalyzers/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29404,7 +29404,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/videoAnalyzers/privateEndpointConnections/operationResults`  \n`"
+      "value": "Type: `Microsoft.Media/videoAnalyzers/privateEndpointConnections/operationResults`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29425,7 +29425,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/videoAnalyzers/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.Media/videoAnalyzers/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29446,7 +29446,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Media/videoAnalyzers/videos`  \n`"
+      "value": "Type: `Microsoft.Media/videoAnalyzers/videos`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29467,7 +29467,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/assessmentProjects`  \n`"
+      "value": "Type: `Microsoft.Migrate/assessmentProjects`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29488,7 +29488,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/assessmentProjects/assessmentOptions`  \n`"
+      "value": "Type: `Microsoft.Migrate/assessmentProjects/assessmentOptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29509,7 +29509,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/assessmentProjects/avsAssessmentOptions`  \n`"
+      "value": "Type: `Microsoft.Migrate/assessmentProjects/avsAssessmentOptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29530,7 +29530,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/assessmentProjects/groups`  \n`"
+      "value": "Type: `Microsoft.Migrate/assessmentProjects/groups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29551,7 +29551,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/assessmentProjects/groups/assessments`  \n`"
+      "value": "Type: `Microsoft.Migrate/assessmentProjects/groups/assessments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29572,7 +29572,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/assessmentProjects/groups/assessments/assessedMachines`  \n`"
+      "value": "Type: `Microsoft.Migrate/assessmentProjects/groups/assessments/assessedMachines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29593,7 +29593,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/assessmentProjects/groups/avsAssessments`  \n`"
+      "value": "Type: `Microsoft.Migrate/assessmentProjects/groups/avsAssessments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29614,7 +29614,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/assessmentProjects/groups/avsAssessments/avsAssessedMachines`  \n`"
+      "value": "Type: `Microsoft.Migrate/assessmentProjects/groups/avsAssessments/avsAssessedMachines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29635,7 +29635,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/assessmentProjects/groups/sqlAssessments`  \n`"
+      "value": "Type: `Microsoft.Migrate/assessmentProjects/groups/sqlAssessments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29656,7 +29656,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/assessmentProjects/groups/sqlAssessments/assessedSqlDatabases`  \n`"
+      "value": "Type: `Microsoft.Migrate/assessmentProjects/groups/sqlAssessments/assessedSqlDatabases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29677,7 +29677,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/assessmentProjects/groups/sqlAssessments/assessedSqlInstances`  \n`"
+      "value": "Type: `Microsoft.Migrate/assessmentProjects/groups/sqlAssessments/assessedSqlInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29698,7 +29698,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/assessmentProjects/groups/sqlAssessments/assessedSqlMachines`  \n`"
+      "value": "Type: `Microsoft.Migrate/assessmentProjects/groups/sqlAssessments/assessedSqlMachines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29719,7 +29719,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/assessmentProjects/groups/sqlAssessments/recommendedAssessedEntities`  \n`"
+      "value": "Type: `Microsoft.Migrate/assessmentProjects/groups/sqlAssessments/recommendedAssessedEntities`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29740,7 +29740,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/assessmentProjects/groups/sqlAssessments/summaries`  \n`"
+      "value": "Type: `Microsoft.Migrate/assessmentProjects/groups/sqlAssessments/summaries`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29761,7 +29761,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/assessmentProjects/hypervcollectors`  \n`"
+      "value": "Type: `Microsoft.Migrate/assessmentProjects/hypervcollectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29782,7 +29782,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/assessmentProjects/importcollectors`  \n`"
+      "value": "Type: `Microsoft.Migrate/assessmentProjects/importcollectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29803,7 +29803,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/assessmentProjects/machines`  \n`"
+      "value": "Type: `Microsoft.Migrate/assessmentProjects/machines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29824,7 +29824,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/assessmentProjects/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Migrate/assessmentProjects/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29845,7 +29845,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/assessmentProjects/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.Migrate/assessmentProjects/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29866,7 +29866,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/assessmentProjects/projectSummary`  \n`"
+      "value": "Type: `Microsoft.Migrate/assessmentProjects/projectSummary`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29887,7 +29887,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/assessmentProjects/servercollectors`  \n`"
+      "value": "Type: `Microsoft.Migrate/assessmentProjects/servercollectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29908,7 +29908,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/assessmentProjects/sqlAssessmentOptions`  \n`"
+      "value": "Type: `Microsoft.Migrate/assessmentProjects/sqlAssessmentOptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29929,7 +29929,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/assessmentProjects/sqlcollectors`  \n`"
+      "value": "Type: `Microsoft.Migrate/assessmentProjects/sqlcollectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29950,7 +29950,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/assessmentProjects/vmwarecollectors`  \n`"
+      "value": "Type: `Microsoft.Migrate/assessmentProjects/vmwarecollectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29971,7 +29971,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/migrateProjects`  \n`"
+      "value": "Type: `Microsoft.Migrate/migrateProjects`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -29992,7 +29992,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/migrateProjects/privateEndpointConnectionProxies`  \n`"
+      "value": "Type: `Microsoft.Migrate/migrateProjects/privateEndpointConnectionProxies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30013,7 +30013,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/migrateProjects/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Migrate/migrateProjects/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30034,7 +30034,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/migrateProjects/solutions`  \n`"
+      "value": "Type: `Microsoft.Migrate/migrateProjects/solutions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30055,7 +30055,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/modernizeProjects`  \n`"
+      "value": "Type: `Microsoft.Migrate/modernizeProjects`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30076,7 +30076,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/modernizeProjects/deployedResources`  \n`"
+      "value": "Type: `Microsoft.Migrate/modernizeProjects/deployedResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30097,7 +30097,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/modernizeProjects/jobs`  \n`"
+      "value": "Type: `Microsoft.Migrate/modernizeProjects/jobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30118,7 +30118,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/modernizeProjects/migrateAgents`  \n`"
+      "value": "Type: `Microsoft.Migrate/modernizeProjects/migrateAgents`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30139,7 +30139,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/modernizeProjects/workloadDeployments`  \n`"
+      "value": "Type: `Microsoft.Migrate/modernizeProjects/workloadDeployments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30160,7 +30160,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/modernizeProjects/workloadInstances`  \n`"
+      "value": "Type: `Microsoft.Migrate/modernizeProjects/workloadInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30181,7 +30181,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/moveCollections`  \n`"
+      "value": "Type: `Microsoft.Migrate/moveCollections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30202,7 +30202,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/moveCollections/moveResources`  \n`"
+      "value": "Type: `Microsoft.Migrate/moveCollections/moveResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30223,7 +30223,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/projects`  \n`"
+      "value": "Type: `Microsoft.Migrate/projects`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30244,7 +30244,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/projects/groups`  \n`"
+      "value": "Type: `Microsoft.Migrate/projects/groups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30265,7 +30265,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/projects/groups/assessments`  \n`"
+      "value": "Type: `Microsoft.Migrate/projects/groups/assessments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30286,7 +30286,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/projects/groups/assessments/assessedMachines`  \n`"
+      "value": "Type: `Microsoft.Migrate/projects/groups/assessments/assessedMachines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30307,7 +30307,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Migrate/projects/machines`  \n`"
+      "value": "Type: `Microsoft.Migrate/projects/machines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30328,7 +30328,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MixedReality/objectAnchorsAccounts`  \n`"
+      "value": "Type: `Microsoft.MixedReality/objectAnchorsAccounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30349,7 +30349,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MixedReality/remoteRenderingAccounts`  \n`"
+      "value": "Type: `Microsoft.MixedReality/remoteRenderingAccounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30370,7 +30370,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MixedReality/spatialAnchorsAccounts`  \n`"
+      "value": "Type: `Microsoft.MixedReality/spatialAnchorsAccounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30391,7 +30391,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MobileNetwork/mobileNetworks`  \n`"
+      "value": "Type: `Microsoft.MobileNetwork/mobileNetworks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30412,7 +30412,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MobileNetwork/mobileNetworks/dataNetworks`  \n`"
+      "value": "Type: `Microsoft.MobileNetwork/mobileNetworks/dataNetworks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30433,7 +30433,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MobileNetwork/mobileNetworks/services`  \n`"
+      "value": "Type: `Microsoft.MobileNetwork/mobileNetworks/services`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30454,7 +30454,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MobileNetwork/mobileNetworks/simPolicies`  \n`"
+      "value": "Type: `Microsoft.MobileNetwork/mobileNetworks/simPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30475,7 +30475,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MobileNetwork/mobileNetworks/sites`  \n`"
+      "value": "Type: `Microsoft.MobileNetwork/mobileNetworks/sites`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30496,7 +30496,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MobileNetwork/mobileNetworks/slices`  \n`"
+      "value": "Type: `Microsoft.MobileNetwork/mobileNetworks/slices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30517,7 +30517,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MobileNetwork/packetCoreControlPlaneVersions`  \n`"
+      "value": "Type: `Microsoft.MobileNetwork/packetCoreControlPlaneVersions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30538,7 +30538,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MobileNetwork/packetCoreControlPlanes`  \n`"
+      "value": "Type: `Microsoft.MobileNetwork/packetCoreControlPlanes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30559,7 +30559,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MobileNetwork/packetCoreControlPlanes/diagnosticsPackages`  \n`"
+      "value": "Type: `Microsoft.MobileNetwork/packetCoreControlPlanes/diagnosticsPackages`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30580,7 +30580,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MobileNetwork/packetCoreControlPlanes/packetCaptures`  \n`"
+      "value": "Type: `Microsoft.MobileNetwork/packetCoreControlPlanes/packetCaptures`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30601,7 +30601,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MobileNetwork/packetCoreControlPlanes/packetCoreDataPlanes`  \n`"
+      "value": "Type: `Microsoft.MobileNetwork/packetCoreControlPlanes/packetCoreDataPlanes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30622,7 +30622,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MobileNetwork/packetCoreControlPlanes/packetCoreDataPlanes/attachedDataNetworks`  \n`"
+      "value": "Type: `Microsoft.MobileNetwork/packetCoreControlPlanes/packetCoreDataPlanes/attachedDataNetworks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30643,7 +30643,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MobileNetwork/simGroups`  \n`"
+      "value": "Type: `Microsoft.MobileNetwork/simGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30664,7 +30664,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MobileNetwork/simGroups/sims`  \n`"
+      "value": "Type: `Microsoft.MobileNetwork/simGroups/sims`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30685,7 +30685,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MobileNetwork/sims`  \n`"
+      "value": "Type: `Microsoft.MobileNetwork/sims`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30706,7 +30706,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.MobilePacketCore/networkFunctions`  \n`"
+      "value": "Type: `Microsoft.MobilePacketCore/networkFunctions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30727,7 +30727,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Monitor/accounts`  \n`"
+      "value": "Type: `Microsoft.Monitor/accounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30748,7 +30748,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetApp/locations/quotaLimits`  \n`"
+      "value": "Type: `Microsoft.NetApp/locations/quotaLimits`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30769,7 +30769,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetApp/netAppAccounts`  \n`"
+      "value": "Type: `Microsoft.NetApp/netAppAccounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30790,7 +30790,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetApp/netAppAccounts/accountBackups`  \n`"
+      "value": "Type: `Microsoft.NetApp/netAppAccounts/accountBackups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30811,7 +30811,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetApp/netAppAccounts/backupPolicies`  \n`"
+      "value": "Type: `Microsoft.NetApp/netAppAccounts/backupPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30832,7 +30832,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetApp/netAppAccounts/backupVaults`  \n`"
+      "value": "Type: `Microsoft.NetApp/netAppAccounts/backupVaults`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30853,7 +30853,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetApp/netAppAccounts/backupVaults/backups`  \n`"
+      "value": "Type: `Microsoft.NetApp/netAppAccounts/backupVaults/backups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30874,7 +30874,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetApp/netAppAccounts/capacityPools`  \n`"
+      "value": "Type: `Microsoft.NetApp/netAppAccounts/capacityPools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30895,7 +30895,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetApp/netAppAccounts/capacityPools/volumes`  \n`"
+      "value": "Type: `Microsoft.NetApp/netAppAccounts/capacityPools/volumes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30916,7 +30916,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetApp/netAppAccounts/capacityPools/volumes/backups`  \n`"
+      "value": "Type: `Microsoft.NetApp/netAppAccounts/capacityPools/volumes/backups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30937,7 +30937,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetApp/netAppAccounts/capacityPools/volumes/snapshots`  \n`"
+      "value": "Type: `Microsoft.NetApp/netAppAccounts/capacityPools/volumes/snapshots`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30958,7 +30958,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetApp/netAppAccounts/capacityPools/volumes/subvolumes`  \n`"
+      "value": "Type: `Microsoft.NetApp/netAppAccounts/capacityPools/volumes/subvolumes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -30979,7 +30979,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetApp/netAppAccounts/capacityPools/volumes/volumeQuotaRules`  \n`"
+      "value": "Type: `Microsoft.NetApp/netAppAccounts/capacityPools/volumes/volumeQuotaRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31000,7 +31000,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetApp/netAppAccounts/snapshotPolicies`  \n`"
+      "value": "Type: `Microsoft.NetApp/netAppAccounts/snapshotPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31021,7 +31021,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetApp/netAppAccounts/volumeGroups`  \n`"
+      "value": "Type: `Microsoft.NetApp/netAppAccounts/volumeGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31042,7 +31042,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network.Admin/locations/quotas`  \n`"
+      "value": "Type: `Microsoft.Network.Admin/locations/quotas`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31063,7 +31063,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies`  \n`"
+      "value": "Type: `Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31084,7 +31084,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/ExpressRoutePorts`  \n`"
+      "value": "Type: `Microsoft.Network/ExpressRoutePorts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31105,7 +31105,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/ExpressRoutePorts/links`  \n`"
+      "value": "Type: `Microsoft.Network/ExpressRoutePorts/links`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31126,7 +31126,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/ExpressRoutePortsLocations`  \n`"
+      "value": "Type: `Microsoft.Network/ExpressRoutePortsLocations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31147,7 +31147,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/FrontDoorWebApplicationFirewallPolicies`  \n`"
+      "value": "Type: `Microsoft.Network/FrontDoorWebApplicationFirewallPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31168,7 +31168,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/IpAllocations`  \n`"
+      "value": "Type: `Microsoft.Network/IpAllocations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31189,7 +31189,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/NetworkExperimentProfiles`  \n`"
+      "value": "Type: `Microsoft.Network/NetworkExperimentProfiles`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31210,7 +31210,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/NetworkExperimentProfiles/Experiments`  \n`"
+      "value": "Type: `Microsoft.Network/NetworkExperimentProfiles/Experiments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31231,7 +31231,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/applicationGatewayAvailableSslOptions`  \n`"
+      "value": "Type: `Microsoft.Network/applicationGatewayAvailableSslOptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31252,7 +31252,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/applicationGatewayAvailableSslOptions/predefinedPolicies`  \n`"
+      "value": "Type: `Microsoft.Network/applicationGatewayAvailableSslOptions/predefinedPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31273,7 +31273,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/applicationGateways`  \n`"
+      "value": "Type: `Microsoft.Network/applicationGateways`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31294,7 +31294,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/applicationGateways/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Network/applicationGateways/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31315,7 +31315,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/applicationSecurityGroups`  \n`"
+      "value": "Type: `Microsoft.Network/applicationSecurityGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31336,7 +31336,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/azureFirewalls`  \n`"
+      "value": "Type: `Microsoft.Network/azureFirewalls`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31357,7 +31357,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/bastionHosts`  \n`"
+      "value": "Type: `Microsoft.Network/bastionHosts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31378,7 +31378,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/cloudServiceSlots`  \n`"
+      "value": "Type: `Microsoft.Network/cloudServiceSlots`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31399,7 +31399,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/connections`  \n`"
+      "value": "Type: `Microsoft.Network/connections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31420,7 +31420,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/customIpPrefixes`  \n`"
+      "value": "Type: `Microsoft.Network/customIpPrefixes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31441,7 +31441,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/ddosCustomPolicies`  \n`"
+      "value": "Type: `Microsoft.Network/ddosCustomPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31462,7 +31462,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/ddosProtectionPlans`  \n`"
+      "value": "Type: `Microsoft.Network/ddosProtectionPlans`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31483,7 +31483,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/dnsForwardingRulesets`  \n`"
+      "value": "Type: `Microsoft.Network/dnsForwardingRulesets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31504,7 +31504,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/dnsForwardingRulesets/forwardingRules`  \n`"
+      "value": "Type: `Microsoft.Network/dnsForwardingRulesets/forwardingRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31525,7 +31525,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/dnsForwardingRulesets/virtualNetworkLinks`  \n`"
+      "value": "Type: `Microsoft.Network/dnsForwardingRulesets/virtualNetworkLinks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31546,7 +31546,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/dnsResolvers`  \n`"
+      "value": "Type: `Microsoft.Network/dnsResolvers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31567,7 +31567,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/dnsResolvers/inboundEndpoints`  \n`"
+      "value": "Type: `Microsoft.Network/dnsResolvers/inboundEndpoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31588,7 +31588,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/dnsResolvers/outboundEndpoints`  \n`"
+      "value": "Type: `Microsoft.Network/dnsResolvers/outboundEndpoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31609,7 +31609,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/dnsZones`  \n`"
+      "value": "Type: `Microsoft.Network/dnsZones`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31630,7 +31630,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/dnsZones/A`  \n`"
+      "value": "Type: `Microsoft.Network/dnsZones/A`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31651,7 +31651,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/dnsZones/AAAA`  \n`"
+      "value": "Type: `Microsoft.Network/dnsZones/AAAA`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31672,7 +31672,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/dnsZones/CAA`  \n`"
+      "value": "Type: `Microsoft.Network/dnsZones/CAA`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31693,7 +31693,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/dnsZones/CNAME`  \n`"
+      "value": "Type: `Microsoft.Network/dnsZones/CNAME`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31714,7 +31714,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/dnsZones/DS`  \n`"
+      "value": "Type: `Microsoft.Network/dnsZones/DS`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31735,7 +31735,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/dnsZones/MX`  \n`"
+      "value": "Type: `Microsoft.Network/dnsZones/MX`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31756,7 +31756,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/dnsZones/NAPTR`  \n`"
+      "value": "Type: `Microsoft.Network/dnsZones/NAPTR`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31777,7 +31777,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/dnsZones/NS`  \n`"
+      "value": "Type: `Microsoft.Network/dnsZones/NS`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31798,7 +31798,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/dnsZones/PTR`  \n`"
+      "value": "Type: `Microsoft.Network/dnsZones/PTR`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31819,7 +31819,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/dnsZones/SOA`  \n`"
+      "value": "Type: `Microsoft.Network/dnsZones/SOA`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31840,7 +31840,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/dnsZones/SRV`  \n`"
+      "value": "Type: `Microsoft.Network/dnsZones/SRV`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31861,7 +31861,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/dnsZones/TLSA`  \n`"
+      "value": "Type: `Microsoft.Network/dnsZones/TLSA`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31882,7 +31882,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/dnsZones/TXT`  \n`"
+      "value": "Type: `Microsoft.Network/dnsZones/TXT`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31903,7 +31903,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/dnsZones/dnssecConfigs`  \n`"
+      "value": "Type: `Microsoft.Network/dnsZones/dnssecConfigs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31924,7 +31924,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/dscpConfigurations`  \n`"
+      "value": "Type: `Microsoft.Network/dscpConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31945,7 +31945,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/expressRouteCircuits`  \n`"
+      "value": "Type: `Microsoft.Network/expressRouteCircuits`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31966,7 +31966,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/expressRouteCircuits/authorizations`  \n`"
+      "value": "Type: `Microsoft.Network/expressRouteCircuits/authorizations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -31987,7 +31987,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/expressRouteCircuits/peerings`  \n`"
+      "value": "Type: `Microsoft.Network/expressRouteCircuits/peerings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32008,7 +32008,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/expressRouteCircuits/peerings/connections`  \n`"
+      "value": "Type: `Microsoft.Network/expressRouteCircuits/peerings/connections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32029,7 +32029,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/expressRouteCircuits/peerings/peerConnections`  \n`"
+      "value": "Type: `Microsoft.Network/expressRouteCircuits/peerings/peerConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32050,7 +32050,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/expressRouteCrossConnections`  \n`"
+      "value": "Type: `Microsoft.Network/expressRouteCrossConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32071,7 +32071,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/expressRouteCrossConnections/peerings`  \n`"
+      "value": "Type: `Microsoft.Network/expressRouteCrossConnections/peerings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32092,7 +32092,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/expressRouteGateways`  \n`"
+      "value": "Type: `Microsoft.Network/expressRouteGateways`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32113,7 +32113,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/expressRouteGateways/expressRouteConnections`  \n`"
+      "value": "Type: `Microsoft.Network/expressRouteGateways/expressRouteConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32134,7 +32134,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/expressRoutePorts/authorizations`  \n`"
+      "value": "Type: `Microsoft.Network/expressRoutePorts/authorizations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32155,7 +32155,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/expressRouteProviderPorts`  \n`"
+      "value": "Type: `Microsoft.Network/expressRouteProviderPorts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32176,7 +32176,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/firewallPolicies`  \n`"
+      "value": "Type: `Microsoft.Network/firewallPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32197,7 +32197,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/firewallPolicies/ruleCollectionGroups`  \n`"
+      "value": "Type: `Microsoft.Network/firewallPolicies/ruleCollectionGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32218,7 +32218,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/firewallPolicies/ruleGroups`  \n`"
+      "value": "Type: `Microsoft.Network/firewallPolicies/ruleGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32239,7 +32239,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/firewallPolicies/signatureOverrides`  \n`"
+      "value": "Type: `Microsoft.Network/firewallPolicies/signatureOverrides`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32260,7 +32260,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/frontDoors`  \n`"
+      "value": "Type: `Microsoft.Network/frontDoors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32281,7 +32281,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/frontDoors/frontendEndpoints`  \n`"
+      "value": "Type: `Microsoft.Network/frontDoors/frontendEndpoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32302,7 +32302,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/frontDoors/rulesEngines`  \n`"
+      "value": "Type: `Microsoft.Network/frontDoors/rulesEngines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32323,7 +32323,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/interfaceEndpoints`  \n`"
+      "value": "Type: `Microsoft.Network/interfaceEndpoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32344,7 +32344,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/ipGroups`  \n`"
+      "value": "Type: `Microsoft.Network/ipGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32365,7 +32365,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/loadBalancers`  \n`"
+      "value": "Type: `Microsoft.Network/loadBalancers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32386,7 +32386,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/loadBalancers/backendAddressPools`  \n`"
+      "value": "Type: `Microsoft.Network/loadBalancers/backendAddressPools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32407,7 +32407,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/loadBalancers/frontendIPConfigurations`  \n`"
+      "value": "Type: `Microsoft.Network/loadBalancers/frontendIPConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32428,7 +32428,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/loadBalancers/inboundNatRules`  \n`"
+      "value": "Type: `Microsoft.Network/loadBalancers/inboundNatRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32449,7 +32449,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/loadBalancers/loadBalancingRules`  \n`"
+      "value": "Type: `Microsoft.Network/loadBalancers/loadBalancingRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32470,7 +32470,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/loadBalancers/outboundRules`  \n`"
+      "value": "Type: `Microsoft.Network/loadBalancers/outboundRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32491,7 +32491,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/loadBalancers/probes`  \n`"
+      "value": "Type: `Microsoft.Network/loadBalancers/probes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32512,7 +32512,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/localNetworkGateways`  \n`"
+      "value": "Type: `Microsoft.Network/localNetworkGateways`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32533,7 +32533,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/managementGroups/networkManagerConnections`  \n`"
+      "value": "Type: `Microsoft.Network/managementGroups/networkManagerConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32554,7 +32554,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/natGateways`  \n`"
+      "value": "Type: `Microsoft.Network/natGateways`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32575,7 +32575,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkInterfaces`  \n`"
+      "value": "Type: `Microsoft.Network/networkInterfaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32596,7 +32596,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkInterfaces/ipConfigurations`  \n`"
+      "value": "Type: `Microsoft.Network/networkInterfaces/ipConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32617,7 +32617,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkInterfaces/tapConfigurations`  \n`"
+      "value": "Type: `Microsoft.Network/networkInterfaces/tapConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32638,7 +32638,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkManagerConnections`  \n`"
+      "value": "Type: `Microsoft.Network/networkManagerConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32659,7 +32659,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkManagers`  \n`"
+      "value": "Type: `Microsoft.Network/networkManagers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32680,7 +32680,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkManagers/connectivityConfigurations`  \n`"
+      "value": "Type: `Microsoft.Network/networkManagers/connectivityConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32701,7 +32701,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkManagers/networkGroups`  \n`"
+      "value": "Type: `Microsoft.Network/networkManagers/networkGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32722,7 +32722,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkManagers/networkGroups/staticMembers`  \n`"
+      "value": "Type: `Microsoft.Network/networkManagers/networkGroups/staticMembers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32743,7 +32743,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkManagers/scopeConnections`  \n`"
+      "value": "Type: `Microsoft.Network/networkManagers/scopeConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32764,7 +32764,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkManagers/securityAdminConfigurations`  \n`"
+      "value": "Type: `Microsoft.Network/networkManagers/securityAdminConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32785,7 +32785,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkManagers/securityAdminConfigurations/ruleCollections`  \n`"
+      "value": "Type: `Microsoft.Network/networkManagers/securityAdminConfigurations/ruleCollections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32806,7 +32806,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkManagers/securityAdminConfigurations/ruleCollections/rules`  \n`"
+      "value": "Type: `Microsoft.Network/networkManagers/securityAdminConfigurations/ruleCollections/rules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32827,7 +32827,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkManagers/securityUserConfigurations`  \n`"
+      "value": "Type: `Microsoft.Network/networkManagers/securityUserConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32848,7 +32848,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkManagers/securityUserConfigurations/ruleCollections`  \n`"
+      "value": "Type: `Microsoft.Network/networkManagers/securityUserConfigurations/ruleCollections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32869,7 +32869,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkManagers/securityUserConfigurations/ruleCollections/rules`  \n`"
+      "value": "Type: `Microsoft.Network/networkManagers/securityUserConfigurations/ruleCollections/rules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32890,7 +32890,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkProfiles`  \n`"
+      "value": "Type: `Microsoft.Network/networkProfiles`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32911,7 +32911,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkSecurityGroups`  \n`"
+      "value": "Type: `Microsoft.Network/networkSecurityGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32932,7 +32932,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkSecurityGroups/defaultSecurityRules`  \n`"
+      "value": "Type: `Microsoft.Network/networkSecurityGroups/defaultSecurityRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32953,7 +32953,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkSecurityGroups/securityRules`  \n`"
+      "value": "Type: `Microsoft.Network/networkSecurityGroups/securityRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32974,7 +32974,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkSecurityPerimeters`  \n`"
+      "value": "Type: `Microsoft.Network/networkSecurityPerimeters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -32995,7 +32995,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkSecurityPerimeters/linkReferences`  \n`"
+      "value": "Type: `Microsoft.Network/networkSecurityPerimeters/linkReferences`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33016,7 +33016,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkSecurityPerimeters/links`  \n`"
+      "value": "Type: `Microsoft.Network/networkSecurityPerimeters/links`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33037,7 +33037,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkSecurityPerimeters/profiles`  \n`"
+      "value": "Type: `Microsoft.Network/networkSecurityPerimeters/profiles`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33058,7 +33058,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkSecurityPerimeters/profiles/accessRules`  \n`"
+      "value": "Type: `Microsoft.Network/networkSecurityPerimeters/profiles/accessRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33079,7 +33079,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkSecurityPerimeters/resourceAssociations`  \n`"
+      "value": "Type: `Microsoft.Network/networkSecurityPerimeters/resourceAssociations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33100,7 +33100,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkVirtualApplianceSkus`  \n`"
+      "value": "Type: `Microsoft.Network/networkVirtualApplianceSkus`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33121,7 +33121,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkVirtualAppliances`  \n`"
+      "value": "Type: `Microsoft.Network/networkVirtualAppliances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33142,7 +33142,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkVirtualAppliances/inboundSecurityRules`  \n`"
+      "value": "Type: `Microsoft.Network/networkVirtualAppliances/inboundSecurityRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33163,7 +33163,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkVirtualAppliances/networkVirtualApplianceConnections`  \n`"
+      "value": "Type: `Microsoft.Network/networkVirtualAppliances/networkVirtualApplianceConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33184,7 +33184,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkVirtualAppliances/virtualApplianceSites`  \n`"
+      "value": "Type: `Microsoft.Network/networkVirtualAppliances/virtualApplianceSites`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33205,7 +33205,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkWatchers`  \n`"
+      "value": "Type: `Microsoft.Network/networkWatchers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33226,7 +33226,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkWatchers/connectionMonitors`  \n`"
+      "value": "Type: `Microsoft.Network/networkWatchers/connectionMonitors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33247,7 +33247,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkWatchers/flowLogs`  \n`"
+      "value": "Type: `Microsoft.Network/networkWatchers/flowLogs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33268,7 +33268,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/networkWatchers/packetCaptures`  \n`"
+      "value": "Type: `Microsoft.Network/networkWatchers/packetCaptures`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33289,7 +33289,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/p2svpnGateways`  \n`"
+      "value": "Type: `Microsoft.Network/p2svpnGateways`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33310,7 +33310,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/privateDnsZones`  \n`"
+      "value": "Type: `Microsoft.Network/privateDnsZones`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33331,7 +33331,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/privateDnsZones/A`  \n`"
+      "value": "Type: `Microsoft.Network/privateDnsZones/A`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33352,7 +33352,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/privateDnsZones/AAAA`  \n`"
+      "value": "Type: `Microsoft.Network/privateDnsZones/AAAA`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33373,7 +33373,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/privateDnsZones/CNAME`  \n`"
+      "value": "Type: `Microsoft.Network/privateDnsZones/CNAME`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33394,7 +33394,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/privateDnsZones/MX`  \n`"
+      "value": "Type: `Microsoft.Network/privateDnsZones/MX`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33415,7 +33415,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/privateDnsZones/PTR`  \n`"
+      "value": "Type: `Microsoft.Network/privateDnsZones/PTR`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33436,7 +33436,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/privateDnsZones/SOA`  \n`"
+      "value": "Type: `Microsoft.Network/privateDnsZones/SOA`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33457,7 +33457,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/privateDnsZones/SRV`  \n`"
+      "value": "Type: `Microsoft.Network/privateDnsZones/SRV`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33478,7 +33478,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/privateDnsZones/TXT`  \n`"
+      "value": "Type: `Microsoft.Network/privateDnsZones/TXT`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33499,7 +33499,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/privateDnsZones/virtualNetworkLinks`  \n`"
+      "value": "Type: `Microsoft.Network/privateDnsZones/virtualNetworkLinks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33520,7 +33520,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/privateEndpoints`  \n`"
+      "value": "Type: `Microsoft.Network/privateEndpoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33541,7 +33541,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/privateEndpoints/privateDnsZoneGroups`  \n`"
+      "value": "Type: `Microsoft.Network/privateEndpoints/privateDnsZoneGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33562,7 +33562,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/privateLinkServices`  \n`"
+      "value": "Type: `Microsoft.Network/privateLinkServices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33583,7 +33583,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/privateLinkServices/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Network/privateLinkServices/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33604,7 +33604,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/publicIPAddresses`  \n`"
+      "value": "Type: `Microsoft.Network/publicIPAddresses`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33625,7 +33625,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/publicIPPrefixes`  \n`"
+      "value": "Type: `Microsoft.Network/publicIPPrefixes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33646,7 +33646,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/routeFilters`  \n`"
+      "value": "Type: `Microsoft.Network/routeFilters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33667,7 +33667,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/routeFilters/routeFilterRules`  \n`"
+      "value": "Type: `Microsoft.Network/routeFilters/routeFilterRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33688,7 +33688,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/routeTables`  \n`"
+      "value": "Type: `Microsoft.Network/routeTables`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33709,7 +33709,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/routeTables/routes`  \n`"
+      "value": "Type: `Microsoft.Network/routeTables/routes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33730,7 +33730,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/securityPartnerProviders`  \n`"
+      "value": "Type: `Microsoft.Network/securityPartnerProviders`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33751,7 +33751,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/serviceEndpointPolicies`  \n`"
+      "value": "Type: `Microsoft.Network/serviceEndpointPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33772,7 +33772,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/serviceEndpointPolicies/serviceEndpointPolicyDefinitions`  \n`"
+      "value": "Type: `Microsoft.Network/serviceEndpointPolicies/serviceEndpointPolicyDefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33793,7 +33793,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/trafficManagerGeographicHierarchies`  \n`"
+      "value": "Type: `Microsoft.Network/trafficManagerGeographicHierarchies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33814,7 +33814,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/trafficManagerUserMetricsKeys`  \n`"
+      "value": "Type: `Microsoft.Network/trafficManagerUserMetricsKeys`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33835,7 +33835,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/trafficmanagerprofiles`  \n`"
+      "value": "Type: `Microsoft.Network/trafficmanagerprofiles`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33856,7 +33856,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/trafficmanagerprofiles/AzureEndpoints`  \n`"
+      "value": "Type: `Microsoft.Network/trafficmanagerprofiles/AzureEndpoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33877,7 +33877,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/trafficmanagerprofiles/ExternalEndpoints`  \n`"
+      "value": "Type: `Microsoft.Network/trafficmanagerprofiles/ExternalEndpoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33898,7 +33898,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/trafficmanagerprofiles/NestedEndpoints`  \n`"
+      "value": "Type: `Microsoft.Network/trafficmanagerprofiles/NestedEndpoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33919,7 +33919,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/trafficmanagerprofiles/heatMaps`  \n`"
+      "value": "Type: `Microsoft.Network/trafficmanagerprofiles/heatMaps`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33940,7 +33940,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualHubs`  \n`"
+      "value": "Type: `Microsoft.Network/virtualHubs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33961,7 +33961,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualHubs/bgpConnections`  \n`"
+      "value": "Type: `Microsoft.Network/virtualHubs/bgpConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -33982,7 +33982,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualHubs/hubRouteTables`  \n`"
+      "value": "Type: `Microsoft.Network/virtualHubs/hubRouteTables`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34003,7 +34003,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualHubs/hubVirtualNetworkConnections`  \n`"
+      "value": "Type: `Microsoft.Network/virtualHubs/hubVirtualNetworkConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34024,7 +34024,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualHubs/ipConfigurations`  \n`"
+      "value": "Type: `Microsoft.Network/virtualHubs/ipConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34045,7 +34045,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualHubs/routeMaps`  \n`"
+      "value": "Type: `Microsoft.Network/virtualHubs/routeMaps`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34066,7 +34066,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualHubs/routeTables`  \n`"
+      "value": "Type: `Microsoft.Network/virtualHubs/routeTables`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34087,7 +34087,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualHubs/routingIntent`  \n`"
+      "value": "Type: `Microsoft.Network/virtualHubs/routingIntent`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34108,7 +34108,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworkGateways`  \n`"
+      "value": "Type: `Microsoft.Network/virtualNetworkGateways`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34129,7 +34129,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworkGateways/natRules`  \n`"
+      "value": "Type: `Microsoft.Network/virtualNetworkGateways/natRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34150,7 +34150,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworkTaps`  \n`"
+      "value": "Type: `Microsoft.Network/virtualNetworkTaps`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34171,7 +34171,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \n`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34192,7 +34192,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks/subnets`  \n`"
+      "value": "Type: `Microsoft.Network/virtualNetworks/subnets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34213,7 +34213,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks/virtualNetworkPeerings`  \n`"
+      "value": "Type: `Microsoft.Network/virtualNetworks/virtualNetworkPeerings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34234,7 +34234,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualRouters`  \n`"
+      "value": "Type: `Microsoft.Network/virtualRouters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34255,7 +34255,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualRouters/peerings`  \n`"
+      "value": "Type: `Microsoft.Network/virtualRouters/peerings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34276,7 +34276,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualWans`  \n`"
+      "value": "Type: `Microsoft.Network/virtualWans`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34297,7 +34297,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualWans/p2sVpnServerConfigurations`  \n`"
+      "value": "Type: `Microsoft.Network/virtualWans/p2sVpnServerConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34318,7 +34318,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/vpnGateways`  \n`"
+      "value": "Type: `Microsoft.Network/vpnGateways`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34339,7 +34339,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/vpnGateways/natRules`  \n`"
+      "value": "Type: `Microsoft.Network/vpnGateways/natRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34360,7 +34360,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/vpnGateways/vpnConnections`  \n`"
+      "value": "Type: `Microsoft.Network/vpnGateways/vpnConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34381,7 +34381,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/vpnGateways/vpnConnections/vpnLinkConnections`  \n`"
+      "value": "Type: `Microsoft.Network/vpnGateways/vpnConnections/vpnLinkConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34402,7 +34402,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/vpnServerConfigurations`  \n`"
+      "value": "Type: `Microsoft.Network/vpnServerConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34423,7 +34423,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/vpnServerConfigurations/configurationPolicyGroups`  \n`"
+      "value": "Type: `Microsoft.Network/vpnServerConfigurations/configurationPolicyGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34444,7 +34444,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/vpnSites`  \n`"
+      "value": "Type: `Microsoft.Network/vpnSites`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34465,7 +34465,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/vpnSites/vpnSiteLinks`  \n`"
+      "value": "Type: `Microsoft.Network/vpnSites/vpnSiteLinks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34486,7 +34486,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetworkAnalytics/dataProducts`  \n`"
+      "value": "Type: `Microsoft.NetworkAnalytics/dataProducts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34507,7 +34507,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetworkAnalytics/dataProducts/dataTypes`  \n`"
+      "value": "Type: `Microsoft.NetworkAnalytics/dataProducts/dataTypes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34528,7 +34528,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetworkAnalytics/dataProductsCatalogs`  \n`"
+      "value": "Type: `Microsoft.NetworkAnalytics/dataProductsCatalogs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34549,7 +34549,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetworkCloud/bareMetalMachines`  \n`"
+      "value": "Type: `Microsoft.NetworkCloud/bareMetalMachines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34570,7 +34570,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetworkCloud/cloudServicesNetworks`  \n`"
+      "value": "Type: `Microsoft.NetworkCloud/cloudServicesNetworks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34591,7 +34591,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetworkCloud/clusterManagers`  \n`"
+      "value": "Type: `Microsoft.NetworkCloud/clusterManagers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34612,7 +34612,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetworkCloud/clusters`  \n`"
+      "value": "Type: `Microsoft.NetworkCloud/clusters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34633,7 +34633,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetworkCloud/clusters/bareMetalMachineKeySets`  \n`"
+      "value": "Type: `Microsoft.NetworkCloud/clusters/bareMetalMachineKeySets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34654,7 +34654,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetworkCloud/clusters/bmcKeySets`  \n`"
+      "value": "Type: `Microsoft.NetworkCloud/clusters/bmcKeySets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34675,7 +34675,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetworkCloud/clusters/metricsConfigurations`  \n`"
+      "value": "Type: `Microsoft.NetworkCloud/clusters/metricsConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34696,7 +34696,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetworkCloud/defaultCniNetworks`  \n`"
+      "value": "Type: `Microsoft.NetworkCloud/defaultCniNetworks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34717,7 +34717,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetworkCloud/hybridAksClusters`  \n`"
+      "value": "Type: `Microsoft.NetworkCloud/hybridAksClusters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34738,7 +34738,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetworkCloud/kubernetesClusters`  \n`"
+      "value": "Type: `Microsoft.NetworkCloud/kubernetesClusters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34759,7 +34759,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetworkCloud/kubernetesClusters/agentPools`  \n`"
+      "value": "Type: `Microsoft.NetworkCloud/kubernetesClusters/agentPools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34780,7 +34780,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetworkCloud/l2Networks`  \n`"
+      "value": "Type: `Microsoft.NetworkCloud/l2Networks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34801,7 +34801,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetworkCloud/l3Networks`  \n`"
+      "value": "Type: `Microsoft.NetworkCloud/l3Networks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34822,7 +34822,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetworkCloud/rackSkus`  \n`"
+      "value": "Type: `Microsoft.NetworkCloud/rackSkus`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34843,7 +34843,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetworkCloud/racks`  \n`"
+      "value": "Type: `Microsoft.NetworkCloud/racks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34864,7 +34864,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetworkCloud/storageAppliances`  \n`"
+      "value": "Type: `Microsoft.NetworkCloud/storageAppliances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34885,7 +34885,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetworkCloud/trunkedNetworks`  \n`"
+      "value": "Type: `Microsoft.NetworkCloud/trunkedNetworks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34906,7 +34906,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetworkCloud/virtualMachines`  \n`"
+      "value": "Type: `Microsoft.NetworkCloud/virtualMachines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34927,7 +34927,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetworkCloud/virtualMachines/consoles`  \n`"
+      "value": "Type: `Microsoft.NetworkCloud/virtualMachines/consoles`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34948,7 +34948,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetworkCloud/volumes`  \n`"
+      "value": "Type: `Microsoft.NetworkCloud/volumes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34969,7 +34969,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetworkFunction/azureTrafficCollectors`  \n`"
+      "value": "Type: `Microsoft.NetworkFunction/azureTrafficCollectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -34990,7 +34990,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NetworkFunction/azureTrafficCollectors/collectorPolicies`  \n`"
+      "value": "Type: `Microsoft.NetworkFunction/azureTrafficCollectors/collectorPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35011,7 +35011,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NotificationHubs/namespaces`  \n`"
+      "value": "Type: `Microsoft.NotificationHubs/namespaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35032,7 +35032,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NotificationHubs/namespaces/authorizationRules`  \n`"
+      "value": "Type: `Microsoft.NotificationHubs/namespaces/authorizationRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35053,7 +35053,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NotificationHubs/namespaces/notificationHubs`  \n`"
+      "value": "Type: `Microsoft.NotificationHubs/namespaces/notificationHubs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35074,7 +35074,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NotificationHubs/namespaces/notificationHubs/authorizationRules`  \n`"
+      "value": "Type: `Microsoft.NotificationHubs/namespaces/notificationHubs/authorizationRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35095,7 +35095,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NotificationHubs/namespaces/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.NotificationHubs/namespaces/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35116,7 +35116,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.NotificationHubs/namespaces/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.NotificationHubs/namespaces/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35137,7 +35137,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/hypervSites`  \n`"
+      "value": "Type: `Microsoft.OffAzure/hypervSites`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35158,7 +35158,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/hypervSites/clusters`  \n`"
+      "value": "Type: `Microsoft.OffAzure/hypervSites/clusters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35179,7 +35179,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/hypervSites/hosts`  \n`"
+      "value": "Type: `Microsoft.OffAzure/hypervSites/hosts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35200,7 +35200,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/hypervSites/jobs`  \n`"
+      "value": "Type: `Microsoft.OffAzure/hypervSites/jobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35221,7 +35221,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/hypervSites/machines`  \n`"
+      "value": "Type: `Microsoft.OffAzure/hypervSites/machines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35242,7 +35242,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/hypervSites/machines/softwareInventories`  \n`"
+      "value": "Type: `Microsoft.OffAzure/hypervSites/machines/softwareInventories`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35263,7 +35263,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/hypervSites/runAsAccounts`  \n`"
+      "value": "Type: `Microsoft.OffAzure/hypervSites/runAsAccounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35284,7 +35284,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/importSites`  \n`"
+      "value": "Type: `Microsoft.OffAzure/importSites`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35305,7 +35305,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/importSites/deleteJobs`  \n`"
+      "value": "Type: `Microsoft.OffAzure/importSites/deleteJobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35326,7 +35326,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/importSites/jobs`  \n`"
+      "value": "Type: `Microsoft.OffAzure/importSites/jobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35347,7 +35347,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/importSites/machines`  \n`"
+      "value": "Type: `Microsoft.OffAzure/importSites/machines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35368,7 +35368,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/masterSites`  \n`"
+      "value": "Type: `Microsoft.OffAzure/masterSites`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35389,7 +35389,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/masterSites/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.OffAzure/masterSites/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35410,7 +35410,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/masterSites/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.OffAzure/masterSites/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35431,7 +35431,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/masterSites/sqlSites`  \n`"
+      "value": "Type: `Microsoft.OffAzure/masterSites/sqlSites`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35452,7 +35452,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/masterSites/sqlSites/discoverySiteDataSources`  \n`"
+      "value": "Type: `Microsoft.OffAzure/masterSites/sqlSites/discoverySiteDataSources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35473,7 +35473,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/masterSites/sqlSites/jobs`  \n`"
+      "value": "Type: `Microsoft.OffAzure/masterSites/sqlSites/jobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35494,7 +35494,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/masterSites/sqlSites/runAsAccounts`  \n`"
+      "value": "Type: `Microsoft.OffAzure/masterSites/sqlSites/runAsAccounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35515,7 +35515,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/masterSites/sqlSites/sqlAvailabilityGroups`  \n`"
+      "value": "Type: `Microsoft.OffAzure/masterSites/sqlSites/sqlAvailabilityGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35536,7 +35536,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/masterSites/sqlSites/sqlDatabases`  \n`"
+      "value": "Type: `Microsoft.OffAzure/masterSites/sqlSites/sqlDatabases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35557,7 +35557,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/masterSites/sqlSites/sqlServers`  \n`"
+      "value": "Type: `Microsoft.OffAzure/masterSites/sqlSites/sqlServers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35578,7 +35578,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/masterSites/webAppSites`  \n`"
+      "value": "Type: `Microsoft.OffAzure/masterSites/webAppSites`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35599,7 +35599,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/masterSites/webAppSites/discoverySiteDataSources`  \n`"
+      "value": "Type: `Microsoft.OffAzure/masterSites/webAppSites/discoverySiteDataSources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35620,7 +35620,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/masterSites/webAppSites/extendedMachines`  \n`"
+      "value": "Type: `Microsoft.OffAzure/masterSites/webAppSites/extendedMachines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35641,7 +35641,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/masterSites/webAppSites/iisWebApplications`  \n`"
+      "value": "Type: `Microsoft.OffAzure/masterSites/webAppSites/iisWebApplications`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35662,7 +35662,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/masterSites/webAppSites/iisWebServers`  \n`"
+      "value": "Type: `Microsoft.OffAzure/masterSites/webAppSites/iisWebServers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35683,7 +35683,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/masterSites/webAppSites/runasaccounts`  \n`"
+      "value": "Type: `Microsoft.OffAzure/masterSites/webAppSites/runasaccounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35704,7 +35704,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/masterSites/webAppSites/tomcatWebApplications`  \n`"
+      "value": "Type: `Microsoft.OffAzure/masterSites/webAppSites/tomcatWebApplications`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35725,7 +35725,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/masterSites/webAppSites/tomcatWebServers`  \n`"
+      "value": "Type: `Microsoft.OffAzure/masterSites/webAppSites/tomcatWebServers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35746,7 +35746,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/serverSites`  \n`"
+      "value": "Type: `Microsoft.OffAzure/serverSites`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35767,7 +35767,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/serverSites/jobs`  \n`"
+      "value": "Type: `Microsoft.OffAzure/serverSites/jobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35788,7 +35788,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/serverSites/machines`  \n`"
+      "value": "Type: `Microsoft.OffAzure/serverSites/machines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35809,7 +35809,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/serverSites/machines/softwareInventories`  \n`"
+      "value": "Type: `Microsoft.OffAzure/serverSites/machines/softwareInventories`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35830,7 +35830,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/serverSites/runAsAccounts`  \n`"
+      "value": "Type: `Microsoft.OffAzure/serverSites/runAsAccounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35851,7 +35851,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/vmwareSites`  \n`"
+      "value": "Type: `Microsoft.OffAzure/vmwareSites`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35872,7 +35872,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/vmwareSites/hosts`  \n`"
+      "value": "Type: `Microsoft.OffAzure/vmwareSites/hosts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35893,7 +35893,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/vmwareSites/jobs`  \n`"
+      "value": "Type: `Microsoft.OffAzure/vmwareSites/jobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35914,7 +35914,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/vmwareSites/machines`  \n`"
+      "value": "Type: `Microsoft.OffAzure/vmwareSites/machines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35935,7 +35935,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/vmwareSites/machines/softwareInventories`  \n`"
+      "value": "Type: `Microsoft.OffAzure/vmwareSites/machines/softwareInventories`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35956,7 +35956,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/vmwareSites/runAsAccounts`  \n`"
+      "value": "Type: `Microsoft.OffAzure/vmwareSites/runAsAccounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35977,7 +35977,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OffAzure/vmwareSites/vcenters`  \n`"
+      "value": "Type: `Microsoft.OffAzure/vmwareSites/vcenters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -35998,7 +35998,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OpenEnergyPlatform/energyServices`  \n`"
+      "value": "Type: `Microsoft.OpenEnergyPlatform/energyServices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36019,7 +36019,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OperationalInsights/clusters`  \n`"
+      "value": "Type: `Microsoft.OperationalInsights/clusters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36040,7 +36040,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OperationalInsights/queryPacks`  \n`"
+      "value": "Type: `Microsoft.OperationalInsights/queryPacks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36061,7 +36061,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OperationalInsights/queryPacks/queries`  \n`"
+      "value": "Type: `Microsoft.OperationalInsights/queryPacks/queries`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36082,7 +36082,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OperationalInsights/workspaces`  \n`"
+      "value": "Type: `Microsoft.OperationalInsights/workspaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36103,7 +36103,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OperationalInsights/workspaces/dataCollectorLogs`  \n`"
+      "value": "Type: `Microsoft.OperationalInsights/workspaces/dataCollectorLogs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36124,7 +36124,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OperationalInsights/workspaces/dataExports`  \n`"
+      "value": "Type: `Microsoft.OperationalInsights/workspaces/dataExports`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36145,7 +36145,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OperationalInsights/workspaces/dataSources`  \n`"
+      "value": "Type: `Microsoft.OperationalInsights/workspaces/dataSources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36166,7 +36166,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OperationalInsights/workspaces/features/clientGroups`  \n`"
+      "value": "Type: `Microsoft.OperationalInsights/workspaces/features/clientGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36187,7 +36187,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OperationalInsights/workspaces/features/machineGroups`  \n`"
+      "value": "Type: `Microsoft.OperationalInsights/workspaces/features/machineGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36208,7 +36208,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OperationalInsights/workspaces/features/machines`  \n`"
+      "value": "Type: `Microsoft.OperationalInsights/workspaces/features/machines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36229,7 +36229,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OperationalInsights/workspaces/features/machines/ports`  \n`"
+      "value": "Type: `Microsoft.OperationalInsights/workspaces/features/machines/ports`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36250,7 +36250,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OperationalInsights/workspaces/features/machines/processes`  \n`"
+      "value": "Type: `Microsoft.OperationalInsights/workspaces/features/machines/processes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36271,7 +36271,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OperationalInsights/workspaces/features/summaries`  \n`"
+      "value": "Type: `Microsoft.OperationalInsights/workspaces/features/summaries`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36292,7 +36292,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OperationalInsights/workspaces/linkedServices`  \n`"
+      "value": "Type: `Microsoft.OperationalInsights/workspaces/linkedServices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36313,7 +36313,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OperationalInsights/workspaces/linkedStorageAccounts`  \n`"
+      "value": "Type: `Microsoft.OperationalInsights/workspaces/linkedStorageAccounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36334,7 +36334,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OperationalInsights/workspaces/savedSearches`  \n`"
+      "value": "Type: `Microsoft.OperationalInsights/workspaces/savedSearches`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36355,7 +36355,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OperationalInsights/workspaces/storageInsightConfigs`  \n`"
+      "value": "Type: `Microsoft.OperationalInsights/workspaces/storageInsightConfigs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36376,7 +36376,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OperationalInsights/workspaces/tables`  \n`"
+      "value": "Type: `Microsoft.OperationalInsights/workspaces/tables`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36397,7 +36397,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OperationsManagement/ManagementAssociations`  \n`"
+      "value": "Type: `Microsoft.OperationsManagement/ManagementAssociations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36418,7 +36418,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OperationsManagement/ManagementConfigurations`  \n`"
+      "value": "Type: `Microsoft.OperationsManagement/ManagementConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36439,7 +36439,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.OperationsManagement/solutions`  \n`"
+      "value": "Type: `Microsoft.OperationsManagement/solutions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36460,7 +36460,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Orbital/contactProfiles`  \n`"
+      "value": "Type: `Microsoft.Orbital/contactProfiles`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36481,7 +36481,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Orbital/spacecrafts`  \n`"
+      "value": "Type: `Microsoft.Orbital/spacecrafts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36502,7 +36502,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Orbital/spacecrafts/contacts`  \n`"
+      "value": "Type: `Microsoft.Orbital/spacecrafts/contacts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36523,7 +36523,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Peering/peerAsns`  \n`"
+      "value": "Type: `Microsoft.Peering/peerAsns`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36544,7 +36544,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Peering/peeringServices`  \n`"
+      "value": "Type: `Microsoft.Peering/peeringServices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36565,7 +36565,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Peering/peeringServices/connectionMonitorTests`  \n`"
+      "value": "Type: `Microsoft.Peering/peeringServices/connectionMonitorTests`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36586,7 +36586,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Peering/peeringServices/prefixes`  \n`"
+      "value": "Type: `Microsoft.Peering/peeringServices/prefixes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36607,7 +36607,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Peering/peerings`  \n`"
+      "value": "Type: `Microsoft.Peering/peerings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36628,7 +36628,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Peering/peerings/registeredAsns`  \n`"
+      "value": "Type: `Microsoft.Peering/peerings/registeredAsns`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36649,7 +36649,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Peering/peerings/registeredPrefixes`  \n`"
+      "value": "Type: `Microsoft.Peering/peerings/registeredPrefixes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36670,7 +36670,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.PolicyInsights/attestations`  \n`"
+      "value": "Type: `Microsoft.PolicyInsights/attestations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36691,7 +36691,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.PolicyInsights/remediations`  \n`"
+      "value": "Type: `Microsoft.PolicyInsights/remediations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36712,7 +36712,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Portal/consoles`  \n`"
+      "value": "Type: `Microsoft.Portal/consoles`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36733,7 +36733,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Portal/dashboards`  \n`"
+      "value": "Type: `Microsoft.Portal/dashboards`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36754,7 +36754,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Portal/locations/consoles`  \n`"
+      "value": "Type: `Microsoft.Portal/locations/consoles`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36775,7 +36775,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Portal/locations/userSettings`  \n`"
+      "value": "Type: `Microsoft.Portal/locations/userSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36796,7 +36796,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Portal/tenantConfigurations`  \n`"
+      "value": "Type: `Microsoft.Portal/tenantConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36817,7 +36817,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Portal/userSettings`  \n`"
+      "value": "Type: `Microsoft.Portal/userSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36838,7 +36838,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.PowerBI/privateLinkServicesForPowerBI`  \n`"
+      "value": "Type: `Microsoft.PowerBI/privateLinkServicesForPowerBI`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36859,7 +36859,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.PowerBI/privateLinkServicesForPowerBI/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.PowerBI/privateLinkServicesForPowerBI/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36880,7 +36880,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.PowerBI/workspaceCollections`  \n`"
+      "value": "Type: `Microsoft.PowerBI/workspaceCollections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36901,7 +36901,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.PowerBIDedicated/autoScaleVCores`  \n`"
+      "value": "Type: `Microsoft.PowerBIDedicated/autoScaleVCores`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36922,7 +36922,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.PowerBIDedicated/capacities`  \n`"
+      "value": "Type: `Microsoft.PowerBIDedicated/capacities`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36943,7 +36943,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.PowerPlatform/accounts`  \n`"
+      "value": "Type: `Microsoft.PowerPlatform/accounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36964,7 +36964,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.PowerPlatform/enterprisePolicies`  \n`"
+      "value": "Type: `Microsoft.PowerPlatform/enterprisePolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36985,7 +36985,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.PowerPlatform/enterprisePolicies/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.PowerPlatform/enterprisePolicies/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37006,7 +37006,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.PowerPlatform/enterprisePolicies/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.PowerPlatform/enterprisePolicies/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37027,7 +37027,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ProfessionalService/operationResults`  \n`"
+      "value": "Type: `Microsoft.ProfessionalService/operationResults`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37048,7 +37048,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ProfessionalService/resources`  \n`"
+      "value": "Type: `Microsoft.ProfessionalService/resources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37069,7 +37069,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ProviderHub/providerRegistrations`  \n`"
+      "value": "Type: `Microsoft.ProviderHub/providerRegistrations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37090,7 +37090,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ProviderHub/providerRegistrations/customRollouts`  \n`"
+      "value": "Type: `Microsoft.ProviderHub/providerRegistrations/customRollouts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37111,7 +37111,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ProviderHub/providerRegistrations/defaultRollouts`  \n`"
+      "value": "Type: `Microsoft.ProviderHub/providerRegistrations/defaultRollouts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37132,7 +37132,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ProviderHub/providerRegistrations/notificationRegistrations`  \n`"
+      "value": "Type: `Microsoft.ProviderHub/providerRegistrations/notificationRegistrations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37153,7 +37153,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ProviderHub/providerRegistrations/operations`  \n`"
+      "value": "Type: `Microsoft.ProviderHub/providerRegistrations/operations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37174,7 +37174,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ProviderHub/providerRegistrations/resourcetypeRegistrations`  \n`"
+      "value": "Type: `Microsoft.ProviderHub/providerRegistrations/resourcetypeRegistrations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37195,7 +37195,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ProviderHub/providerRegistrations/resourcetypeRegistrations/resourcetypeRegistrations/resourcetypeRegistrations/resourcetypeRegistrations/skus`  \n`"
+      "value": "Type: `Microsoft.ProviderHub/providerRegistrations/resourcetypeRegistrations/resourcetypeRegistrations/resourcetypeRegistrations/resourcetypeRegistrations/skus`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37216,7 +37216,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ProviderHub/providerRegistrations/resourcetypeRegistrations/resourcetypeRegistrations/resourcetypeRegistrations/skus`  \n`"
+      "value": "Type: `Microsoft.ProviderHub/providerRegistrations/resourcetypeRegistrations/resourcetypeRegistrations/resourcetypeRegistrations/skus`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37237,7 +37237,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ProviderHub/providerRegistrations/resourcetypeRegistrations/resourcetypeRegistrations/skus`  \n`"
+      "value": "Type: `Microsoft.ProviderHub/providerRegistrations/resourcetypeRegistrations/resourcetypeRegistrations/skus`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37258,7 +37258,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ProviderHub/providerRegistrations/resourcetypeRegistrations/skus`  \n`"
+      "value": "Type: `Microsoft.ProviderHub/providerRegistrations/resourcetypeRegistrations/skus`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37279,7 +37279,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Purview/accounts`  \n`"
+      "value": "Type: `Microsoft.Purview/accounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37300,7 +37300,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Purview/accounts/kafkaConfigurations`  \n`"
+      "value": "Type: `Microsoft.Purview/accounts/kafkaConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37321,7 +37321,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Purview/accounts/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Purview/accounts/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37342,7 +37342,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Quantum/workspaces`  \n`"
+      "value": "Type: `Microsoft.Quantum/workspaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37363,7 +37363,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Quota/groupQuotas`  \n`"
+      "value": "Type: `Microsoft.Quota/groupQuotas`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37384,7 +37384,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Quota/groupQuotas/groupQuotaLimits`  \n`"
+      "value": "Type: `Microsoft.Quota/groupQuotas/groupQuotaLimits`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37405,7 +37405,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Quota/groupQuotas/quotaAllocations`  \n`"
+      "value": "Type: `Microsoft.Quota/groupQuotas/quotaAllocations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37426,7 +37426,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Quota/groupQuotas/subscriptionRequests`  \n`"
+      "value": "Type: `Microsoft.Quota/groupQuotas/subscriptionRequests`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37447,7 +37447,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Quota/groupQuotas/subscriptions`  \n`"
+      "value": "Type: `Microsoft.Quota/groupQuotas/subscriptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37468,7 +37468,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Quota/quotas`  \n`"
+      "value": "Type: `Microsoft.Quota/quotas`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37489,7 +37489,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Quota/usages`  \n`"
+      "value": "Type: `Microsoft.Quota/usages`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37510,7 +37510,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecommendationsService/accounts`  \n`"
+      "value": "Type: `Microsoft.RecommendationsService/accounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37531,7 +37531,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecommendationsService/accounts/modeling`  \n`"
+      "value": "Type: `Microsoft.RecommendationsService/accounts/modeling`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37552,7 +37552,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecommendationsService/accounts/serviceEndpoints`  \n`"
+      "value": "Type: `Microsoft.RecommendationsService/accounts/serviceEndpoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37573,7 +37573,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37594,7 +37594,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/backupEncryptionConfigs`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/backupEncryptionConfigs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37615,7 +37615,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/backupEngines`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/backupEngines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37636,7 +37636,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/backupFabrics/backupProtectionIntent`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/backupFabrics/backupProtectionIntent`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37657,7 +37657,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37678,7 +37678,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/operationResults`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/operationResults`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37699,7 +37699,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37720,7 +37720,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/operationResults`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/operationResults`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37741,7 +37741,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37762,7 +37762,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/backupJobs`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/backupJobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37783,7 +37783,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/backupPolicies`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/backupPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37804,7 +37804,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/backupPolicies/operationResults`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/backupPolicies/operationResults`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37825,7 +37825,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/backupResourceGuardProxies`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/backupResourceGuardProxies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37846,7 +37846,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/backupconfig`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/backupconfig`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37867,7 +37867,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/backupstorageconfig`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/backupstorageconfig`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37888,7 +37888,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/certificates`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/certificates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37909,7 +37909,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/extendedInformation`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/extendedInformation`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37930,7 +37930,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/operationResults`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/operationResults`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37951,7 +37951,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37972,7 +37972,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationAlertSettings`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationAlertSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -37993,7 +37993,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationEvents`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationEvents`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38014,7 +38014,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38035,7 +38035,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics/replicationLogicalNetworks`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics/replicationLogicalNetworks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38056,7 +38056,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics/replicationNetworks`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics/replicationNetworks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38077,7 +38077,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics/replicationNetworks/replicationNetworkMappings`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics/replicationNetworks/replicationNetworkMappings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38098,7 +38098,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38119,7 +38119,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationMigrationItems`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationMigrationItems`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38140,7 +38140,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationMigrationItems/migrationRecoveryPoints`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationMigrationItems/migrationRecoveryPoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38161,7 +38161,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectableItems`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectableItems`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38182,7 +38182,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38203,7 +38203,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/recoveryPoints`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/recoveryPoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38224,7 +38224,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectionContainerMappings`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectionContainerMappings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38245,7 +38245,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics/replicationRecoveryServicesProviders`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics/replicationRecoveryServicesProviders`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38266,7 +38266,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics/replicationStorageClassifications`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics/replicationStorageClassifications`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38287,7 +38287,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics/replicationStorageClassifications/replicationStorageClassificationMappings`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics/replicationStorageClassifications/replicationStorageClassificationMappings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38308,7 +38308,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics/replicationvCenters`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationFabrics/replicationvCenters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38329,7 +38329,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationJobs`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationJobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38350,7 +38350,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationPolicies`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38371,7 +38371,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationProtectionIntents`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationProtectionIntents`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38392,7 +38392,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationRecoveryPlans`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationRecoveryPlans`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38413,7 +38413,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationVaultSettings`  \n`"
+      "value": "Type: `Microsoft.RecoveryServices/vaults/replicationVaultSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38434,7 +38434,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RedHatOpenShift/openShiftClusters`  \n`"
+      "value": "Type: `Microsoft.RedHatOpenShift/openShiftClusters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38455,7 +38455,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RedHatOpenShift/openshiftclusters/machinePool`  \n`"
+      "value": "Type: `Microsoft.RedHatOpenShift/openshiftclusters/machinePool`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38476,7 +38476,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RedHatOpenShift/openshiftclusters/secret`  \n`"
+      "value": "Type: `Microsoft.RedHatOpenShift/openshiftclusters/secret`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38497,7 +38497,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RedHatOpenShift/openshiftclusters/syncIdentityProvider`  \n`"
+      "value": "Type: `Microsoft.RedHatOpenShift/openshiftclusters/syncIdentityProvider`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38518,7 +38518,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.RedHatOpenShift/openshiftclusters/syncSet`  \n`"
+      "value": "Type: `Microsoft.RedHatOpenShift/openshiftclusters/syncSet`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38539,7 +38539,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Relay/namespaces`  \n`"
+      "value": "Type: `Microsoft.Relay/namespaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38560,7 +38560,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Relay/namespaces/authorizationRules`  \n`"
+      "value": "Type: `Microsoft.Relay/namespaces/authorizationRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38581,7 +38581,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Relay/namespaces/hybridConnections`  \n`"
+      "value": "Type: `Microsoft.Relay/namespaces/hybridConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38602,7 +38602,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Relay/namespaces/hybridConnections/authorizationRules`  \n`"
+      "value": "Type: `Microsoft.Relay/namespaces/hybridConnections/authorizationRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38623,7 +38623,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Relay/namespaces/networkRuleSets`  \n`"
+      "value": "Type: `Microsoft.Relay/namespaces/networkRuleSets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38644,7 +38644,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Relay/namespaces/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Relay/namespaces/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38665,7 +38665,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Relay/namespaces/wcfRelays`  \n`"
+      "value": "Type: `Microsoft.Relay/namespaces/wcfRelays`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38686,7 +38686,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Relay/namespaces/wcfRelays/authorizationRules`  \n`"
+      "value": "Type: `Microsoft.Relay/namespaces/wcfRelays/authorizationRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38707,7 +38707,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ResourceConnector/appliances`  \n`"
+      "value": "Type: `Microsoft.ResourceConnector/appliances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38728,7 +38728,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ResourceGraph/queries`  \n`"
+      "value": "Type: `Microsoft.ResourceGraph/queries`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38749,7 +38749,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ResourceHealth/emergingIssues`  \n`"
+      "value": "Type: `Microsoft.ResourceHealth/emergingIssues`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38770,7 +38770,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ResourceHealth/events`  \n`"
+      "value": "Type: `Microsoft.ResourceHealth/events`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38791,7 +38791,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ResourceHealth/events/impactedResources`  \n`"
+      "value": "Type: `Microsoft.ResourceHealth/events/impactedResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38812,7 +38812,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ResourceHealth/metadata`  \n`"
+      "value": "Type: `Microsoft.ResourceHealth/metadata`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38833,7 +38833,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Resources/builtInTemplateSpecs`  \n`"
+      "value": "Type: `Microsoft.Resources/builtInTemplateSpecs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38854,7 +38854,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Resources/builtInTemplateSpecs/versions`  \n`"
+      "value": "Type: `Microsoft.Resources/builtInTemplateSpecs/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38875,7 +38875,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Resources/changes`  \n`"
+      "value": "Type: `Microsoft.Resources/changes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38896,7 +38896,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Resources/deploymentScripts`  \n`"
+      "value": "Type: `Microsoft.Resources/deploymentScripts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38917,7 +38917,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Resources/deploymentScripts/logs`  \n`"
+      "value": "Type: `Microsoft.Resources/deploymentScripts/logs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38938,7 +38938,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Resources/deploymentStacks`  \n`"
+      "value": "Type: `Microsoft.Resources/deploymentStacks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38959,7 +38959,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Resources/deployments`  \n`"
+      "value": "Type: `Microsoft.Resources/deployments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38980,7 +38980,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Resources/resourceGroups`  \n`"
+      "value": "Type: `Microsoft.Resources/resourceGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39001,7 +39001,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Resources/snapshots`  \n`"
+      "value": "Type: `Microsoft.Resources/snapshots`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39022,7 +39022,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Resources/tags`  \n`"
+      "value": "Type: `Microsoft.Resources/tags`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39043,7 +39043,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Resources/templateSpecs`  \n`"
+      "value": "Type: `Microsoft.Resources/templateSpecs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39064,7 +39064,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Resources/templateSpecs/versions`  \n`"
+      "value": "Type: `Microsoft.Resources/templateSpecs/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39085,7 +39085,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ScVmm/availabilitySets`  \n`"
+      "value": "Type: `Microsoft.ScVmm/availabilitySets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39106,7 +39106,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ScVmm/clouds`  \n`"
+      "value": "Type: `Microsoft.ScVmm/clouds`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39127,7 +39127,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ScVmm/virtualMachineInstances`  \n`"
+      "value": "Type: `Microsoft.ScVmm/virtualMachineInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39148,7 +39148,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ScVmm/virtualMachineInstances/guestAgents`  \n`"
+      "value": "Type: `Microsoft.ScVmm/virtualMachineInstances/guestAgents`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39169,7 +39169,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ScVmm/virtualMachineInstances/hybridIdentityMetadata`  \n`"
+      "value": "Type: `Microsoft.ScVmm/virtualMachineInstances/hybridIdentityMetadata`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39190,7 +39190,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ScVmm/virtualMachineTemplates`  \n`"
+      "value": "Type: `Microsoft.ScVmm/virtualMachineTemplates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39211,7 +39211,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ScVmm/virtualMachines`  \n`"
+      "value": "Type: `Microsoft.ScVmm/virtualMachines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39232,7 +39232,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ScVmm/virtualMachines/extensions`  \n`"
+      "value": "Type: `Microsoft.ScVmm/virtualMachines/extensions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39253,7 +39253,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ScVmm/virtualMachines/guestAgents`  \n`"
+      "value": "Type: `Microsoft.ScVmm/virtualMachines/guestAgents`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39274,7 +39274,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ScVmm/virtualMachines/hybridIdentityMetadata`  \n`"
+      "value": "Type: `Microsoft.ScVmm/virtualMachines/hybridIdentityMetadata`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39295,7 +39295,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ScVmm/virtualNetworks`  \n`"
+      "value": "Type: `Microsoft.ScVmm/virtualNetworks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39316,7 +39316,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ScVmm/vmmServers`  \n`"
+      "value": "Type: `Microsoft.ScVmm/vmmServers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39337,7 +39337,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ScVmm/vmmServers/inventoryItems`  \n`"
+      "value": "Type: `Microsoft.ScVmm/vmmServers/inventoryItems`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39358,7 +39358,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Scheduler/jobCollections`  \n`"
+      "value": "Type: `Microsoft.Scheduler/jobCollections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39379,7 +39379,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Scheduler/jobCollections/jobs`  \n`"
+      "value": "Type: `Microsoft.Scheduler/jobCollections/jobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39400,7 +39400,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Scom/managedInstances`  \n`"
+      "value": "Type: `Microsoft.Scom/managedInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39421,7 +39421,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Scom/managedInstances/managedGateways`  \n`"
+      "value": "Type: `Microsoft.Scom/managedInstances/managedGateways`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39442,7 +39442,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Scom/managedInstances/monitoredResources`  \n`"
+      "value": "Type: `Microsoft.Scom/managedInstances/monitoredResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39463,7 +39463,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Search/searchServices`  \n`"
+      "value": "Type: `Microsoft.Search/searchServices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39484,7 +39484,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Search/searchServices/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Search/searchServices/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39505,7 +39505,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Search/searchServices/sharedPrivateLinkResources`  \n`"
+      "value": "Type: `Microsoft.Search/searchServices/sharedPrivateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39526,7 +39526,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/adaptiveNetworkHardenings`  \n`"
+      "value": "Type: `Microsoft.Security/adaptiveNetworkHardenings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39547,7 +39547,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/advancedThreatProtectionSettings`  \n`"
+      "value": "Type: `Microsoft.Security/advancedThreatProtectionSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39568,7 +39568,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/alertsSuppressionRules`  \n`"
+      "value": "Type: `Microsoft.Security/alertsSuppressionRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39589,7 +39589,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/apiCollections`  \n`"
+      "value": "Type: `Microsoft.Security/apiCollections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39610,7 +39610,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/applications`  \n`"
+      "value": "Type: `Microsoft.Security/applications`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39631,7 +39631,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/assessmentMetadata`  \n`"
+      "value": "Type: `Microsoft.Security/assessmentMetadata`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39652,7 +39652,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/assessments`  \n`"
+      "value": "Type: `Microsoft.Security/assessments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39673,7 +39673,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/assessments/governanceAssignments`  \n`"
+      "value": "Type: `Microsoft.Security/assessments/governanceAssignments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39694,7 +39694,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/assessments/subAssessments`  \n`"
+      "value": "Type: `Microsoft.Security/assessments/subAssessments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39715,7 +39715,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/assignments`  \n`"
+      "value": "Type: `Microsoft.Security/assignments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39736,7 +39736,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/autoProvisioningSettings`  \n`"
+      "value": "Type: `Microsoft.Security/autoProvisioningSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39757,7 +39757,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/automations`  \n`"
+      "value": "Type: `Microsoft.Security/automations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39778,7 +39778,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/complianceResults`  \n`"
+      "value": "Type: `Microsoft.Security/complianceResults`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39799,7 +39799,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/compliances`  \n`"
+      "value": "Type: `Microsoft.Security/compliances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39820,7 +39820,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/connectors`  \n`"
+      "value": "Type: `Microsoft.Security/connectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39841,7 +39841,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/customAssessmentAutomations`  \n`"
+      "value": "Type: `Microsoft.Security/customAssessmentAutomations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39862,7 +39862,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/customEntityStoreAssignments`  \n`"
+      "value": "Type: `Microsoft.Security/customEntityStoreAssignments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39883,7 +39883,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/defenderForStorageSettings`  \n`"
+      "value": "Type: `Microsoft.Security/defenderForStorageSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39904,7 +39904,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/deviceSecurityGroups`  \n`"
+      "value": "Type: `Microsoft.Security/deviceSecurityGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39925,7 +39925,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/governanceRules`  \n`"
+      "value": "Type: `Microsoft.Security/governanceRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39946,7 +39946,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/healthReports`  \n`"
+      "value": "Type: `Microsoft.Security/healthReports`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39967,7 +39967,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/informationProtectionPolicies`  \n`"
+      "value": "Type: `Microsoft.Security/informationProtectionPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39988,7 +39988,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/iotSecuritySolutions`  \n`"
+      "value": "Type: `Microsoft.Security/iotSecuritySolutions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40009,7 +40009,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/iotSecuritySolutions/analyticsModels`  \n`"
+      "value": "Type: `Microsoft.Security/iotSecuritySolutions/analyticsModels`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40030,7 +40030,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/iotSecuritySolutions/analyticsModels/aggregatedAlerts`  \n`"
+      "value": "Type: `Microsoft.Security/iotSecuritySolutions/analyticsModels/aggregatedAlerts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40051,7 +40051,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/iotSecuritySolutions/analyticsModels/aggregatedRecommendations`  \n`"
+      "value": "Type: `Microsoft.Security/iotSecuritySolutions/analyticsModels/aggregatedRecommendations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40072,7 +40072,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/iotSecuritySolutions/iotAlertTypes`  \n`"
+      "value": "Type: `Microsoft.Security/iotSecuritySolutions/iotAlertTypes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40093,7 +40093,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/iotSecuritySolutions/iotAlerts`  \n`"
+      "value": "Type: `Microsoft.Security/iotSecuritySolutions/iotAlerts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40114,7 +40114,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/iotSecuritySolutions/iotRecommendationTypes`  \n`"
+      "value": "Type: `Microsoft.Security/iotSecuritySolutions/iotRecommendationTypes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40135,7 +40135,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/iotSecuritySolutions/iotRecommendations`  \n`"
+      "value": "Type: `Microsoft.Security/iotSecuritySolutions/iotRecommendations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40156,7 +40156,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/locations`  \n`"
+      "value": "Type: `Microsoft.Security/locations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40177,7 +40177,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/locations/ExternalSecuritySolutions`  \n`"
+      "value": "Type: `Microsoft.Security/locations/ExternalSecuritySolutions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40198,7 +40198,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/locations/alerts`  \n`"
+      "value": "Type: `Microsoft.Security/locations/alerts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40219,7 +40219,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/locations/allowedConnections`  \n`"
+      "value": "Type: `Microsoft.Security/locations/allowedConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40240,7 +40240,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/locations/applicationWhitelistings`  \n`"
+      "value": "Type: `Microsoft.Security/locations/applicationWhitelistings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40261,7 +40261,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/locations/discoveredSecuritySolutions`  \n`"
+      "value": "Type: `Microsoft.Security/locations/discoveredSecuritySolutions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40282,7 +40282,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/locations/jitNetworkAccessPolicies`  \n`"
+      "value": "Type: `Microsoft.Security/locations/jitNetworkAccessPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40303,7 +40303,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/locations/securitySolutions`  \n`"
+      "value": "Type: `Microsoft.Security/locations/securitySolutions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40324,7 +40324,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/locations/tasks`  \n`"
+      "value": "Type: `Microsoft.Security/locations/tasks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40345,7 +40345,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/locations/topologies`  \n`"
+      "value": "Type: `Microsoft.Security/locations/topologies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40366,7 +40366,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/mdeOnboardings`  \n`"
+      "value": "Type: `Microsoft.Security/mdeOnboardings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40387,7 +40387,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/pricings`  \n`"
+      "value": "Type: `Microsoft.Security/pricings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40408,7 +40408,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/pricings/securityOperators`  \n`"
+      "value": "Type: `Microsoft.Security/pricings/securityOperators`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40429,7 +40429,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/regulatoryComplianceStandards`  \n`"
+      "value": "Type: `Microsoft.Security/regulatoryComplianceStandards`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40450,7 +40450,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/regulatoryComplianceStandards/regulatoryComplianceControls`  \n`"
+      "value": "Type: `Microsoft.Security/regulatoryComplianceStandards/regulatoryComplianceControls`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40471,7 +40471,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/regulatoryComplianceStandards/regulatoryComplianceControls/regulatoryComplianceAssessments`  \n`"
+      "value": "Type: `Microsoft.Security/regulatoryComplianceStandards/regulatoryComplianceControls/regulatoryComplianceAssessments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40492,7 +40492,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/secureScores`  \n`"
+      "value": "Type: `Microsoft.Security/secureScores`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40513,7 +40513,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/securityConnectors`  \n`"
+      "value": "Type: `Microsoft.Security/securityConnectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40534,7 +40534,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/securityConnectors/devops`  \n`"
+      "value": "Type: `Microsoft.Security/securityConnectors/devops`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40555,7 +40555,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/securityConnectors/devops/azureDevOpsOrgs`  \n`"
+      "value": "Type: `Microsoft.Security/securityConnectors/devops/azureDevOpsOrgs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40576,7 +40576,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/securityConnectors/devops/azureDevOpsOrgs/projects`  \n`"
+      "value": "Type: `Microsoft.Security/securityConnectors/devops/azureDevOpsOrgs/projects`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40597,7 +40597,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/securityConnectors/devops/azureDevOpsOrgs/projects/repos`  \n`"
+      "value": "Type: `Microsoft.Security/securityConnectors/devops/azureDevOpsOrgs/projects/repos`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40618,7 +40618,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/securityConnectors/devops/gitHubOwners`  \n`"
+      "value": "Type: `Microsoft.Security/securityConnectors/devops/gitHubOwners`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40639,7 +40639,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/securityConnectors/devops/gitHubOwners/repos`  \n`"
+      "value": "Type: `Microsoft.Security/securityConnectors/devops/gitHubOwners/repos`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40660,7 +40660,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/securityConnectors/devops/gitLabGroups`  \n`"
+      "value": "Type: `Microsoft.Security/securityConnectors/devops/gitLabGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40681,7 +40681,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/securityConnectors/devops/gitLabGroups/projects`  \n`"
+      "value": "Type: `Microsoft.Security/securityConnectors/devops/gitLabGroups/projects`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40702,7 +40702,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/securityContacts`  \n`"
+      "value": "Type: `Microsoft.Security/securityContacts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40723,7 +40723,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/sensitivitySettings`  \n`"
+      "value": "Type: `Microsoft.Security/sensitivitySettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40744,7 +40744,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/serverVulnerabilityAssessments`  \n`"
+      "value": "Type: `Microsoft.Security/serverVulnerabilityAssessments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40765,7 +40765,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/serverVulnerabilityAssessmentsSettings`  \n`"
+      "value": "Type: `Microsoft.Security/serverVulnerabilityAssessmentsSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40786,7 +40786,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/settings`  \n`"
+      "value": "Type: `Microsoft.Security/settings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40807,7 +40807,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/softwareInventories`  \n`"
+      "value": "Type: `Microsoft.Security/softwareInventories`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40828,7 +40828,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/standards`  \n`"
+      "value": "Type: `Microsoft.Security/standards`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40849,7 +40849,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Security/workspaceSettings`  \n`"
+      "value": "Type: `Microsoft.Security/workspaceSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40870,7 +40870,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForEDMUpload`  \n`"
+      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForEDMUpload`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40891,7 +40891,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForEDMUpload/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForEDMUpload/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40912,7 +40912,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForEDMUpload/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForEDMUpload/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40933,7 +40933,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForM365ComplianceCenter`  \n`"
+      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForM365ComplianceCenter`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40954,7 +40954,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForM365ComplianceCenter/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForM365ComplianceCenter/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40975,7 +40975,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForM365ComplianceCenter/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForM365ComplianceCenter/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40996,7 +40996,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForM365SecurityCenter`  \n`"
+      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForM365SecurityCenter`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41017,7 +41017,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForM365SecurityCenter/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForM365SecurityCenter/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41038,7 +41038,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForM365SecurityCenter/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForM365SecurityCenter/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41059,7 +41059,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForMIPPolicySync`  \n`"
+      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForMIPPolicySync`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41080,7 +41080,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForMIPPolicySync/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForMIPPolicySync/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41101,7 +41101,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForMIPPolicySync/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForMIPPolicySync/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41122,7 +41122,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForO365ManagementActivityAPI`  \n`"
+      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForO365ManagementActivityAPI`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41143,7 +41143,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForO365ManagementActivityAPI/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForO365ManagementActivityAPI/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41164,7 +41164,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForO365ManagementActivityAPI/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForO365ManagementActivityAPI/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41185,7 +41185,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForSCCPowershell`  \n`"
+      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForSCCPowershell`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41206,7 +41206,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForSCCPowershell/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForSCCPowershell/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41227,7 +41227,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForSCCPowershell/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.SecurityAndCompliance/privateLinkServicesForSCCPowershell/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41248,7 +41248,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityDevOps/azureDevOpsConnectors`  \n`"
+      "value": "Type: `Microsoft.SecurityDevOps/azureDevOpsConnectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41269,7 +41269,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityDevOps/azureDevOpsConnectors/orgs`  \n`"
+      "value": "Type: `Microsoft.SecurityDevOps/azureDevOpsConnectors/orgs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41290,7 +41290,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityDevOps/azureDevOpsConnectors/orgs/projects`  \n`"
+      "value": "Type: `Microsoft.SecurityDevOps/azureDevOpsConnectors/orgs/projects`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41311,7 +41311,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityDevOps/azureDevOpsConnectors/orgs/projects/repos`  \n`"
+      "value": "Type: `Microsoft.SecurityDevOps/azureDevOpsConnectors/orgs/projects/repos`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41332,7 +41332,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityDevOps/gitHubConnectors`  \n`"
+      "value": "Type: `Microsoft.SecurityDevOps/gitHubConnectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41353,7 +41353,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityDevOps/gitHubConnectors/owners`  \n`"
+      "value": "Type: `Microsoft.SecurityDevOps/gitHubConnectors/owners`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41374,7 +41374,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityDevOps/gitHubConnectors/owners/repos`  \n`"
+      "value": "Type: `Microsoft.SecurityDevOps/gitHubConnectors/owners/repos`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41395,7 +41395,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/aggregations`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/aggregations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41416,7 +41416,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/alertRuleTemplates`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/alertRuleTemplates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41437,7 +41437,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/alertRules`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/alertRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41458,7 +41458,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/alertRules/actions`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/alertRules/actions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41479,7 +41479,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/automationRules`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/automationRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41500,7 +41500,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/billingStatistics`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/billingStatistics`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41521,7 +41521,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/bookmarks`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/bookmarks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41542,7 +41542,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/bookmarks/relations`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/bookmarks/relations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41563,7 +41563,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/cases`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/cases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41584,7 +41584,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/cases/comments`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/cases/comments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41605,7 +41605,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/cases/relations`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/cases/relations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41626,7 +41626,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/contentPackages`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/contentPackages`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41647,7 +41647,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/contentProductPackages`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/contentProductPackages`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41668,7 +41668,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/contentTemplates`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/contentTemplates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41689,7 +41689,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/contentproducttemplates`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/contentproducttemplates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41710,7 +41710,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/dataConnectorDefinitions`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/dataConnectorDefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41731,7 +41731,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/dataConnectors`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/dataConnectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41752,7 +41752,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/entities`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/entities`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41773,7 +41773,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/entities/relations`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/entities/relations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41794,7 +41794,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/entityQueries`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/entityQueries`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41815,7 +41815,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/entityQueryTemplates`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/entityQueryTemplates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41836,7 +41836,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/fileImports`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/fileImports`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41857,7 +41857,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/hunts`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/hunts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41878,7 +41878,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/hunts/comments`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/hunts/comments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41899,7 +41899,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/hunts/relations`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/hunts/relations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41920,7 +41920,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/incidents`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/incidents`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41941,7 +41941,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/incidents/comments`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/incidents/comments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41962,7 +41962,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/incidents/relations`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/incidents/relations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41983,7 +41983,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/incidents/tasks`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/incidents/tasks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42004,7 +42004,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/metadata`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/metadata`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42025,7 +42025,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/officeConsents`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/officeConsents`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42046,7 +42046,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/onboardingStates`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/onboardingStates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42067,7 +42067,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/securityMLAnalyticsSettings`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/securityMLAnalyticsSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42088,7 +42088,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/settings`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/settings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42109,7 +42109,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/sourcecontrols`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/sourcecontrols`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42130,7 +42130,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/threatIntelligence/indicators`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/threatIntelligence/indicators`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42151,7 +42151,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/triggeredAnalyticsRuleRuns`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/triggeredAnalyticsRuleRuns`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42172,7 +42172,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/watchlists`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/watchlists`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42193,7 +42193,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/watchlists/watchlistItems`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/watchlists/watchlistItems`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42214,7 +42214,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/workspaceManagerAssignments`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/workspaceManagerAssignments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42235,7 +42235,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/workspaceManagerAssignments/jobs`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/workspaceManagerAssignments/jobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42256,7 +42256,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/workspaceManagerConfigurations`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/workspaceManagerConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42277,7 +42277,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/workspaceManagerGroups`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/workspaceManagerGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42298,7 +42298,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SecurityInsights/workspaceManagerMembers`  \n`"
+      "value": "Type: `Microsoft.SecurityInsights/workspaceManagerMembers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42319,7 +42319,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SerialConsole/serialPorts`  \n`"
+      "value": "Type: `Microsoft.SerialConsole/serialPorts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42340,7 +42340,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceBus/namespaces`  \n`"
+      "value": "Type: `Microsoft.ServiceBus/namespaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42361,7 +42361,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceBus/namespaces/AuthorizationRules`  \n`"
+      "value": "Type: `Microsoft.ServiceBus/namespaces/AuthorizationRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42382,7 +42382,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceBus/namespaces/disasterRecoveryConfigs`  \n`"
+      "value": "Type: `Microsoft.ServiceBus/namespaces/disasterRecoveryConfigs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42403,7 +42403,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceBus/namespaces/disasterRecoveryConfigs/authorizationRules`  \n`"
+      "value": "Type: `Microsoft.ServiceBus/namespaces/disasterRecoveryConfigs/authorizationRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42424,7 +42424,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceBus/namespaces/ipfilterrules`  \n`"
+      "value": "Type: `Microsoft.ServiceBus/namespaces/ipfilterrules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42445,7 +42445,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceBus/namespaces/migrationConfigurations`  \n`"
+      "value": "Type: `Microsoft.ServiceBus/namespaces/migrationConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42466,7 +42466,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceBus/namespaces/networkRuleSets`  \n`"
+      "value": "Type: `Microsoft.ServiceBus/namespaces/networkRuleSets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42487,7 +42487,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceBus/namespaces/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.ServiceBus/namespaces/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42508,7 +42508,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceBus/namespaces/queues`  \n`"
+      "value": "Type: `Microsoft.ServiceBus/namespaces/queues`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42529,7 +42529,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceBus/namespaces/queues/authorizationRules`  \n`"
+      "value": "Type: `Microsoft.ServiceBus/namespaces/queues/authorizationRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42550,7 +42550,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceBus/namespaces/topics`  \n`"
+      "value": "Type: `Microsoft.ServiceBus/namespaces/topics`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42571,7 +42571,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceBus/namespaces/topics/authorizationRules`  \n`"
+      "value": "Type: `Microsoft.ServiceBus/namespaces/topics/authorizationRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42592,7 +42592,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceBus/namespaces/topics/subscriptions`  \n`"
+      "value": "Type: `Microsoft.ServiceBus/namespaces/topics/subscriptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42613,7 +42613,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceBus/namespaces/topics/subscriptions/rules`  \n`"
+      "value": "Type: `Microsoft.ServiceBus/namespaces/topics/subscriptions/rules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42634,7 +42634,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceBus/namespaces/virtualnetworkrules`  \n`"
+      "value": "Type: `Microsoft.ServiceBus/namespaces/virtualnetworkrules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42655,7 +42655,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceFabric/clusters`  \n`"
+      "value": "Type: `Microsoft.ServiceFabric/clusters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42676,7 +42676,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceFabric/clusters/applicationTypes`  \n`"
+      "value": "Type: `Microsoft.ServiceFabric/clusters/applicationTypes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42697,7 +42697,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceFabric/clusters/applicationTypes/versions`  \n`"
+      "value": "Type: `Microsoft.ServiceFabric/clusters/applicationTypes/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42718,7 +42718,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceFabric/clusters/applications`  \n`"
+      "value": "Type: `Microsoft.ServiceFabric/clusters/applications`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42739,7 +42739,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceFabric/clusters/applications/services`  \n`"
+      "value": "Type: `Microsoft.ServiceFabric/clusters/applications/services`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42760,7 +42760,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceFabric/managedClusters`  \n`"
+      "value": "Type: `Microsoft.ServiceFabric/managedClusters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42781,7 +42781,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceFabric/managedClusters/nodeTypes`  \n`"
+      "value": "Type: `Microsoft.ServiceFabric/managedClusters/nodeTypes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42802,7 +42802,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceFabric/managedclusters/applicationTypes`  \n`"
+      "value": "Type: `Microsoft.ServiceFabric/managedclusters/applicationTypes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42823,7 +42823,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceFabric/managedclusters/applicationTypes/versions`  \n`"
+      "value": "Type: `Microsoft.ServiceFabric/managedclusters/applicationTypes/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42844,7 +42844,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceFabric/managedclusters/applications`  \n`"
+      "value": "Type: `Microsoft.ServiceFabric/managedclusters/applications`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42865,7 +42865,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceFabric/managedclusters/applications/services`  \n`"
+      "value": "Type: `Microsoft.ServiceFabric/managedclusters/applications/services`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42886,7 +42886,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceFabricMesh/applications`  \n`"
+      "value": "Type: `Microsoft.ServiceFabricMesh/applications`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42907,7 +42907,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceFabricMesh/applications/services`  \n`"
+      "value": "Type: `Microsoft.ServiceFabricMesh/applications/services`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42928,7 +42928,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceFabricMesh/gateways`  \n`"
+      "value": "Type: `Microsoft.ServiceFabricMesh/gateways`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42949,7 +42949,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceFabricMesh/networks`  \n`"
+      "value": "Type: `Microsoft.ServiceFabricMesh/networks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42970,7 +42970,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceFabricMesh/secrets`  \n`"
+      "value": "Type: `Microsoft.ServiceFabricMesh/secrets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42991,7 +42991,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceFabricMesh/secrets/values`  \n`"
+      "value": "Type: `Microsoft.ServiceFabricMesh/secrets/values`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43012,7 +43012,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceFabricMesh/volumes`  \n`"
+      "value": "Type: `Microsoft.ServiceFabricMesh/volumes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43033,7 +43033,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceLinker/dryruns`  \n`"
+      "value": "Type: `Microsoft.ServiceLinker/dryruns`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43054,7 +43054,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceLinker/linkers`  \n`"
+      "value": "Type: `Microsoft.ServiceLinker/linkers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43075,7 +43075,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceLinker/locations/connectors`  \n`"
+      "value": "Type: `Microsoft.ServiceLinker/locations/connectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43096,7 +43096,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceLinker/locations/dryruns`  \n`"
+      "value": "Type: `Microsoft.ServiceLinker/locations/dryruns`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43117,7 +43117,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceNetworking/trafficControllers`  \n`"
+      "value": "Type: `Microsoft.ServiceNetworking/trafficControllers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43138,7 +43138,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceNetworking/trafficControllers/associations`  \n`"
+      "value": "Type: `Microsoft.ServiceNetworking/trafficControllers/associations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43159,7 +43159,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.ServiceNetworking/trafficControllers/frontends`  \n`"
+      "value": "Type: `Microsoft.ServiceNetworking/trafficControllers/frontends`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43180,7 +43180,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SignalRService/signalR`  \n`"
+      "value": "Type: `Microsoft.SignalRService/signalR`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43201,7 +43201,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SignalRService/signalR/customCertificates`  \n`"
+      "value": "Type: `Microsoft.SignalRService/signalR/customCertificates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43222,7 +43222,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SignalRService/signalR/customDomains`  \n`"
+      "value": "Type: `Microsoft.SignalRService/signalR/customDomains`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43243,7 +43243,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SignalRService/signalR/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.SignalRService/signalR/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43264,7 +43264,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SignalRService/signalR/replicas`  \n`"
+      "value": "Type: `Microsoft.SignalRService/signalR/replicas`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43285,7 +43285,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SignalRService/signalR/sharedPrivateLinkResources`  \n`"
+      "value": "Type: `Microsoft.SignalRService/signalR/sharedPrivateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43306,7 +43306,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SignalRService/webPubSub`  \n`"
+      "value": "Type: `Microsoft.SignalRService/webPubSub`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43327,7 +43327,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SignalRService/webPubSub/customCertificates`  \n`"
+      "value": "Type: `Microsoft.SignalRService/webPubSub/customCertificates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43348,7 +43348,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SignalRService/webPubSub/customDomains`  \n`"
+      "value": "Type: `Microsoft.SignalRService/webPubSub/customDomains`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43369,7 +43369,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SignalRService/webPubSub/hubs`  \n`"
+      "value": "Type: `Microsoft.SignalRService/webPubSub/hubs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43390,7 +43390,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SignalRService/webPubSub/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.SignalRService/webPubSub/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43411,7 +43411,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SignalRService/webPubSub/replicas`  \n`"
+      "value": "Type: `Microsoft.SignalRService/webPubSub/replicas`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43432,7 +43432,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SignalRService/webPubSub/sharedPrivateLinkResources`  \n`"
+      "value": "Type: `Microsoft.SignalRService/webPubSub/sharedPrivateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43453,7 +43453,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SoftwarePlan/hybridUseBenefits`  \n`"
+      "value": "Type: `Microsoft.SoftwarePlan/hybridUseBenefits`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43474,7 +43474,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Solutions/applianceDefinitions`  \n`"
+      "value": "Type: `Microsoft.Solutions/applianceDefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43495,7 +43495,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Solutions/appliances`  \n`"
+      "value": "Type: `Microsoft.Solutions/appliances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43516,7 +43516,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Solutions/applicationDefinitions`  \n`"
+      "value": "Type: `Microsoft.Solutions/applicationDefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43537,7 +43537,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Solutions/applications`  \n`"
+      "value": "Type: `Microsoft.Solutions/applications`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43558,7 +43558,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Solutions/jitRequests`  \n`"
+      "value": "Type: `Microsoft.Solutions/jitRequests`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43579,7 +43579,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/instancePools`  \n`"
+      "value": "Type: `Microsoft.Sql/instancePools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43600,7 +43600,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/locations/deletedServers`  \n`"
+      "value": "Type: `Microsoft.Sql/locations/deletedServers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43621,7 +43621,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/locations/instanceFailoverGroups`  \n`"
+      "value": "Type: `Microsoft.Sql/locations/instanceFailoverGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43642,7 +43642,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/locations/longTermRetentionManagedInstances/longTermRetentionDatabases/longTermRetentionManagedInstanceBackups`  \n`"
+      "value": "Type: `Microsoft.Sql/locations/longTermRetentionManagedInstances/longTermRetentionDatabases/longTermRetentionManagedInstanceBackups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43663,7 +43663,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/locations/longTermRetentionServers/longTermRetentionDatabases/longTermRetentionBackups`  \n`"
+      "value": "Type: `Microsoft.Sql/locations/longTermRetentionServers/longTermRetentionDatabases/longTermRetentionBackups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43684,7 +43684,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/locations/managedDatabaseMoveOperationResults`  \n`"
+      "value": "Type: `Microsoft.Sql/locations/managedDatabaseMoveOperationResults`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43705,7 +43705,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/locations/serverTrustGroups`  \n`"
+      "value": "Type: `Microsoft.Sql/locations/serverTrustGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43726,7 +43726,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/locations/timeZones`  \n`"
+      "value": "Type: `Microsoft.Sql/locations/timeZones`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43747,7 +43747,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/locations/usages`  \n`"
+      "value": "Type: `Microsoft.Sql/locations/usages`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43768,7 +43768,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43789,7 +43789,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/administrators`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/administrators`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43810,7 +43810,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/advancedThreatProtectionSettings`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/advancedThreatProtectionSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43831,7 +43831,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/azureADOnlyAuthentications`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/azureADOnlyAuthentications`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43852,7 +43852,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/databases`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/databases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43873,7 +43873,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/databases/advancedThreatProtectionSettings`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/databases/advancedThreatProtectionSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43894,7 +43894,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/databases/backupLongTermRetentionPolicies`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/databases/backupLongTermRetentionPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43915,7 +43915,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/databases/backupShortTermRetentionPolicies`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/databases/backupShortTermRetentionPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43936,7 +43936,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/databases/ledgerDigestUploads`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/databases/ledgerDigestUploads`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43957,7 +43957,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/databases/queries`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/databases/queries`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43978,7 +43978,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/databases/restoreDetails`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/databases/restoreDetails`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43999,7 +43999,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/databases/schemas`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/databases/schemas`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44020,7 +44020,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/databases/schemas/tables`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/databases/schemas/tables`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44041,7 +44041,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/databases/schemas/tables/columns`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/databases/schemas/tables/columns`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44062,7 +44062,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/databases/schemas/tables/columns/sensitivityLabels`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/databases/schemas/tables/columns/sensitivityLabels`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44083,7 +44083,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/databases/securityAlertPolicies`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/databases/securityAlertPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44104,7 +44104,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/databases/transparentDataEncryption`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/databases/transparentDataEncryption`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44125,7 +44125,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/databases/vulnerabilityAssessments`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/databases/vulnerabilityAssessments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44146,7 +44146,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/databases/vulnerabilityAssessments/rules/baselines`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/databases/vulnerabilityAssessments/rules/baselines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44167,7 +44167,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/databases/vulnerabilityAssessments/scans`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/databases/vulnerabilityAssessments/scans`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44188,7 +44188,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/distributedAvailabilityGroups`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/distributedAvailabilityGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44209,7 +44209,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/dnsAliases`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/dnsAliases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44230,7 +44230,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/dtc`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/dtc`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44251,7 +44251,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/encryptionProtector`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/encryptionProtector`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44272,7 +44272,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/endpointCertificates`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/endpointCertificates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44293,7 +44293,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/keys`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/keys`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44314,7 +44314,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/operations`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/operations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44335,7 +44335,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44356,7 +44356,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44377,7 +44377,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/recoverableDatabases`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/recoverableDatabases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44398,7 +44398,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/restorableDroppedDatabases`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/restorableDroppedDatabases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44419,7 +44419,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/restorableDroppedDatabases/backupShortTermRetentionPolicies`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/restorableDroppedDatabases/backupShortTermRetentionPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44440,7 +44440,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/securityAlertPolicies`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/securityAlertPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44461,7 +44461,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/serverConfigurationOptions`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/serverConfigurationOptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44482,7 +44482,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/serverTrustCertificates`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/serverTrustCertificates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44503,7 +44503,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/sqlAgent`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/sqlAgent`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44524,7 +44524,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/startStopSchedules`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/startStopSchedules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44545,7 +44545,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/managedInstances/vulnerabilityAssessments`  \n`"
+      "value": "Type: `Microsoft.Sql/managedInstances/vulnerabilityAssessments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44566,7 +44566,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers`  \n`"
+      "value": "Type: `Microsoft.Sql/servers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44587,7 +44587,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/administrators`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/administrators`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44608,7 +44608,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/advancedThreatProtectionSettings`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/advancedThreatProtectionSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44629,7 +44629,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/advisors`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/advisors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44650,7 +44650,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/auditingPolicies`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/auditingPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44671,7 +44671,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/auditingSettings`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/auditingSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44692,7 +44692,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/automaticTuning`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/automaticTuning`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44713,7 +44713,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/azureADOnlyAuthentications`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/azureADOnlyAuthentications`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44734,7 +44734,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/communicationLinks`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/communicationLinks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44755,7 +44755,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/connectionPolicies`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/connectionPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44776,7 +44776,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44797,7 +44797,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/advancedThreatProtectionSettings`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/advancedThreatProtectionSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44818,7 +44818,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/advisors`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/advisors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44839,7 +44839,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/advisors/recommendedActions`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/advisors/recommendedActions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44860,7 +44860,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/auditingPolicies`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/auditingPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44881,7 +44881,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/auditingSettings`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/auditingSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44902,7 +44902,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/automaticTuning`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/automaticTuning`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44923,7 +44923,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44944,7 +44944,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44965,7 +44965,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/connectionPolicies`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/connectionPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -44986,7 +44986,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/dataMaskingPolicies`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/dataMaskingPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45007,7 +45007,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/dataMaskingPolicies/rules`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/dataMaskingPolicies/rules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45028,7 +45028,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/dataWarehouseUserActivities`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/dataWarehouseUserActivities`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45049,7 +45049,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/extendedAuditingSettings`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/extendedAuditingSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45070,7 +45070,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/extensions`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/extensions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45091,7 +45091,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/geoBackupPolicies`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/geoBackupPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45112,7 +45112,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/ledgerDigestUploads`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/ledgerDigestUploads`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45133,7 +45133,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/replicationLinks`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/replicationLinks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45154,7 +45154,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/restorePoints`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/restorePoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45175,7 +45175,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/schemas`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/schemas`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45196,7 +45196,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/schemas/tables`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/schemas/tables`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45217,7 +45217,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/schemas/tables/columns`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/schemas/tables/columns`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45238,7 +45238,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/schemas/tables/columns/sensitivityLabels`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/schemas/tables/columns/sensitivityLabels`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45259,7 +45259,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/securityAlertPolicies`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/securityAlertPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45280,7 +45280,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/serviceTierAdvisors`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/serviceTierAdvisors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45301,7 +45301,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/sqlVulnerabilityAssessments`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/sqlVulnerabilityAssessments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45322,7 +45322,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/sqlVulnerabilityAssessments/baselines`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/sqlVulnerabilityAssessments/baselines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45343,7 +45343,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/sqlVulnerabilityAssessments/baselines/rules`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/sqlVulnerabilityAssessments/baselines/rules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45364,7 +45364,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/sqlVulnerabilityAssessments/scans`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/sqlVulnerabilityAssessments/scans`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45385,7 +45385,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/sqlVulnerabilityAssessments/scans/scanResults`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/sqlVulnerabilityAssessments/scans/scanResults`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45406,7 +45406,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/syncGroups`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/syncGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45427,7 +45427,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/syncGroups/syncMembers`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/syncGroups/syncMembers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45448,7 +45448,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/transparentDataEncryption`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/transparentDataEncryption`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45469,7 +45469,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/vulnerabilityAssessments`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/vulnerabilityAssessments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45490,7 +45490,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/vulnerabilityAssessments/rules/baselines`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/vulnerabilityAssessments/rules/baselines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45511,7 +45511,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/vulnerabilityAssessments/scans`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/vulnerabilityAssessments/scans`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45532,7 +45532,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/workloadGroups`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/workloadGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45553,7 +45553,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/databases/workloadGroups/workloadClassifiers`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/databases/workloadGroups/workloadClassifiers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45574,7 +45574,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/devOpsAuditingSettings`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/devOpsAuditingSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45595,7 +45595,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/disasterRecoveryConfiguration`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/disasterRecoveryConfiguration`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45616,7 +45616,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/dnsAliases`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/dnsAliases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45637,7 +45637,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/elasticPools`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/elasticPools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45658,7 +45658,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/elasticPools/databases`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/elasticPools/databases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45679,7 +45679,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/encryptionProtector`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/encryptionProtector`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45700,7 +45700,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/extendedAuditingSettings`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/extendedAuditingSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45721,7 +45721,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/failoverGroups`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/failoverGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45742,7 +45742,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/firewallRules`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/firewallRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45763,7 +45763,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/ipv6FirewallRules`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/ipv6FirewallRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45784,7 +45784,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/jobAgents`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/jobAgents`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45805,7 +45805,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/jobAgents/credentials`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/jobAgents/credentials`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45826,7 +45826,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/jobAgents/jobs`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/jobAgents/jobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45847,7 +45847,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/jobAgents/jobs/executions`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/jobAgents/jobs/executions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45868,7 +45868,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/jobAgents/jobs/executions/steps`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/jobAgents/jobs/executions/steps`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45889,7 +45889,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/jobAgents/jobs/executions/steps/targets`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/jobAgents/jobs/executions/steps/targets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45910,7 +45910,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/jobAgents/jobs/steps`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/jobAgents/jobs/steps`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45931,7 +45931,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/jobAgents/jobs/versions`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/jobAgents/jobs/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45952,7 +45952,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/jobAgents/jobs/versions/steps`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/jobAgents/jobs/versions/steps`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45973,7 +45973,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/jobAgents/privateEndpoints`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/jobAgents/privateEndpoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45994,7 +45994,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/jobAgents/targetGroups`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/jobAgents/targetGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46015,7 +46015,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/keys`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/keys`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46036,7 +46036,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/networkSecurityPerimeterConfigurations`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/networkSecurityPerimeterConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46057,7 +46057,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/outboundFirewallRules`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/outboundFirewallRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46078,7 +46078,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46099,7 +46099,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46120,7 +46120,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/recommendedElasticPools`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/recommendedElasticPools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46141,7 +46141,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/recommendedElasticPools/databases`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/recommendedElasticPools/databases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46162,7 +46162,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/recoverableDatabases`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/recoverableDatabases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46183,7 +46183,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/restorableDroppedDatabases`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/restorableDroppedDatabases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46204,7 +46204,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/securityAlertPolicies`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/securityAlertPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46225,7 +46225,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/serviceObjectives`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/serviceObjectives`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46246,7 +46246,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/sqlVulnerabilityAssessments`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/sqlVulnerabilityAssessments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46267,7 +46267,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/syncAgents`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/syncAgents`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46288,7 +46288,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/virtualNetworkRules`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/virtualNetworkRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46309,7 +46309,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/servers/vulnerabilityAssessments`  \n`"
+      "value": "Type: `Microsoft.Sql/servers/vulnerabilityAssessments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46330,7 +46330,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Sql/virtualClusters`  \n`"
+      "value": "Type: `Microsoft.Sql/virtualClusters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46351,7 +46351,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SqlVirtualMachine/sqlVirtualMachineGroups`  \n`"
+      "value": "Type: `Microsoft.SqlVirtualMachine/sqlVirtualMachineGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46372,7 +46372,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SqlVirtualMachine/sqlVirtualMachineGroups/availabilityGroupListeners`  \n`"
+      "value": "Type: `Microsoft.SqlVirtualMachine/sqlVirtualMachineGroups/availabilityGroupListeners`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46393,7 +46393,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.SqlVirtualMachine/sqlVirtualMachines`  \n`"
+      "value": "Type: `Microsoft.SqlVirtualMachine/sqlVirtualMachines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46414,7 +46414,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorSimple/managers`  \n`"
+      "value": "Type: `Microsoft.StorSimple/managers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46435,7 +46435,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorSimple/managers/accessControlRecords`  \n`"
+      "value": "Type: `Microsoft.StorSimple/managers/accessControlRecords`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46456,7 +46456,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorSimple/managers/bandwidthSettings`  \n`"
+      "value": "Type: `Microsoft.StorSimple/managers/bandwidthSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46477,7 +46477,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorSimple/managers/certificates`  \n`"
+      "value": "Type: `Microsoft.StorSimple/managers/certificates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46498,7 +46498,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorSimple/managers/devices/alertSettings`  \n`"
+      "value": "Type: `Microsoft.StorSimple/managers/devices/alertSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46519,7 +46519,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorSimple/managers/devices/backupPolicies`  \n`"
+      "value": "Type: `Microsoft.StorSimple/managers/devices/backupPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46540,7 +46540,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorSimple/managers/devices/backupPolicies/schedules`  \n`"
+      "value": "Type: `Microsoft.StorSimple/managers/devices/backupPolicies/schedules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46561,7 +46561,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorSimple/managers/devices/backupScheduleGroups`  \n`"
+      "value": "Type: `Microsoft.StorSimple/managers/devices/backupScheduleGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46582,7 +46582,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorSimple/managers/devices/chapSettings`  \n`"
+      "value": "Type: `Microsoft.StorSimple/managers/devices/chapSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46603,7 +46603,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorSimple/managers/devices/fileservers`  \n`"
+      "value": "Type: `Microsoft.StorSimple/managers/devices/fileservers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46624,7 +46624,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorSimple/managers/devices/fileservers/shares`  \n`"
+      "value": "Type: `Microsoft.StorSimple/managers/devices/fileservers/shares`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46645,7 +46645,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorSimple/managers/devices/iscsiservers`  \n`"
+      "value": "Type: `Microsoft.StorSimple/managers/devices/iscsiservers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46666,7 +46666,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorSimple/managers/devices/iscsiservers/disks`  \n`"
+      "value": "Type: `Microsoft.StorSimple/managers/devices/iscsiservers/disks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46687,7 +46687,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorSimple/managers/devices/timeSettings`  \n`"
+      "value": "Type: `Microsoft.StorSimple/managers/devices/timeSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46708,7 +46708,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorSimple/managers/devices/volumeContainers`  \n`"
+      "value": "Type: `Microsoft.StorSimple/managers/devices/volumeContainers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46729,7 +46729,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorSimple/managers/devices/volumeContainers/volumes`  \n`"
+      "value": "Type: `Microsoft.StorSimple/managers/devices/volumeContainers/volumes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46750,7 +46750,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorSimple/managers/extendedInformation`  \n`"
+      "value": "Type: `Microsoft.StorSimple/managers/extendedInformation`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46771,7 +46771,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorSimple/managers/storageAccountCredentials`  \n`"
+      "value": "Type: `Microsoft.StorSimple/managers/storageAccountCredentials`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46792,7 +46792,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorSimple/managers/storageDomains`  \n`"
+      "value": "Type: `Microsoft.StorSimple/managers/storageDomains`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46813,7 +46813,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage.Admin/locations/quotas`  \n`"
+      "value": "Type: `Microsoft.Storage.Admin/locations/quotas`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46834,7 +46834,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage.Admin/locations/storageAccounts`  \n`"
+      "value": "Type: `Microsoft.Storage.Admin/locations/storageAccounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46855,7 +46855,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage.Admin/storageServices`  \n`"
+      "value": "Type: `Microsoft.Storage.Admin/storageServices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46876,7 +46876,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/locations/deletedAccounts`  \n`"
+      "value": "Type: `Microsoft.Storage/locations/deletedAccounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46897,7 +46897,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts`  \n`"
+      "value": "Type: `Microsoft.Storage/storageAccounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46918,7 +46918,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts/blobServices`  \n`"
+      "value": "Type: `Microsoft.Storage/storageAccounts/blobServices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46939,7 +46939,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts/blobServices/containers`  \n`"
+      "value": "Type: `Microsoft.Storage/storageAccounts/blobServices/containers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46960,7 +46960,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies`  \n`"
+      "value": "Type: `Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46981,7 +46981,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts/encryptionScopes`  \n`"
+      "value": "Type: `Microsoft.Storage/storageAccounts/encryptionScopes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47002,7 +47002,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts/fileServices`  \n`"
+      "value": "Type: `Microsoft.Storage/storageAccounts/fileServices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47023,7 +47023,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts/fileServices/shares`  \n`"
+      "value": "Type: `Microsoft.Storage/storageAccounts/fileServices/shares`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47044,7 +47044,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts/inventoryPolicies`  \n`"
+      "value": "Type: `Microsoft.Storage/storageAccounts/inventoryPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47065,7 +47065,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts/localUsers`  \n`"
+      "value": "Type: `Microsoft.Storage/storageAccounts/localUsers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47086,7 +47086,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts/managementPolicies`  \n`"
+      "value": "Type: `Microsoft.Storage/storageAccounts/managementPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47107,7 +47107,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts/objectReplicationPolicies`  \n`"
+      "value": "Type: `Microsoft.Storage/storageAccounts/objectReplicationPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47128,7 +47128,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Storage/storageAccounts/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47149,7 +47149,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts/queueServices`  \n`"
+      "value": "Type: `Microsoft.Storage/storageAccounts/queueServices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47170,7 +47170,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts/queueServices/queues`  \n`"
+      "value": "Type: `Microsoft.Storage/storageAccounts/queueServices/queues`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47191,7 +47191,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts/tableServices`  \n`"
+      "value": "Type: `Microsoft.Storage/storageAccounts/tableServices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47212,7 +47212,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts/tableServices/tables`  \n`"
+      "value": "Type: `Microsoft.Storage/storageAccounts/tableServices/tables`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47233,7 +47233,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorageActions/storageTasks`  \n`"
+      "value": "Type: `Microsoft.StorageActions/storageTasks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47254,7 +47254,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorageCache/amlFilesystems`  \n`"
+      "value": "Type: `Microsoft.StorageCache/amlFilesystems`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47275,7 +47275,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorageCache/caches`  \n`"
+      "value": "Type: `Microsoft.StorageCache/caches`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47296,7 +47296,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorageCache/caches/storageTargets`  \n`"
+      "value": "Type: `Microsoft.StorageCache/caches/storageTargets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47317,7 +47317,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorageMover/storageMovers`  \n`"
+      "value": "Type: `Microsoft.StorageMover/storageMovers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47338,7 +47338,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorageMover/storageMovers/agents`  \n`"
+      "value": "Type: `Microsoft.StorageMover/storageMovers/agents`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47359,7 +47359,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorageMover/storageMovers/endpoints`  \n`"
+      "value": "Type: `Microsoft.StorageMover/storageMovers/endpoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47380,7 +47380,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorageMover/storageMovers/projects`  \n`"
+      "value": "Type: `Microsoft.StorageMover/storageMovers/projects`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47401,7 +47401,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorageMover/storageMovers/projects/jobDefinitions`  \n`"
+      "value": "Type: `Microsoft.StorageMover/storageMovers/projects/jobDefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47422,7 +47422,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorageMover/storageMovers/projects/jobDefinitions/jobRuns`  \n`"
+      "value": "Type: `Microsoft.StorageMover/storageMovers/projects/jobDefinitions/jobRuns`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47443,7 +47443,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StoragePool/diskPools`  \n`"
+      "value": "Type: `Microsoft.StoragePool/diskPools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47464,7 +47464,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StoragePool/diskPools/iscsiTargets`  \n`"
+      "value": "Type: `Microsoft.StoragePool/diskPools/iscsiTargets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47485,7 +47485,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorageSync/storageSyncServices`  \n`"
+      "value": "Type: `Microsoft.StorageSync/storageSyncServices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47506,7 +47506,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorageSync/storageSyncServices/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.StorageSync/storageSyncServices/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47527,7 +47527,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorageSync/storageSyncServices/registeredServers`  \n`"
+      "value": "Type: `Microsoft.StorageSync/storageSyncServices/registeredServers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47548,7 +47548,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorageSync/storageSyncServices/syncGroups`  \n`"
+      "value": "Type: `Microsoft.StorageSync/storageSyncServices/syncGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47569,7 +47569,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorageSync/storageSyncServices/syncGroups/cloudEndpoints`  \n`"
+      "value": "Type: `Microsoft.StorageSync/storageSyncServices/syncGroups/cloudEndpoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47590,7 +47590,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorageSync/storageSyncServices/syncGroups/serverEndpoints`  \n`"
+      "value": "Type: `Microsoft.StorageSync/storageSyncServices/syncGroups/serverEndpoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47611,7 +47611,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorageSync/storageSyncServices/workflows`  \n`"
+      "value": "Type: `Microsoft.StorageSync/storageSyncServices/workflows`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47632,7 +47632,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StorageTasks/storageTasks`  \n`"
+      "value": "Type: `Microsoft.StorageTasks/storageTasks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47653,7 +47653,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StreamAnalytics/clusters`  \n`"
+      "value": "Type: `Microsoft.StreamAnalytics/clusters`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47674,7 +47674,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StreamAnalytics/clusters/privateEndpoints`  \n`"
+      "value": "Type: `Microsoft.StreamAnalytics/clusters/privateEndpoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47695,7 +47695,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StreamAnalytics/streamingjobs`  \n`"
+      "value": "Type: `Microsoft.StreamAnalytics/streamingjobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47716,7 +47716,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StreamAnalytics/streamingjobs/functions`  \n`"
+      "value": "Type: `Microsoft.StreamAnalytics/streamingjobs/functions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47737,7 +47737,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StreamAnalytics/streamingjobs/inputs`  \n`"
+      "value": "Type: `Microsoft.StreamAnalytics/streamingjobs/inputs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47758,7 +47758,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StreamAnalytics/streamingjobs/outputs`  \n`"
+      "value": "Type: `Microsoft.StreamAnalytics/streamingjobs/outputs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47779,7 +47779,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.StreamAnalytics/streamingjobs/transformations`  \n`"
+      "value": "Type: `Microsoft.StreamAnalytics/streamingjobs/transformations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47800,7 +47800,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Subscription/aliases`  \n`"
+      "value": "Type: `Microsoft.Subscription/aliases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47821,7 +47821,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Subscription/policies`  \n`"
+      "value": "Type: `Microsoft.Subscription/policies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47842,7 +47842,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Subscription/subscriptionDefinitions`  \n`"
+      "value": "Type: `Microsoft.Subscription/subscriptionDefinitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47863,7 +47863,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Subscription/subscriptionOperations`  \n`"
+      "value": "Type: `Microsoft.Subscription/subscriptionOperations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47884,7 +47884,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Subscriptions.Admin/delegatedProviders`  \n`"
+      "value": "Type: `Microsoft.Subscriptions.Admin/delegatedProviders`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47905,7 +47905,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Subscriptions.Admin/delegatedProviders/offers`  \n`"
+      "value": "Type: `Microsoft.Subscriptions.Admin/delegatedProviders/offers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47926,7 +47926,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Subscriptions.Admin/directoryTenants`  \n`"
+      "value": "Type: `Microsoft.Subscriptions.Admin/directoryTenants`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47947,7 +47947,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Subscriptions.Admin/locations`  \n`"
+      "value": "Type: `Microsoft.Subscriptions.Admin/locations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47968,7 +47968,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Subscriptions.Admin/locations/quotas`  \n`"
+      "value": "Type: `Microsoft.Subscriptions.Admin/locations/quotas`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -47989,7 +47989,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Subscriptions.Admin/offers`  \n`"
+      "value": "Type: `Microsoft.Subscriptions.Admin/offers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48010,7 +48010,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Subscriptions.Admin/offers/offerDelegations`  \n`"
+      "value": "Type: `Microsoft.Subscriptions.Admin/offers/offerDelegations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48031,7 +48031,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Subscriptions.Admin/plans`  \n`"
+      "value": "Type: `Microsoft.Subscriptions.Admin/plans`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48052,7 +48052,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Subscriptions.Admin/subscriptions`  \n`"
+      "value": "Type: `Microsoft.Subscriptions.Admin/subscriptions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48073,7 +48073,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Subscriptions.Admin/subscriptions/acquiredPlans`  \n`"
+      "value": "Type: `Microsoft.Subscriptions.Admin/subscriptions/acquiredPlans`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48094,7 +48094,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Support/fileWorkspaces`  \n`"
+      "value": "Type: `Microsoft.Support/fileWorkspaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48115,7 +48115,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Support/fileWorkspaces/files`  \n`"
+      "value": "Type: `Microsoft.Support/fileWorkspaces/files`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48136,7 +48136,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Support/supportTickets`  \n`"
+      "value": "Type: `Microsoft.Support/supportTickets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48157,7 +48157,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Support/supportTickets/chatTranscripts`  \n`"
+      "value": "Type: `Microsoft.Support/supportTickets/chatTranscripts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48178,7 +48178,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Support/supportTickets/communications`  \n`"
+      "value": "Type: `Microsoft.Support/supportTickets/communications`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48199,7 +48199,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/privateLinkHubs`  \n`"
+      "value": "Type: `Microsoft.Synapse/privateLinkHubs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48220,7 +48220,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/privateLinkHubs/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.Synapse/privateLinkHubs/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48241,7 +48241,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48262,7 +48262,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/administrators`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/administrators`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48283,7 +48283,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/auditingSettings`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/auditingSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48304,7 +48304,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/azureADOnlyAuthentications`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/azureADOnlyAuthentications`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48325,7 +48325,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/bigDataPools`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/bigDataPools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48346,7 +48346,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/dedicatedSQLminimalTlsSettings`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/dedicatedSQLminimalTlsSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48367,7 +48367,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/encryptionProtector`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/encryptionProtector`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48388,7 +48388,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/extendedAuditingSettings`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/extendedAuditingSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48409,7 +48409,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/firewallRules`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/firewallRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48430,7 +48430,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/integrationRuntimes`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/integrationRuntimes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48451,7 +48451,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/keys`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/keys`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48472,7 +48472,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/kustoPools`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/kustoPools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48493,7 +48493,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/kustoPools/attachedDatabaseConfigurations`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/kustoPools/attachedDatabaseConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48514,7 +48514,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/kustoPools/databases`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/kustoPools/databases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48535,7 +48535,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/kustoPools/databases/dataConnections`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/kustoPools/databases/dataConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48556,7 +48556,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/kustoPools/databases/principalAssignments`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/kustoPools/databases/principalAssignments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48577,7 +48577,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/kustoPools/principalAssignments`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/kustoPools/principalAssignments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48598,7 +48598,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/libraries`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/libraries`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48619,7 +48619,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/managedIdentitySqlControlSettings`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/managedIdentitySqlControlSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48640,7 +48640,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48661,7 +48661,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/privateLinkResources`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48682,7 +48682,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/recoverableSqlPools`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/recoverableSqlPools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48703,7 +48703,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/restorableDroppedSqlPools`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/restorableDroppedSqlPools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48724,7 +48724,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/securityAlertPolicies`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/securityAlertPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48745,7 +48745,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/sparkconfigurations`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/sparkconfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48766,7 +48766,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/sqlAdministrators`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/sqlAdministrators`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48787,7 +48787,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/sqlDatabases`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/sqlDatabases`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48808,7 +48808,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48829,7 +48829,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/auditingSettings`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/auditingSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48850,7 +48850,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/connectionPolicies`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/connectionPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48871,7 +48871,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/dataMaskingPolicies`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/dataMaskingPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48892,7 +48892,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/dataMaskingPolicies/rules`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/dataMaskingPolicies/rules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48913,7 +48913,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/dataWarehouseUserActivities`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/dataWarehouseUserActivities`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48934,7 +48934,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/extendedAuditingSettings`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/extendedAuditingSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48955,7 +48955,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/geoBackupPolicies`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/geoBackupPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48976,7 +48976,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/metadataSync`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/metadataSync`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -48997,7 +48997,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/operationResults`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/operationResults`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49018,7 +49018,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/replicationLinks`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/replicationLinks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49039,7 +49039,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/restorePoints`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/restorePoints`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49060,7 +49060,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/schemas`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/schemas`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49081,7 +49081,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/schemas/tables`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/schemas/tables`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49102,7 +49102,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/schemas/tables/columns`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/schemas/tables/columns`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49123,7 +49123,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/schemas/tables/columns/sensitivityLabels`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/schemas/tables/columns/sensitivityLabels`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49144,7 +49144,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/securityAlertPolicies`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/securityAlertPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49165,7 +49165,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/transparentDataEncryption`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/transparentDataEncryption`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49186,7 +49186,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/vulnerabilityAssessments`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/vulnerabilityAssessments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49207,7 +49207,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/vulnerabilityAssessments/rules/baselines`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/vulnerabilityAssessments/rules/baselines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49228,7 +49228,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/vulnerabilityAssessments/scans`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/vulnerabilityAssessments/scans`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49249,7 +49249,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/workloadGroups`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/workloadGroups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49270,7 +49270,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/workloadGroups/workloadClassifiers`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/sqlPools/workloadGroups/workloadClassifiers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49291,7 +49291,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/trustedServiceByPassConfiguration`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/trustedServiceByPassConfiguration`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49312,7 +49312,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Synapse/workspaces/vulnerabilityAssessments`  \n`"
+      "value": "Type: `Microsoft.Synapse/workspaces/vulnerabilityAssessments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49333,7 +49333,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Syntex/documentProcessors`  \n`"
+      "value": "Type: `Microsoft.Syntex/documentProcessors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49354,7 +49354,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.TestBase/testBaseAccounts`  \n`"
+      "value": "Type: `Microsoft.TestBase/testBaseAccounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49375,7 +49375,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.TestBase/testBaseAccounts/availableOSs`  \n`"
+      "value": "Type: `Microsoft.TestBase/testBaseAccounts/availableOSs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49396,7 +49396,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.TestBase/testBaseAccounts/customerEvents`  \n`"
+      "value": "Type: `Microsoft.TestBase/testBaseAccounts/customerEvents`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49417,7 +49417,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.TestBase/testBaseAccounts/emailEvents`  \n`"
+      "value": "Type: `Microsoft.TestBase/testBaseAccounts/emailEvents`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49438,7 +49438,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.TestBase/testBaseAccounts/flightingRings`  \n`"
+      "value": "Type: `Microsoft.TestBase/testBaseAccounts/flightingRings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49459,7 +49459,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.TestBase/testBaseAccounts/packages`  \n`"
+      "value": "Type: `Microsoft.TestBase/testBaseAccounts/packages`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49480,7 +49480,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.TestBase/testBaseAccounts/packages/favoriteProcesses`  \n`"
+      "value": "Type: `Microsoft.TestBase/testBaseAccounts/packages/favoriteProcesses`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49501,7 +49501,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.TestBase/testBaseAccounts/packages/osUpdates`  \n`"
+      "value": "Type: `Microsoft.TestBase/testBaseAccounts/packages/osUpdates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49522,7 +49522,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.TestBase/testBaseAccounts/packages/testResults`  \n`"
+      "value": "Type: `Microsoft.TestBase/testBaseAccounts/packages/testResults`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49543,7 +49543,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.TestBase/testBaseAccounts/packages/testResults/analysisResults`  \n`"
+      "value": "Type: `Microsoft.TestBase/testBaseAccounts/packages/testResults/analysisResults`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49564,7 +49564,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.TestBase/testBaseAccounts/testSummaries`  \n`"
+      "value": "Type: `Microsoft.TestBase/testBaseAccounts/testSummaries`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49585,7 +49585,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.TestBase/testBaseAccounts/testTypes`  \n`"
+      "value": "Type: `Microsoft.TestBase/testBaseAccounts/testTypes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49606,7 +49606,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.TimeSeriesInsights/environments`  \n`"
+      "value": "Type: `Microsoft.TimeSeriesInsights/environments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49627,7 +49627,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.TimeSeriesInsights/environments/accessPolicies`  \n`"
+      "value": "Type: `Microsoft.TimeSeriesInsights/environments/accessPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49648,7 +49648,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.TimeSeriesInsights/environments/eventSources`  \n`"
+      "value": "Type: `Microsoft.TimeSeriesInsights/environments/eventSources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49669,7 +49669,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.TimeSeriesInsights/environments/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.TimeSeriesInsights/environments/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49690,7 +49690,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.TimeSeriesInsights/environments/referenceDataSets`  \n`"
+      "value": "Type: `Microsoft.TimeSeriesInsights/environments/referenceDataSets`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49711,7 +49711,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Update.Admin/updateLocations`  \n`"
+      "value": "Type: `Microsoft.Update.Admin/updateLocations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49732,7 +49732,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Update.Admin/updateLocations/updateRuns`  \n`"
+      "value": "Type: `Microsoft.Update.Admin/updateLocations/updateRuns`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49753,7 +49753,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Update.Admin/updateLocations/updates`  \n`"
+      "value": "Type: `Microsoft.Update.Admin/updateLocations/updates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49774,7 +49774,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Update.Admin/updateLocations/updates/updateRuns`  \n`"
+      "value": "Type: `Microsoft.Update.Admin/updateLocations/updates/updateRuns`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49795,7 +49795,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.VMwareCloudSimple/dedicatedCloudNodes`  \n`"
+      "value": "Type: `Microsoft.VMwareCloudSimple/dedicatedCloudNodes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49816,7 +49816,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.VMwareCloudSimple/dedicatedCloudServices`  \n`"
+      "value": "Type: `Microsoft.VMwareCloudSimple/dedicatedCloudServices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49837,7 +49837,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.VMwareCloudSimple/virtualMachines`  \n`"
+      "value": "Type: `Microsoft.VMwareCloudSimple/virtualMachines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49858,7 +49858,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.VideoIndexer/accounts`  \n`"
+      "value": "Type: `Microsoft.VideoIndexer/accounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49879,7 +49879,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.VirtualMachineImages/imageTemplates`  \n`"
+      "value": "Type: `Microsoft.VirtualMachineImages/imageTemplates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49900,7 +49900,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.VirtualMachineImages/imageTemplates/runOutputs`  \n`"
+      "value": "Type: `Microsoft.VirtualMachineImages/imageTemplates/runOutputs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49921,7 +49921,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.VirtualMachineImages/imageTemplates/triggers`  \n`"
+      "value": "Type: `Microsoft.VirtualMachineImages/imageTemplates/triggers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49942,7 +49942,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.VoiceServices/communicationsGateways`  \n`"
+      "value": "Type: `Microsoft.VoiceServices/communicationsGateways`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49963,7 +49963,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.VoiceServices/communicationsGateways/contacts`  \n`"
+      "value": "Type: `Microsoft.VoiceServices/communicationsGateways/contacts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -49984,7 +49984,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.VoiceServices/communicationsGateways/testLines`  \n`"
+      "value": "Type: `Microsoft.VoiceServices/communicationsGateways/testLines`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50005,7 +50005,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/certificates`  \n`"
+      "value": "Type: `Microsoft.Web/certificates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50026,7 +50026,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/classicMobileServices`  \n`"
+      "value": "Type: `Microsoft.Web/classicMobileServices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50047,7 +50047,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/connectionGateways`  \n`"
+      "value": "Type: `Microsoft.Web/connectionGateways`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50068,7 +50068,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/connections`  \n`"
+      "value": "Type: `Microsoft.Web/connections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50089,7 +50089,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/containerApps`  \n`"
+      "value": "Type: `Microsoft.Web/containerApps`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50110,7 +50110,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/containerApps/revisions`  \n`"
+      "value": "Type: `Microsoft.Web/containerApps/revisions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50131,7 +50131,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/csrs`  \n`"
+      "value": "Type: `Microsoft.Web/csrs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50152,7 +50152,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/customApis`  \n`"
+      "value": "Type: `Microsoft.Web/customApis`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50173,7 +50173,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/deletedSites`  \n`"
+      "value": "Type: `Microsoft.Web/deletedSites`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50194,7 +50194,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/hostingEnvironments`  \n`"
+      "value": "Type: `Microsoft.Web/hostingEnvironments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50215,7 +50215,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/hostingEnvironments/capacities`  \n`"
+      "value": "Type: `Microsoft.Web/hostingEnvironments/capacities`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50236,7 +50236,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/hostingEnvironments/configurations`  \n`"
+      "value": "Type: `Microsoft.Web/hostingEnvironments/configurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50257,7 +50257,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/hostingEnvironments/detectors`  \n`"
+      "value": "Type: `Microsoft.Web/hostingEnvironments/detectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50278,7 +50278,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/hostingEnvironments/multiRolePools`  \n`"
+      "value": "Type: `Microsoft.Web/hostingEnvironments/multiRolePools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50299,7 +50299,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/hostingEnvironments/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Web/hostingEnvironments/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50320,7 +50320,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/hostingEnvironments/recommendations`  \n`"
+      "value": "Type: `Microsoft.Web/hostingEnvironments/recommendations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50341,7 +50341,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/hostingEnvironments/workerPools`  \n`"
+      "value": "Type: `Microsoft.Web/hostingEnvironments/workerPools`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50362,7 +50362,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/kubeEnvironments`  \n`"
+      "value": "Type: `Microsoft.Web/kubeEnvironments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50383,7 +50383,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/locations/connectionGatewayInstallations`  \n`"
+      "value": "Type: `Microsoft.Web/locations/connectionGatewayInstallations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50404,7 +50404,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/locations/deletedSites`  \n`"
+      "value": "Type: `Microsoft.Web/locations/deletedSites`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50425,7 +50425,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/locations/managedApis`  \n`"
+      "value": "Type: `Microsoft.Web/locations/managedApis`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50446,7 +50446,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/managedHostingEnvironments`  \n`"
+      "value": "Type: `Microsoft.Web/managedHostingEnvironments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50467,7 +50467,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/publishingUsers`  \n`"
+      "value": "Type: `Microsoft.Web/publishingUsers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50488,7 +50488,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/serverfarms`  \n`"
+      "value": "Type: `Microsoft.Web/serverfarms`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50509,7 +50509,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/serverfarms/hybridConnectionNamespaces/relays`  \n`"
+      "value": "Type: `Microsoft.Web/serverfarms/hybridConnectionNamespaces/relays`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50530,7 +50530,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/serverfarms/hybridConnectionPlanLimits`  \n`"
+      "value": "Type: `Microsoft.Web/serverfarms/hybridConnectionPlanLimits`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50551,7 +50551,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/serverfarms/operationresults`  \n`"
+      "value": "Type: `Microsoft.Web/serverfarms/operationresults`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50572,7 +50572,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/serverfarms/virtualNetworkConnections`  \n`"
+      "value": "Type: `Microsoft.Web/serverfarms/virtualNetworkConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50593,7 +50593,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/serverfarms/virtualNetworkConnections/gateways`  \n`"
+      "value": "Type: `Microsoft.Web/serverfarms/virtualNetworkConnections/gateways`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50614,7 +50614,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/serverfarms/virtualNetworkConnections/routes`  \n`"
+      "value": "Type: `Microsoft.Web/serverfarms/virtualNetworkConnections/routes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50635,7 +50635,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites`  \n`"
+      "value": "Type: `Microsoft.Web/sites`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50656,7 +50656,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/backups`  \n`"
+      "value": "Type: `Microsoft.Web/sites/backups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50677,7 +50677,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/basicPublishingCredentialsPolicies`  \n`"
+      "value": "Type: `Microsoft.Web/sites/basicPublishingCredentialsPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50698,7 +50698,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/config`  \n`"
+      "value": "Type: `Microsoft.Web/sites/config`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50719,7 +50719,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/config/appsettings`  \n`"
+      "value": "Type: `Microsoft.Web/sites/config/appsettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50740,7 +50740,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/config/connectionstrings`  \n`"
+      "value": "Type: `Microsoft.Web/sites/config/connectionstrings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50761,7 +50761,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/config/snapshots`  \n`"
+      "value": "Type: `Microsoft.Web/sites/config/snapshots`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50782,7 +50782,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/continuouswebjobs`  \n`"
+      "value": "Type: `Microsoft.Web/sites/continuouswebjobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50803,7 +50803,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/deploymentStatus`  \n`"
+      "value": "Type: `Microsoft.Web/sites/deploymentStatus`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50824,7 +50824,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/deployments`  \n`"
+      "value": "Type: `Microsoft.Web/sites/deployments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50845,7 +50845,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/detectors`  \n`"
+      "value": "Type: `Microsoft.Web/sites/detectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50866,7 +50866,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/diagnostics`  \n`"
+      "value": "Type: `Microsoft.Web/sites/diagnostics`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50887,7 +50887,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/diagnostics/analyses`  \n`"
+      "value": "Type: `Microsoft.Web/sites/diagnostics/analyses`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50908,7 +50908,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/diagnostics/detectors`  \n`"
+      "value": "Type: `Microsoft.Web/sites/diagnostics/detectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50929,7 +50929,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/domainOwnershipIdentifiers`  \n`"
+      "value": "Type: `Microsoft.Web/sites/domainOwnershipIdentifiers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50950,7 +50950,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/extensions`  \n`"
+      "value": "Type: `Microsoft.Web/sites/extensions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50971,7 +50971,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/functions`  \n`"
+      "value": "Type: `Microsoft.Web/sites/functions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -50992,7 +50992,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/functions/keys`  \n`"
+      "value": "Type: `Microsoft.Web/sites/functions/keys`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51013,7 +51013,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/hostNameBindings`  \n`"
+      "value": "Type: `Microsoft.Web/sites/hostNameBindings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51034,7 +51034,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/hostruntime/webhooks/api/workflows/runs`  \n`"
+      "value": "Type: `Microsoft.Web/sites/hostruntime/webhooks/api/workflows/runs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51055,7 +51055,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/hostruntime/webhooks/api/workflows/runs/actions`  \n`"
+      "value": "Type: `Microsoft.Web/sites/hostruntime/webhooks/api/workflows/runs/actions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51076,7 +51076,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/hostruntime/webhooks/api/workflows/runs/actions/repetitions`  \n`"
+      "value": "Type: `Microsoft.Web/sites/hostruntime/webhooks/api/workflows/runs/actions/repetitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51097,7 +51097,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/hostruntime/webhooks/api/workflows/runs/actions/repetitions/requestHistories`  \n`"
+      "value": "Type: `Microsoft.Web/sites/hostruntime/webhooks/api/workflows/runs/actions/repetitions/requestHistories`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51118,7 +51118,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/hostruntime/webhooks/api/workflows/runs/actions/scopeRepetitions`  \n`"
+      "value": "Type: `Microsoft.Web/sites/hostruntime/webhooks/api/workflows/runs/actions/scopeRepetitions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51139,7 +51139,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/hostruntime/webhooks/api/workflows/triggers`  \n`"
+      "value": "Type: `Microsoft.Web/sites/hostruntime/webhooks/api/workflows/triggers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51160,7 +51160,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/hostruntime/webhooks/api/workflows/triggers/histories`  \n`"
+      "value": "Type: `Microsoft.Web/sites/hostruntime/webhooks/api/workflows/triggers/histories`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51181,7 +51181,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/hostruntime/webhooks/api/workflows/versions`  \n`"
+      "value": "Type: `Microsoft.Web/sites/hostruntime/webhooks/api/workflows/versions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51202,7 +51202,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/hybridConnectionNamespaces/relays`  \n`"
+      "value": "Type: `Microsoft.Web/sites/hybridConnectionNamespaces/relays`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51223,7 +51223,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/hybridconnection`  \n`"
+      "value": "Type: `Microsoft.Web/sites/hybridconnection`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51244,7 +51244,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/instances`  \n`"
+      "value": "Type: `Microsoft.Web/sites/instances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51265,7 +51265,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/instances/deployments`  \n`"
+      "value": "Type: `Microsoft.Web/sites/instances/deployments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51286,7 +51286,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/instances/extensions`  \n`"
+      "value": "Type: `Microsoft.Web/sites/instances/extensions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51307,7 +51307,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/instances/processes`  \n`"
+      "value": "Type: `Microsoft.Web/sites/instances/processes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51328,7 +51328,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/instances/processes/modules`  \n`"
+      "value": "Type: `Microsoft.Web/sites/instances/processes/modules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51349,7 +51349,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/instances/processes/threads`  \n`"
+      "value": "Type: `Microsoft.Web/sites/instances/processes/threads`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51370,7 +51370,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/migratemysql`  \n`"
+      "value": "Type: `Microsoft.Web/sites/migratemysql`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51391,7 +51391,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/networkConfig`  \n`"
+      "value": "Type: `Microsoft.Web/sites/networkConfig`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51412,7 +51412,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/networkFeatures`  \n`"
+      "value": "Type: `Microsoft.Web/sites/networkFeatures`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51433,7 +51433,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/premieraddons`  \n`"
+      "value": "Type: `Microsoft.Web/sites/premieraddons`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51454,7 +51454,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/privateAccess`  \n`"
+      "value": "Type: `Microsoft.Web/sites/privateAccess`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51475,7 +51475,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Web/sites/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51496,7 +51496,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/processes`  \n`"
+      "value": "Type: `Microsoft.Web/sites/processes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51517,7 +51517,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/processes/modules`  \n`"
+      "value": "Type: `Microsoft.Web/sites/processes/modules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51538,7 +51538,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/processes/threads`  \n`"
+      "value": "Type: `Microsoft.Web/sites/processes/threads`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51559,7 +51559,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/publicCertificates`  \n`"
+      "value": "Type: `Microsoft.Web/sites/publicCertificates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51580,7 +51580,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/recommendations`  \n`"
+      "value": "Type: `Microsoft.Web/sites/recommendations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51601,7 +51601,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/resourceHealthMetadata`  \n`"
+      "value": "Type: `Microsoft.Web/sites/resourceHealthMetadata`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51622,7 +51622,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/siteextensions`  \n`"
+      "value": "Type: `Microsoft.Web/sites/siteextensions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51643,7 +51643,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51664,7 +51664,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/backups`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/backups`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51685,7 +51685,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51706,7 +51706,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/config`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/config`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51727,7 +51727,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/config/appsettings`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/config/appsettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51748,7 +51748,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/config/connectionstrings`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/config/connectionstrings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51769,7 +51769,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/config/snapshots`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/config/snapshots`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51790,7 +51790,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/continuouswebjobs`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/continuouswebjobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51811,7 +51811,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/deploymentStatus`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/deploymentStatus`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51832,7 +51832,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/deployments`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/deployments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51853,7 +51853,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/detectors`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/detectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51874,7 +51874,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/diagnostics`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/diagnostics`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51895,7 +51895,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/diagnostics/analyses`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/diagnostics/analyses`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51916,7 +51916,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/diagnostics/detectors`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/diagnostics/detectors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51937,7 +51937,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/domainOwnershipIdentifiers`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/domainOwnershipIdentifiers`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51958,7 +51958,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/extensions`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/extensions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -51979,7 +51979,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/functions`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/functions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52000,7 +52000,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/functions/keys`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/functions/keys`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52021,7 +52021,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/hostNameBindings`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/hostNameBindings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52042,7 +52042,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/hybridConnectionNamespaces/relays`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/hybridConnectionNamespaces/relays`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52063,7 +52063,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/hybridconnection`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/hybridconnection`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52084,7 +52084,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/instances`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/instances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52105,7 +52105,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/instances/deployments`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/instances/deployments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52126,7 +52126,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/instances/extensions`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/instances/extensions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52147,7 +52147,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/instances/processes`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/instances/processes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52168,7 +52168,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/instances/processes/modules`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/instances/processes/modules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52189,7 +52189,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/instances/processes/threads`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/instances/processes/threads`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52210,7 +52210,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/migratemysql`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/migratemysql`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52231,7 +52231,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/networkConfig`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/networkConfig`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52252,7 +52252,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/networkFeatures`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/networkFeatures`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52273,7 +52273,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/premieraddons`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/premieraddons`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52294,7 +52294,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/privateAccess`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/privateAccess`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52315,7 +52315,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52336,7 +52336,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/processes`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/processes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52357,7 +52357,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/processes/modules`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/processes/modules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52378,7 +52378,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/processes/threads`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/processes/threads`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52399,7 +52399,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/publicCertificates`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/publicCertificates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52420,7 +52420,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/resourceHealthMetadata`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/resourceHealthMetadata`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52441,7 +52441,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/siteextensions`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/siteextensions`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52462,7 +52462,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/sourcecontrols`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/sourcecontrols`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52483,7 +52483,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/triggeredwebjobs`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/triggeredwebjobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52504,7 +52504,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/triggeredwebjobs/history`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/triggeredwebjobs/history`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52525,7 +52525,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/virtualNetworkConnections`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/virtualNetworkConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52546,7 +52546,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/virtualNetworkConnections/gateways`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/virtualNetworkConnections/gateways`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52567,7 +52567,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/slots/webjobs`  \n`"
+      "value": "Type: `Microsoft.Web/sites/slots/webjobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52588,7 +52588,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/sourcecontrols`  \n`"
+      "value": "Type: `Microsoft.Web/sites/sourcecontrols`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52609,7 +52609,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/triggeredwebjobs`  \n`"
+      "value": "Type: `Microsoft.Web/sites/triggeredwebjobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52630,7 +52630,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/triggeredwebjobs/history`  \n`"
+      "value": "Type: `Microsoft.Web/sites/triggeredwebjobs/history`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52651,7 +52651,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/virtualNetworkConnections`  \n`"
+      "value": "Type: `Microsoft.Web/sites/virtualNetworkConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52672,7 +52672,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/virtualNetworkConnections/gateways`  \n`"
+      "value": "Type: `Microsoft.Web/sites/virtualNetworkConnections/gateways`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52693,7 +52693,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sites/webjobs`  \n`"
+      "value": "Type: `Microsoft.Web/sites/webjobs`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52714,7 +52714,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/sourcecontrols`  \n`"
+      "value": "Type: `Microsoft.Web/sourcecontrols`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52735,7 +52735,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/staticSites`  \n`"
+      "value": "Type: `Microsoft.Web/staticSites`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52756,7 +52756,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/staticSites/basicAuth`  \n`"
+      "value": "Type: `Microsoft.Web/staticSites/basicAuth`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52777,7 +52777,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/staticSites/builds`  \n`"
+      "value": "Type: `Microsoft.Web/staticSites/builds`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52798,7 +52798,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/staticSites/builds/config`  \n`"
+      "value": "Type: `Microsoft.Web/staticSites/builds/config`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52819,7 +52819,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/staticSites/builds/databaseConnections`  \n`"
+      "value": "Type: `Microsoft.Web/staticSites/builds/databaseConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52840,7 +52840,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/staticSites/builds/linkedBackends`  \n`"
+      "value": "Type: `Microsoft.Web/staticSites/builds/linkedBackends`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52861,7 +52861,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/staticSites/builds/userProvidedFunctionApps`  \n`"
+      "value": "Type: `Microsoft.Web/staticSites/builds/userProvidedFunctionApps`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52882,7 +52882,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/staticSites/config`  \n`"
+      "value": "Type: `Microsoft.Web/staticSites/config`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52903,7 +52903,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/staticSites/customDomains`  \n`"
+      "value": "Type: `Microsoft.Web/staticSites/customDomains`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52924,7 +52924,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/staticSites/databaseConnections`  \n`"
+      "value": "Type: `Microsoft.Web/staticSites/databaseConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52945,7 +52945,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/staticSites/linkedBackends`  \n`"
+      "value": "Type: `Microsoft.Web/staticSites/linkedBackends`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52966,7 +52966,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/staticSites/privateEndpointConnections`  \n`"
+      "value": "Type: `Microsoft.Web/staticSites/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52987,7 +52987,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Web/staticSites/userProvidedFunctionApps`  \n`"
+      "value": "Type: `Microsoft.Web/staticSites/userProvidedFunctionApps`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53008,7 +53008,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.WindowsESU/multipleActivationKeys`  \n`"
+      "value": "Type: `Microsoft.WindowsESU/multipleActivationKeys`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53029,7 +53029,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.WindowsIoT/deviceServices`  \n`"
+      "value": "Type: `Microsoft.WindowsIoT/deviceServices`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53050,7 +53050,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.WorkloadMonitor/components`  \n`"
+      "value": "Type: `Microsoft.WorkloadMonitor/components`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53071,7 +53071,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.WorkloadMonitor/monitorInstances`  \n`"
+      "value": "Type: `Microsoft.WorkloadMonitor/monitorInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53092,7 +53092,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.WorkloadMonitor/monitors`  \n`"
+      "value": "Type: `Microsoft.WorkloadMonitor/monitors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53113,7 +53113,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.WorkloadMonitor/monitors/history`  \n`"
+      "value": "Type: `Microsoft.WorkloadMonitor/monitors/history`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53134,7 +53134,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.WorkloadMonitor/notificationSettings`  \n`"
+      "value": "Type: `Microsoft.WorkloadMonitor/notificationSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53155,7 +53155,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Workloads/monitors`  \n`"
+      "value": "Type: `Microsoft.Workloads/monitors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53176,7 +53176,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Workloads/monitors/providerInstances`  \n`"
+      "value": "Type: `Microsoft.Workloads/monitors/providerInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53197,7 +53197,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Workloads/monitors/sapLandscapeMonitor`  \n`"
+      "value": "Type: `Microsoft.Workloads/monitors/sapLandscapeMonitor`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53218,7 +53218,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Workloads/phpWorkloads`  \n`"
+      "value": "Type: `Microsoft.Workloads/phpWorkloads`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53239,7 +53239,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Workloads/phpWorkloads/wordpressInstances`  \n`"
+      "value": "Type: `Microsoft.Workloads/phpWorkloads/wordpressInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53260,7 +53260,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Workloads/sapVirtualInstances`  \n`"
+      "value": "Type: `Microsoft.Workloads/sapVirtualInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53281,7 +53281,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Workloads/sapVirtualInstances/applicationInstances`  \n`"
+      "value": "Type: `Microsoft.Workloads/sapVirtualInstances/applicationInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53302,7 +53302,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Workloads/sapVirtualInstances/centralInstances`  \n`"
+      "value": "Type: `Microsoft.Workloads/sapVirtualInstances/centralInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53323,7 +53323,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Workloads/sapVirtualInstances/databaseInstances`  \n`"
+      "value": "Type: `Microsoft.Workloads/sapVirtualInstances/databaseInstances`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53344,7 +53344,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `NewRelic.Observability/monitors`  \n`"
+      "value": "Type: `NewRelic.Observability/monitors`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53365,7 +53365,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `NewRelic.Observability/monitors/tagRules`  \n`"
+      "value": "Type: `NewRelic.Observability/monitors/tagRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53386,7 +53386,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Nginx.NginxPlus/nginxDeployments`  \n`"
+      "value": "Type: `Nginx.NginxPlus/nginxDeployments`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53407,7 +53407,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Nginx.NginxPlus/nginxDeployments/certificates`  \n`"
+      "value": "Type: `Nginx.NginxPlus/nginxDeployments/certificates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53428,7 +53428,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Nginx.NginxPlus/nginxDeployments/configurations`  \n`"
+      "value": "Type: `Nginx.NginxPlus/nginxDeployments/configurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53449,7 +53449,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `PaloAltoNetworks.Cloudngfw/firewalls`  \n`"
+      "value": "Type: `PaloAltoNetworks.Cloudngfw/firewalls`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53470,7 +53470,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `PaloAltoNetworks.Cloudngfw/firewalls/statuses`  \n`"
+      "value": "Type: `PaloAltoNetworks.Cloudngfw/firewalls/statuses`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53491,7 +53491,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `PaloAltoNetworks.Cloudngfw/globalRulestacks`  \n`"
+      "value": "Type: `PaloAltoNetworks.Cloudngfw/globalRulestacks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53512,7 +53512,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `PaloAltoNetworks.Cloudngfw/globalRulestacks/certificates`  \n`"
+      "value": "Type: `PaloAltoNetworks.Cloudngfw/globalRulestacks/certificates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53533,7 +53533,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `PaloAltoNetworks.Cloudngfw/globalRulestacks/fqdnlists`  \n`"
+      "value": "Type: `PaloAltoNetworks.Cloudngfw/globalRulestacks/fqdnlists`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53554,7 +53554,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `PaloAltoNetworks.Cloudngfw/globalRulestacks/postRules`  \n`"
+      "value": "Type: `PaloAltoNetworks.Cloudngfw/globalRulestacks/postRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53575,7 +53575,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `PaloAltoNetworks.Cloudngfw/globalRulestacks/preRules`  \n`"
+      "value": "Type: `PaloAltoNetworks.Cloudngfw/globalRulestacks/preRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53596,7 +53596,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `PaloAltoNetworks.Cloudngfw/globalRulestacks/prefixlists`  \n`"
+      "value": "Type: `PaloAltoNetworks.Cloudngfw/globalRulestacks/prefixlists`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53617,7 +53617,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `PaloAltoNetworks.Cloudngfw/localRulestacks`  \n`"
+      "value": "Type: `PaloAltoNetworks.Cloudngfw/localRulestacks`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53638,7 +53638,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `PaloAltoNetworks.Cloudngfw/localRulestacks/certificates`  \n`"
+      "value": "Type: `PaloAltoNetworks.Cloudngfw/localRulestacks/certificates`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53659,7 +53659,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `PaloAltoNetworks.Cloudngfw/localRulestacks/fqdnlists`  \n`"
+      "value": "Type: `PaloAltoNetworks.Cloudngfw/localRulestacks/fqdnlists`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53680,7 +53680,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `PaloAltoNetworks.Cloudngfw/localRulestacks/localRules`  \n`"
+      "value": "Type: `PaloAltoNetworks.Cloudngfw/localRulestacks/localRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53701,7 +53701,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `PaloAltoNetworks.Cloudngfw/localRulestacks/prefixlists`  \n`"
+      "value": "Type: `PaloAltoNetworks.Cloudngfw/localRulestacks/prefixlists`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53722,7 +53722,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Qumulo.Storage/fileSystems`  \n`"
+      "value": "Type: `Qumulo.Storage/fileSystems`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53743,7 +53743,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `microsoft.Compute/virtualMachineScaleSets/virtualMachines/networkInterfaces`  \n`"
+      "value": "Type: `microsoft.Compute/virtualMachineScaleSets/virtualMachines/networkInterfaces`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53764,7 +53764,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `microsoft.Compute/virtualMachineScaleSets/virtualMachines/networkInterfaces/ipConfigurations`  \n`"
+      "value": "Type: `microsoft.Compute/virtualMachineScaleSets/virtualMachines/networkInterfaces/ipConfigurations`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53785,7 +53785,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `microsoft.aadiam/azureADMetrics`  \n`"
+      "value": "Type: `microsoft.aadiam/azureADMetrics`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53806,7 +53806,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `microsoft.aadiam/diagnosticSettings`  \n`"
+      "value": "Type: `microsoft.aadiam/diagnosticSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53827,7 +53827,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `microsoft.aadiam/privateLinkForAzureAd`  \n`"
+      "value": "Type: `microsoft.aadiam/privateLinkForAzureAd`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53848,7 +53848,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `microsoft.aadiam/privateLinkForAzureAd/privateEndpointConnections`  \n`"
+      "value": "Type: `microsoft.aadiam/privateLinkForAzureAd/privateEndpointConnections`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53869,7 +53869,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `microsoft.aadiam/privateLinkForAzureAd/privateLinkResources`  \n`"
+      "value": "Type: `microsoft.aadiam/privateLinkForAzureAd/privateLinkResources`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53890,7 +53890,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `microsoft.alertsManagement/smartDetectorAlertRules`  \n`"
+      "value": "Type: `microsoft.alertsManagement/smartDetectorAlertRules`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53911,7 +53911,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `microsoft.gallery.admin/galleryItems`  \n`"
+      "value": "Type: `microsoft.gallery.admin/galleryItems`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53932,7 +53932,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `microsoft.insights/components/analyticsItems`  \n`"
+      "value": "Type: `microsoft.insights/components/analyticsItems`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53953,7 +53953,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `microsoft.insights/components/linkedStorageAccounts`  \n`"
+      "value": "Type: `microsoft.insights/components/linkedStorageAccounts`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53974,7 +53974,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `microsoft.insights/components/myanalyticsItems`  \n`"
+      "value": "Type: `microsoft.insights/components/myanalyticsItems`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53995,7 +53995,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `microsoft.insights/components/pricingPlans`  \n`"
+      "value": "Type: `microsoft.insights/components/pricingPlans`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -54016,7 +54016,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `microsoft.insights/guestDiagnosticSettings`  \n`"
+      "value": "Type: `microsoft.insights/guestDiagnosticSettings`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -54037,7 +54037,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `microsoft.insights/guestDiagnosticSettingsAssociation`  \n`"
+      "value": "Type: `microsoft.insights/guestDiagnosticSettingsAssociation`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -54058,7 +54058,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `microsoft.insights/privateLinkScopes`  \n`"
+      "value": "Type: `microsoft.insights/privateLinkScopes`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -54079,7 +54079,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `microsoft.visualstudio/account`  \n`"
+      "value": "Type: `microsoft.visualstudio/account`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -54100,7 +54100,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `microsoft.visualstudio/account/extension`  \n`"
+      "value": "Type: `microsoft.visualstudio/account/extension`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -54121,7 +54121,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `microsoft.visualstudio/account/project`  \n`"
+      "value": "Type: `microsoft.visualstudio/account/project`  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/azFunctions.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/azFunctions.json
@@ -4,7 +4,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -21,7 +21,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38,7 +38,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -59,7 +59,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -80,7 +80,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -101,7 +101,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -122,7 +122,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -143,7 +143,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -164,7 +164,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -185,7 +185,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -206,7 +206,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -227,7 +227,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -248,7 +248,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -265,7 +265,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/symbols.json
@@ -3,10 +3,6 @@
     "label": "add",
     "kind": "variable",
     "detail": "add",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_add",
@@ -21,10 +17,6 @@
     "label": "and",
     "kind": "variable",
     "detail": "and",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_and",
@@ -99,10 +91,6 @@
     "label": "azFunctions",
     "kind": "variable",
     "detail": "azFunctions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_azFunctions",
@@ -117,10 +105,6 @@
     "label": "bad",
     "kind": "variable",
     "detail": "bad",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bad",
@@ -135,10 +119,6 @@
     "label": "badArrayIndexer",
     "kind": "variable",
     "detail": "badArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badArrayIndexer",
@@ -153,10 +133,6 @@
     "label": "badExpressionInPropertyAccess",
     "kind": "variable",
     "detail": "badExpressionInPropertyAccess",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badExpressionInPropertyAccess",
@@ -171,10 +147,6 @@
     "label": "badExpressionIndexer",
     "kind": "variable",
     "detail": "badExpressionIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badExpressionIndexer",
@@ -189,10 +161,6 @@
     "label": "badIndexOverArray",
     "kind": "variable",
     "detail": "badIndexOverArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badIndexOverArray",
@@ -207,10 +175,6 @@
     "label": "badIndexOverArray2",
     "kind": "variable",
     "detail": "badIndexOverArray2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badIndexOverArray2",
@@ -225,10 +189,6 @@
     "label": "badIndexOverObj",
     "kind": "variable",
     "detail": "badIndexOverObj",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badIndexOverObj",
@@ -243,10 +203,6 @@
     "label": "badIndexOverObj2",
     "kind": "variable",
     "detail": "badIndexOverObj2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badIndexOverObj2",
@@ -261,10 +217,6 @@
     "label": "badIndexer",
     "kind": "variable",
     "detail": "badIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badIndexer",
@@ -279,10 +231,6 @@
     "label": "badInnerArray",
     "kind": "variable",
     "detail": "badInnerArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInnerArray",
@@ -297,10 +245,6 @@
     "label": "badInnerArrayIndexer",
     "kind": "variable",
     "detail": "badInnerArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInnerArrayIndexer",
@@ -315,10 +259,6 @@
     "label": "badInnerProperty",
     "kind": "variable",
     "detail": "badInnerProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInnerProperty",
@@ -333,10 +273,6 @@
     "label": "badInnerType",
     "kind": "variable",
     "detail": "badInnerType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInnerType",
@@ -351,10 +287,6 @@
     "label": "badProperty",
     "kind": "variable",
     "detail": "badProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badProperty",
@@ -369,10 +301,6 @@
     "label": "badPropertyIndexer",
     "kind": "variable",
     "detail": "badPropertyIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badPropertyIndexer",
@@ -387,10 +315,6 @@
     "label": "badSpelling",
     "kind": "variable",
     "detail": "badSpelling",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badSpelling",
@@ -405,10 +329,6 @@
     "label": "badType",
     "kind": "variable",
     "detail": "badType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badType",
@@ -423,10 +343,6 @@
     "label": "bannedFunctions",
     "kind": "variable",
     "detail": "bannedFunctions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bannedFunctions",
@@ -567,10 +483,6 @@
     "label": "complex",
     "kind": "variable",
     "detail": "complex",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_complex",
@@ -606,10 +518,6 @@
     "label": "concatNotEnough",
     "kind": "variable",
     "detail": "concatNotEnough",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_concatNotEnough",
@@ -624,10 +532,6 @@
     "label": "concatWrongTypes",
     "kind": "variable",
     "detail": "concatWrongTypes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_concatWrongTypes",
@@ -642,10 +546,6 @@
     "label": "concatWrongTypesContradiction",
     "kind": "variable",
     "detail": "concatWrongTypesContradiction",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_concatWrongTypesContradiction",
@@ -803,10 +703,6 @@
     "label": "div",
     "kind": "variable",
     "detail": "div",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_div",
@@ -821,10 +717,6 @@
     "label": "dotAccessOnNonObject",
     "kind": "variable",
     "detail": "dotAccessOnNonObject",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dotAccessOnNonObject",
@@ -860,10 +752,6 @@
     "label": "emptyArgInBetween",
     "kind": "variable",
     "detail": "emptyArgInBetween",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArgInBetween",
@@ -878,10 +766,6 @@
     "label": "emptyParens",
     "kind": "variable",
     "detail": "emptyParens",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyParens",
@@ -934,10 +818,6 @@
     "label": "eq",
     "kind": "variable",
     "detail": "eq",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_eq",
@@ -952,10 +832,6 @@
     "label": "errorInsideArrayAccess",
     "kind": "variable",
     "detail": "errorInsideArrayAccess",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_errorInsideArrayAccess",
@@ -991,10 +867,6 @@
     "label": "fakeFunc",
     "kind": "variable",
     "detail": "fakeFunc",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fakeFunc",
@@ -1027,10 +899,6 @@
     "label": "fakeVar",
     "kind": "variable",
     "detail": "fakeVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fakeVar",
@@ -1045,10 +913,6 @@
     "label": "falsehood",
     "kind": "variable",
     "detail": "falsehood",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_falsehood",
@@ -1165,10 +1029,6 @@
     "label": "funcvarvar",
     "kind": "variable",
     "detail": "funcvarvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_funcvarvar",
@@ -1183,10 +1043,6 @@
     "label": "gt",
     "kind": "variable",
     "detail": "gt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_gt",
@@ -1201,10 +1057,6 @@
     "label": "gteq",
     "kind": "variable",
     "detail": "gteq",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_gteq",
@@ -1275,10 +1127,6 @@
     "label": "indexOfWrongTypes",
     "kind": "variable",
     "detail": "indexOfWrongTypes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_indexOfWrongTypes",
@@ -1314,10 +1162,6 @@
     "label": "integerIndexOnNonArray",
     "kind": "variable",
     "detail": "integerIndexOnNonArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_integerIndexOnNonArray",
@@ -1353,10 +1197,6 @@
     "label": "invalidIndexTypeOverAny",
     "kind": "variable",
     "detail": "invalidIndexTypeOverAny",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidIndexTypeOverAny",
@@ -1371,10 +1211,6 @@
     "label": "invalidInstanceFunctionAccess",
     "kind": "variable",
     "detail": "invalidInstanceFunctionAccess",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidInstanceFunctionAccess",
@@ -1389,10 +1225,6 @@
     "label": "invalidInstanceFunctionCall",
     "kind": "variable",
     "detail": "invalidInstanceFunctionCall",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidInstanceFunctionCall",
@@ -1407,10 +1239,6 @@
     "label": "invalidOperands",
     "kind": "variable",
     "detail": "invalidOperands",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidOperands",
@@ -1425,10 +1253,6 @@
     "label": "invalidPropertyAccessOnAzNamespace",
     "kind": "variable",
     "detail": "invalidPropertyAccessOnAzNamespace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidPropertyAccessOnAzNamespace",
@@ -1443,10 +1267,6 @@
     "label": "invalidPropertyAccessOnSysNamespace",
     "kind": "variable",
     "detail": "invalidPropertyAccessOnSysNamespace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidPropertyAccessOnSysNamespace",
@@ -1461,10 +1281,6 @@
     "label": "invalidPropertyCallOnInstanceFunctionAccess",
     "kind": "variable",
     "detail": "invalidPropertyCallOnInstanceFunctionAccess",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidPropertyCallOnInstanceFunctionAccess",
@@ -1479,10 +1295,6 @@
     "label": "invalidStringAddition",
     "kind": "variable",
     "detail": "invalidStringAddition",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidStringAddition",
@@ -1560,10 +1372,6 @@
     "label": "justAComma",
     "kind": "variable",
     "detail": "justAComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_justAComma",
@@ -1620,10 +1428,6 @@
     "label": "leadingAndTrailingEmptyArg",
     "kind": "variable",
     "detail": "leadingAndTrailingEmptyArg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_leadingAndTrailingEmptyArg",
@@ -1638,10 +1442,6 @@
     "label": "leadingEmptyArg",
     "kind": "variable",
     "detail": "leadingEmptyArg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_leadingEmptyArg",
@@ -1761,10 +1561,6 @@
     "label": "lt",
     "kind": "variable",
     "detail": "lt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_lt",
@@ -1779,10 +1575,6 @@
     "label": "lteq",
     "kind": "variable",
     "detail": "lteq",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_lteq",
@@ -1797,10 +1589,6 @@
     "label": "malformedStringIndex",
     "kind": "variable",
     "detail": "malformedStringIndex",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_malformedStringIndex",
@@ -1920,10 +1708,6 @@
     "label": "minus",
     "kind": "variable",
     "detail": "minus",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_minus",
@@ -1938,10 +1722,6 @@
     "label": "missingIndexerOnIdentifier",
     "kind": "variable",
     "detail": "missingIndexerOnIdentifier",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingIndexerOnIdentifier",
@@ -1956,10 +1736,6 @@
     "label": "missingIndexerOnLiteralArray",
     "kind": "variable",
     "detail": "missingIndexerOnLiteralArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingIndexerOnLiteralArray",
@@ -1974,10 +1750,6 @@
     "label": "missingMethodName",
     "kind": "variable",
     "detail": "missingMethodName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingMethodName",
@@ -1992,10 +1764,6 @@
     "label": "missingPropertyInsideAnExpression",
     "kind": "variable",
     "detail": "missingPropertyInsideAnExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingPropertyInsideAnExpression",
@@ -2010,10 +1778,6 @@
     "label": "missingPropertyName",
     "kind": "variable",
     "detail": "missingPropertyName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingPropertyName",
@@ -2028,10 +1792,6 @@
     "label": "mod",
     "kind": "variable",
     "detail": "mod",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mod",
@@ -2046,10 +1806,6 @@
     "label": "mul",
     "kind": "variable",
     "detail": "mul",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mul",
@@ -2064,10 +1820,6 @@
     "label": "multipleArgumentCommas",
     "kind": "variable",
     "detail": "multipleArgumentCommas",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_multipleArgumentCommas",
@@ -2082,10 +1834,6 @@
     "label": "ne",
     "kind": "variable",
     "detail": "ne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_ne",
@@ -2100,10 +1848,6 @@
     "label": "nestedTernary",
     "kind": "variable",
     "detail": "nestedTernary",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedTernary",
@@ -2118,10 +1862,6 @@
     "label": "noElements",
     "kind": "variable",
     "detail": "noElements",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noElements",
@@ -2136,10 +1876,6 @@
     "label": "not",
     "kind": "variable",
     "detail": "not",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_not",
@@ -2154,10 +1890,6 @@
     "label": "nullness",
     "kind": "variable",
     "detail": "nullness",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nullness",
@@ -2172,10 +1904,6 @@
     "label": "oneValidDeclaration",
     "kind": "variable",
     "detail": "oneValidDeclaration",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_oneValidDeclaration",
@@ -2190,10 +1918,6 @@
     "label": "onlyArgumentComma",
     "kind": "variable",
     "detail": "onlyArgumentComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_onlyArgumentComma",
@@ -2208,10 +1932,6 @@
     "label": "or",
     "kind": "variable",
     "detail": "or",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_or",
@@ -2247,10 +1967,6 @@
     "label": "padLeftNotEnough",
     "kind": "variable",
     "detail": "padLeftNotEnough",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_padLeftNotEnough",
@@ -2286,10 +2002,6 @@
     "label": "partialObject",
     "kind": "variable",
     "detail": "partialObject",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_partialObject",
@@ -2325,10 +2037,6 @@
     "label": "propertyAccessOnVariable",
     "kind": "variable",
     "detail": "propertyAccessOnVariable",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyAccessOnVariable",
@@ -2490,10 +2198,6 @@
     "label": "sampleObject",
     "kind": "variable",
     "detail": "sampleObject",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sampleObject",
@@ -2613,10 +2317,6 @@
     "label": "stringIndexOnNonObject",
     "kind": "variable",
     "detail": "stringIndexOnNonObject",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stringIndexOnNonObject",
@@ -2631,10 +2331,6 @@
     "label": "sub",
     "kind": "variable",
     "detail": "sub",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sub",
@@ -2730,10 +2426,6 @@
     "label": "sysFunctions",
     "kind": "variable",
     "detail": "sysFunctions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sysFunctions",
@@ -2748,10 +2440,6 @@
     "label": "sysFunctionsInParens",
     "kind": "variable",
     "detail": "sysFunctionsInParens",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sysFunctionsInParens",
@@ -2787,10 +2475,6 @@
     "label": "takeTooMany",
     "kind": "variable",
     "detail": "takeTooMany",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_takeTooMany",
@@ -2843,10 +2527,6 @@
     "label": "ternary",
     "kind": "variable",
     "detail": "ternary",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_ternary",
@@ -2861,10 +2541,6 @@
     "label": "test1",
     "kind": "variable",
     "detail": "test1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_test1",
@@ -2879,10 +2555,6 @@
     "label": "test2",
     "kind": "variable",
     "detail": "test2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_test2",
@@ -2897,10 +2569,6 @@
     "label": "test3",
     "kind": "variable",
     "detail": "test3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_test3",
@@ -2915,10 +2583,6 @@
     "label": "threeElements",
     "kind": "variable",
     "detail": "threeElements",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_threeElements",
@@ -2996,10 +2660,6 @@
     "label": "trailingArgumentComma",
     "kind": "variable",
     "detail": "trailingArgumentComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingArgumentComma",
@@ -3035,10 +2695,6 @@
     "label": "truth",
     "kind": "variable",
     "detail": "truth",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_truth",
@@ -3053,10 +2709,6 @@
     "label": "twoElements",
     "kind": "variable",
     "detail": "twoElements",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_twoElements",
@@ -3113,10 +2765,6 @@
     "label": "unterminated1",
     "kind": "variable",
     "detail": "unterminated1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unterminated1",
@@ -3131,10 +2779,6 @@
     "label": "unterminated2",
     "kind": "variable",
     "detail": "unterminated2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unterminated2",
@@ -3212,10 +2856,6 @@
     "label": "x",
     "kind": "variable",
     "detail": "x",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_x",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/symbols.json
@@ -3,6 +3,10 @@
     "label": "add",
     "kind": "variable",
     "detail": "add",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_add",
@@ -17,6 +21,10 @@
     "label": "and",
     "kind": "variable",
     "detail": "and",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_and",
@@ -32,7 +40,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53,7 +61,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -91,6 +99,10 @@
     "label": "azFunctions",
     "kind": "variable",
     "detail": "azFunctions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_azFunctions",
@@ -105,6 +117,10 @@
     "label": "bad",
     "kind": "variable",
     "detail": "bad",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bad",
@@ -119,6 +135,10 @@
     "label": "badArrayIndexer",
     "kind": "variable",
     "detail": "badArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badArrayIndexer",
@@ -133,6 +153,10 @@
     "label": "badExpressionInPropertyAccess",
     "kind": "variable",
     "detail": "badExpressionInPropertyAccess",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badExpressionInPropertyAccess",
@@ -147,6 +171,10 @@
     "label": "badExpressionIndexer",
     "kind": "variable",
     "detail": "badExpressionIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badExpressionIndexer",
@@ -161,6 +189,10 @@
     "label": "badIndexOverArray",
     "kind": "variable",
     "detail": "badIndexOverArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badIndexOverArray",
@@ -175,6 +207,10 @@
     "label": "badIndexOverArray2",
     "kind": "variable",
     "detail": "badIndexOverArray2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badIndexOverArray2",
@@ -189,6 +225,10 @@
     "label": "badIndexOverObj",
     "kind": "variable",
     "detail": "badIndexOverObj",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badIndexOverObj",
@@ -203,6 +243,10 @@
     "label": "badIndexOverObj2",
     "kind": "variable",
     "detail": "badIndexOverObj2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badIndexOverObj2",
@@ -217,6 +261,10 @@
     "label": "badIndexer",
     "kind": "variable",
     "detail": "badIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badIndexer",
@@ -231,6 +279,10 @@
     "label": "badInnerArray",
     "kind": "variable",
     "detail": "badInnerArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInnerArray",
@@ -245,6 +297,10 @@
     "label": "badInnerArrayIndexer",
     "kind": "variable",
     "detail": "badInnerArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInnerArrayIndexer",
@@ -259,6 +315,10 @@
     "label": "badInnerProperty",
     "kind": "variable",
     "detail": "badInnerProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInnerProperty",
@@ -273,6 +333,10 @@
     "label": "badInnerType",
     "kind": "variable",
     "detail": "badInnerType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInnerType",
@@ -287,6 +351,10 @@
     "label": "badProperty",
     "kind": "variable",
     "detail": "badProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badProperty",
@@ -301,6 +369,10 @@
     "label": "badPropertyIndexer",
     "kind": "variable",
     "detail": "badPropertyIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badPropertyIndexer",
@@ -315,6 +387,10 @@
     "label": "badSpelling",
     "kind": "variable",
     "detail": "badSpelling",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badSpelling",
@@ -329,6 +405,10 @@
     "label": "badType",
     "kind": "variable",
     "detail": "badType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badType",
@@ -343,6 +423,10 @@
     "label": "bannedFunctions",
     "kind": "variable",
     "detail": "bannedFunctions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bannedFunctions",
@@ -358,7 +442,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -379,7 +463,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -400,7 +484,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -421,7 +505,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -442,7 +526,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -463,7 +547,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -483,6 +567,10 @@
     "label": "complex",
     "kind": "variable",
     "detail": "complex",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_complex",
@@ -498,7 +586,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -518,6 +606,10 @@
     "label": "concatNotEnough",
     "kind": "variable",
     "detail": "concatNotEnough",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_concatNotEnough",
@@ -532,6 +624,10 @@
     "label": "concatWrongTypes",
     "kind": "variable",
     "detail": "concatWrongTypes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_concatWrongTypes",
@@ -546,6 +642,10 @@
     "label": "concatWrongTypesContradiction",
     "kind": "variable",
     "detail": "concatWrongTypesContradiction",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_concatWrongTypesContradiction",
@@ -561,7 +661,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -582,7 +682,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -603,7 +703,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -624,7 +724,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -645,7 +745,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -666,7 +766,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -687,7 +787,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -703,6 +803,10 @@
     "label": "div",
     "kind": "variable",
     "detail": "div",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_div",
@@ -717,6 +821,10 @@
     "label": "dotAccessOnNonObject",
     "kind": "variable",
     "detail": "dotAccessOnNonObject",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dotAccessOnNonObject",
@@ -732,7 +840,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -752,6 +860,10 @@
     "label": "emptyArgInBetween",
     "kind": "variable",
     "detail": "emptyArgInBetween",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArgInBetween",
@@ -766,6 +878,10 @@
     "label": "emptyParens",
     "kind": "variable",
     "detail": "emptyParens",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyParens",
@@ -781,7 +897,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -802,7 +918,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -818,6 +934,10 @@
     "label": "eq",
     "kind": "variable",
     "detail": "eq",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_eq",
@@ -832,6 +952,10 @@
     "label": "errorInsideArrayAccess",
     "kind": "variable",
     "detail": "errorInsideArrayAccess",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_errorInsideArrayAccess",
@@ -847,7 +971,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -867,6 +991,10 @@
     "label": "fakeFunc",
     "kind": "variable",
     "detail": "fakeFunc",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fakeFunc",
@@ -883,7 +1011,7 @@
     "detail": "fakeFuncP",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -899,6 +1027,10 @@
     "label": "fakeVar",
     "kind": "variable",
     "detail": "fakeVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fakeVar",
@@ -913,6 +1045,10 @@
     "label": "falsehood",
     "kind": "variable",
     "detail": "falsehood",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_falsehood",
@@ -928,7 +1064,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -949,7 +1085,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -970,7 +1106,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -991,7 +1127,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1013,7 +1149,7 @@
     "detail": "funcvarparam",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool"
+      "value": "Type: `bool`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1029,6 +1165,10 @@
     "label": "funcvarvar",
     "kind": "variable",
     "detail": "funcvarvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_funcvarvar",
@@ -1043,6 +1183,10 @@
     "label": "gt",
     "kind": "variable",
     "detail": "gt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_gt",
@@ -1057,6 +1201,10 @@
     "label": "gteq",
     "kind": "variable",
     "detail": "gteq",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_gteq",
@@ -1072,7 +1220,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1107,7 +1255,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1127,6 +1275,10 @@
     "label": "indexOfWrongTypes",
     "kind": "variable",
     "detail": "indexOfWrongTypes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_indexOfWrongTypes",
@@ -1142,7 +1294,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1162,6 +1314,10 @@
     "label": "integerIndexOnNonArray",
     "kind": "variable",
     "detail": "integerIndexOnNonArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_integerIndexOnNonArray",
@@ -1177,7 +1333,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1197,6 +1353,10 @@
     "label": "invalidIndexTypeOverAny",
     "kind": "variable",
     "detail": "invalidIndexTypeOverAny",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidIndexTypeOverAny",
@@ -1211,6 +1371,10 @@
     "label": "invalidInstanceFunctionAccess",
     "kind": "variable",
     "detail": "invalidInstanceFunctionAccess",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidInstanceFunctionAccess",
@@ -1225,6 +1389,10 @@
     "label": "invalidInstanceFunctionCall",
     "kind": "variable",
     "detail": "invalidInstanceFunctionCall",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidInstanceFunctionCall",
@@ -1239,6 +1407,10 @@
     "label": "invalidOperands",
     "kind": "variable",
     "detail": "invalidOperands",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidOperands",
@@ -1253,6 +1425,10 @@
     "label": "invalidPropertyAccessOnAzNamespace",
     "kind": "variable",
     "detail": "invalidPropertyAccessOnAzNamespace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidPropertyAccessOnAzNamespace",
@@ -1267,6 +1443,10 @@
     "label": "invalidPropertyAccessOnSysNamespace",
     "kind": "variable",
     "detail": "invalidPropertyAccessOnSysNamespace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidPropertyAccessOnSysNamespace",
@@ -1281,6 +1461,10 @@
     "label": "invalidPropertyCallOnInstanceFunctionAccess",
     "kind": "variable",
     "detail": "invalidPropertyCallOnInstanceFunctionAccess",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidPropertyCallOnInstanceFunctionAccess",
@@ -1295,6 +1479,10 @@
     "label": "invalidStringAddition",
     "kind": "variable",
     "detail": "invalidStringAddition",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidStringAddition",
@@ -1310,7 +1498,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1331,7 +1519,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1352,7 +1540,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1372,6 +1560,10 @@
     "label": "justAComma",
     "kind": "variable",
     "detail": "justAComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_justAComma",
@@ -1387,7 +1579,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1408,7 +1600,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1428,6 +1620,10 @@
     "label": "leadingAndTrailingEmptyArg",
     "kind": "variable",
     "detail": "leadingAndTrailingEmptyArg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_leadingAndTrailingEmptyArg",
@@ -1442,6 +1638,10 @@
     "label": "leadingEmptyArg",
     "kind": "variable",
     "detail": "leadingEmptyArg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_leadingEmptyArg",
@@ -1457,7 +1657,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1478,7 +1678,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1499,7 +1699,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1520,7 +1720,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1541,7 +1741,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1561,6 +1761,10 @@
     "label": "lt",
     "kind": "variable",
     "detail": "lt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_lt",
@@ -1575,6 +1779,10 @@
     "label": "lteq",
     "kind": "variable",
     "detail": "lteq",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_lteq",
@@ -1589,6 +1797,10 @@
     "label": "malformedStringIndex",
     "kind": "variable",
     "detail": "malformedStringIndex",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_malformedStringIndex",
@@ -1604,7 +1816,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1625,7 +1837,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1646,7 +1858,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1667,7 +1879,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1688,7 +1900,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1708,6 +1920,10 @@
     "label": "minus",
     "kind": "variable",
     "detail": "minus",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_minus",
@@ -1722,6 +1938,10 @@
     "label": "missingIndexerOnIdentifier",
     "kind": "variable",
     "detail": "missingIndexerOnIdentifier",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingIndexerOnIdentifier",
@@ -1736,6 +1956,10 @@
     "label": "missingIndexerOnLiteralArray",
     "kind": "variable",
     "detail": "missingIndexerOnLiteralArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingIndexerOnLiteralArray",
@@ -1750,6 +1974,10 @@
     "label": "missingMethodName",
     "kind": "variable",
     "detail": "missingMethodName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingMethodName",
@@ -1764,6 +1992,10 @@
     "label": "missingPropertyInsideAnExpression",
     "kind": "variable",
     "detail": "missingPropertyInsideAnExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingPropertyInsideAnExpression",
@@ -1778,6 +2010,10 @@
     "label": "missingPropertyName",
     "kind": "variable",
     "detail": "missingPropertyName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingPropertyName",
@@ -1792,6 +2028,10 @@
     "label": "mod",
     "kind": "variable",
     "detail": "mod",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mod",
@@ -1806,6 +2046,10 @@
     "label": "mul",
     "kind": "variable",
     "detail": "mul",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mul",
@@ -1820,6 +2064,10 @@
     "label": "multipleArgumentCommas",
     "kind": "variable",
     "detail": "multipleArgumentCommas",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_multipleArgumentCommas",
@@ -1834,6 +2082,10 @@
     "label": "ne",
     "kind": "variable",
     "detail": "ne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_ne",
@@ -1848,6 +2100,10 @@
     "label": "nestedTernary",
     "kind": "variable",
     "detail": "nestedTernary",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedTernary",
@@ -1862,6 +2118,10 @@
     "label": "noElements",
     "kind": "variable",
     "detail": "noElements",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noElements",
@@ -1876,6 +2136,10 @@
     "label": "not",
     "kind": "variable",
     "detail": "not",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_not",
@@ -1890,6 +2154,10 @@
     "label": "nullness",
     "kind": "variable",
     "detail": "nullness",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nullness",
@@ -1904,6 +2172,10 @@
     "label": "oneValidDeclaration",
     "kind": "variable",
     "detail": "oneValidDeclaration",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_oneValidDeclaration",
@@ -1918,6 +2190,10 @@
     "label": "onlyArgumentComma",
     "kind": "variable",
     "detail": "onlyArgumentComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_onlyArgumentComma",
@@ -1932,6 +2208,10 @@
     "label": "or",
     "kind": "variable",
     "detail": "or",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_or",
@@ -1947,7 +2227,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1967,6 +2247,10 @@
     "label": "padLeftNotEnough",
     "kind": "variable",
     "detail": "padLeftNotEnough",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_padLeftNotEnough",
@@ -1982,7 +2266,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2002,6 +2286,10 @@
     "label": "partialObject",
     "kind": "variable",
     "detail": "partialObject",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_partialObject",
@@ -2017,7 +2305,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2037,6 +2325,10 @@
     "label": "propertyAccessOnVariable",
     "kind": "variable",
     "detail": "propertyAccessOnVariable",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyAccessOnVariable",
@@ -2052,7 +2344,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2073,7 +2365,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2094,7 +2386,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2115,7 +2407,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2136,7 +2428,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2157,7 +2449,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2178,7 +2470,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2198,6 +2490,10 @@
     "label": "sampleObject",
     "kind": "variable",
     "detail": "sampleObject",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sampleObject",
@@ -2213,7 +2509,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2234,7 +2530,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2255,7 +2551,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2276,7 +2572,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2297,7 +2593,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2317,6 +2613,10 @@
     "label": "stringIndexOnNonObject",
     "kind": "variable",
     "detail": "stringIndexOnNonObject",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stringIndexOnNonObject",
@@ -2331,6 +2631,10 @@
     "label": "sub",
     "kind": "variable",
     "detail": "sub",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sub",
@@ -2346,7 +2650,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2367,7 +2671,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2388,7 +2692,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2426,6 +2730,10 @@
     "label": "sysFunctions",
     "kind": "variable",
     "detail": "sysFunctions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sysFunctions",
@@ -2440,6 +2748,10 @@
     "label": "sysFunctionsInParens",
     "kind": "variable",
     "detail": "sysFunctionsInParens",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sysFunctionsInParens",
@@ -2455,7 +2767,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2475,6 +2787,10 @@
     "label": "takeTooMany",
     "kind": "variable",
     "detail": "takeTooMany",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_takeTooMany",
@@ -2490,7 +2806,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2507,7 +2823,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2527,6 +2843,10 @@
     "label": "ternary",
     "kind": "variable",
     "detail": "ternary",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_ternary",
@@ -2541,6 +2861,10 @@
     "label": "test1",
     "kind": "variable",
     "detail": "test1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_test1",
@@ -2555,6 +2879,10 @@
     "label": "test2",
     "kind": "variable",
     "detail": "test2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_test2",
@@ -2569,6 +2897,10 @@
     "label": "test3",
     "kind": "variable",
     "detail": "test3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_test3",
@@ -2583,6 +2915,10 @@
     "label": "threeElements",
     "kind": "variable",
     "detail": "threeElements",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_threeElements",
@@ -2598,7 +2934,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2619,7 +2955,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2640,7 +2976,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2660,6 +2996,10 @@
     "label": "trailingArgumentComma",
     "kind": "variable",
     "detail": "trailingArgumentComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingArgumentComma",
@@ -2675,7 +3015,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2695,6 +3035,10 @@
     "label": "truth",
     "kind": "variable",
     "detail": "truth",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_truth",
@@ -2709,6 +3053,10 @@
     "label": "twoElements",
     "kind": "variable",
     "detail": "twoElements",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_twoElements",
@@ -2724,7 +3072,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2745,7 +3093,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2765,6 +3113,10 @@
     "label": "unterminated1",
     "kind": "variable",
     "detail": "unterminated1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unterminated1",
@@ -2779,6 +3131,10 @@
     "label": "unterminated2",
     "kind": "variable",
     "detail": "unterminated2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unterminated2",
@@ -2794,7 +3150,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2815,7 +3171,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2836,7 +3192,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2856,6 +3212,10 @@
     "label": "x",
     "kind": "variable",
     "detail": "x",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_x",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/sysFunctions.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/sysFunctions.json
@@ -4,7 +4,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46,7 +46,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -67,7 +67,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -88,7 +88,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -109,7 +109,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -151,7 +151,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -172,7 +172,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -193,7 +193,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -214,7 +214,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -235,7 +235,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -256,7 +256,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -277,7 +277,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -298,7 +298,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -319,7 +319,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -340,7 +340,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -361,7 +361,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -382,7 +382,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -403,7 +403,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -424,7 +424,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -445,7 +445,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -466,7 +466,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -487,7 +487,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -508,7 +508,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -550,7 +550,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -571,7 +571,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -592,7 +592,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -613,7 +613,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -634,7 +634,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -655,7 +655,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -676,7 +676,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -697,7 +697,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -718,7 +718,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -739,7 +739,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -760,7 +760,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -781,7 +781,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -802,7 +802,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -823,7 +823,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -844,7 +844,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -865,7 +865,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnewGuid(): string\n\n```\nReturns a value in the format of a globally unique identifier. **This function can only be used in the default value for a parameter**.\n"
+      "value": "```bicep\nnewGuid(): string\n\n```  \nReturns a value in the format of a globally unique identifier. **This function can only be used in the default value for a parameter**.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -903,7 +903,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -924,7 +924,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -945,7 +945,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -966,7 +966,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -987,7 +987,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1008,7 +1008,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1029,7 +1029,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1050,7 +1050,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1071,7 +1071,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1113,7 +1113,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1134,7 +1134,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1155,7 +1155,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1176,7 +1176,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1197,7 +1197,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1218,7 +1218,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1239,7 +1239,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1260,7 +1260,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1281,7 +1281,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1302,7 +1302,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1323,7 +1323,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1344,7 +1344,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1365,7 +1365,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nutcNow([format: string]): string\n\n```\nReturns the current (UTC) datetime value in the specified format. If no format is provided, the ISO 8601 (yyyyMMddTHHmmssZ) format is used. **This function can only be used in the default value for a parameter**.\n"
+      "value": "```bicep\nutcNow([format: string]): string\n\n```  \nReturns the current (UTC) datetime value in the specified format. If no format is provided, the ISO 8601 (yyyyMMddTHHmmssZ) format is used. **This function can only be used in the default value for a parameter**.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/moduleBodyCompletions.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/moduleBodyCompletions.json
@@ -5,7 +5,7 @@
     "detail": "for",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n[for item in list: {\n\t\n}]\n```"
+      "value": "```bicep\n[for item in list: {\n\t\n}]\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23,7 +23,7 @@
     "detail": "for-filtered",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n[for (item, index) in list: if (condition) {\n\t\n}]\n```"
+      "value": "```bicep\n[for (item, index) in list: if (condition) {\n\t\n}]\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41,7 +41,7 @@
     "detail": "for-indexed",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n[for (item, index) in list: {\n\t\n}]\n```"
+      "value": "```bicep\n[for (item, index) in list: {\n\t\n}]\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -73,7 +73,7 @@
     "detail": "Required properties",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n{\n\tname: \n\tparams: {\n\t\tarrayParam: \n\t\tobjParam: {\n\t\t}\n\t\tstringParamB: \n\t}\n}\n```"
+      "value": "```bicep\n{\n\tname: \n\tparams: {\n\t\tarrayParam: \n\t\tobjParam: {\n\t\t}\n\t\tstringParamB: \n\t}\n}\n```  \n"
     },
     "deprecated": false,
     "preselect": true,
@@ -103,7 +103,7 @@
     "detail": "{}",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n{\n\t\n}\n```"
+      "value": "```bicep\n{\n\t\n}\n```  \n"
     },
     "deprecated": false,
     "preselect": true,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX.json
@@ -24,10 +24,6 @@
     "label": "anyTypeInScope",
     "kind": "module",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -42,10 +38,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "module",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -60,10 +52,6 @@
     "label": "anyTypeInScopeLoop",
     "kind": "module",
     "detail": "anyTypeInScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeLoop",
@@ -99,10 +87,6 @@
     "label": "assignToOutput",
     "kind": "module",
     "detail": "assignToOutput",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_assignToOutput",
@@ -219,10 +203,6 @@
     "label": "childCompletionA",
     "kind": "module",
     "detail": "childCompletionA",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_childCompletionA",
@@ -237,10 +217,6 @@
     "label": "childCompletionB",
     "kind": "module",
     "detail": "childCompletionB",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_childCompletionB",
@@ -255,10 +231,6 @@
     "label": "childCompletionC",
     "kind": "module",
     "detail": "childCompletionC",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_childCompletionC",
@@ -273,10 +245,6 @@
     "label": "childCompletionD",
     "kind": "module",
     "detail": "childCompletionD",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_childCompletionD",
@@ -333,10 +301,6 @@
     "label": "completionB",
     "kind": "module",
     "detail": "completionB",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_completionB",
@@ -351,10 +315,6 @@
     "label": "completionC",
     "kind": "module",
     "detail": "completionC",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_completionC",
@@ -369,10 +329,6 @@
     "label": "completionD",
     "kind": "module",
     "detail": "completionD",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_completionD",
@@ -387,10 +343,6 @@
     "label": "completionE",
     "kind": "module",
     "detail": "completionE",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_completionE",
@@ -447,10 +399,6 @@
     "label": "cwdFileCompletionA",
     "kind": "module",
     "detail": "cwdFileCompletionA",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cwdFileCompletionA",
@@ -465,10 +413,6 @@
     "label": "cwdFileCompletionB",
     "kind": "module",
     "detail": "cwdFileCompletionB",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cwdFileCompletionB",
@@ -483,10 +427,6 @@
     "label": "cwdFileCompletionC",
     "kind": "module",
     "detail": "cwdFileCompletionC",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cwdFileCompletionC",
@@ -623,10 +563,6 @@
     "label": "directRefToCollectionViaLoopBody",
     "kind": "module",
     "detail": "directRefToCollectionViaLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefToCollectionViaLoopBody",
@@ -641,10 +577,6 @@
     "label": "directRefToCollectionViaLoopBodyWithExtraDependsOn",
     "kind": "module",
     "detail": "directRefToCollectionViaLoopBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefToCollectionViaLoopBodyWithExtraDependsOn",
@@ -659,10 +591,6 @@
     "label": "directRefToCollectionViaSingleBody",
     "kind": "module",
     "detail": "directRefToCollectionViaSingleBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefToCollectionViaSingleBody",
@@ -677,10 +605,6 @@
     "label": "directRefToCollectionViaSingleConditionalBody",
     "kind": "module",
     "detail": "directRefToCollectionViaSingleConditionalBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefToCollectionViaSingleConditionalBody",
@@ -716,10 +640,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -772,10 +692,6 @@
     "label": "evenMoreDuplicates",
     "kind": "variable",
     "detail": "evenMoreDuplicates",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_evenMoreDuplicates",
@@ -790,10 +706,6 @@
     "label": "expectedArrayExpression",
     "kind": "module",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -808,10 +720,6 @@
     "label": "expectedArrayExpression2",
     "kind": "module",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -826,10 +734,6 @@
     "label": "expectedColon",
     "kind": "module",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -844,10 +748,6 @@
     "label": "expectedColon2",
     "kind": "module",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -862,10 +762,6 @@
     "label": "expectedComma",
     "kind": "module",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -880,10 +776,6 @@
     "label": "expectedForKeyword",
     "kind": "module",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -898,10 +790,6 @@
     "label": "expectedForKeyword2",
     "kind": "module",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -916,10 +804,6 @@
     "label": "expectedInKeyword",
     "kind": "module",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -934,10 +818,6 @@
     "label": "expectedInKeyword2",
     "kind": "module",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -952,10 +832,6 @@
     "label": "expectedInKeyword3",
     "kind": "module",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -970,10 +846,6 @@
     "label": "expectedIndexVarName",
     "kind": "module",
     "detail": "expectedIndexVarName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedIndexVarName",
@@ -988,10 +860,6 @@
     "label": "expectedItemVarName",
     "kind": "module",
     "detail": "expectedItemVarName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedItemVarName",
@@ -1006,10 +874,6 @@
     "label": "expectedLoopBody",
     "kind": "module",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -1024,10 +888,6 @@
     "label": "expectedLoopBody2",
     "kind": "module",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -1042,10 +902,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "module",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -1060,10 +916,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "module",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -1078,10 +930,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "module",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -1096,10 +944,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "module",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -1114,10 +958,6 @@
     "label": "expectedLoopVar",
     "kind": "module",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -1314,10 +1154,6 @@
     "label": "interp",
     "kind": "variable",
     "detail": "interp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interp",
@@ -1353,10 +1189,6 @@
     "label": "invalidJsonMod",
     "kind": "module",
     "detail": "invalidJsonMod",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidJsonMod",
@@ -1371,10 +1203,6 @@
     "label": "issue3000",
     "kind": "module",
     "detail": "issue3000",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000",
@@ -1452,10 +1280,6 @@
     "label": "jsonModMissingParam",
     "kind": "module",
     "detail": "jsonModMissingParam",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_jsonModMissingParam",
@@ -1470,10 +1294,6 @@
     "label": "kv",
     "kind": "interface",
     "detail": "kv",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_kv",
@@ -1743,10 +1563,6 @@
     "label": "missingFewerLoopBodyProperties",
     "kind": "module",
     "detail": "missingFewerLoopBodyProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerLoopBodyProperties",
@@ -1761,10 +1577,6 @@
     "label": "missingLoopBodyProperties",
     "kind": "module",
     "detail": "missingLoopBodyProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingLoopBodyProperties",
@@ -1779,10 +1591,6 @@
     "label": "missingLoopBodyProperties2",
     "kind": "module",
     "detail": "missingLoopBodyProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingLoopBodyProperties2",
@@ -1797,10 +1605,6 @@
     "label": "missingValue",
     "kind": "module",
     "detail": "missingValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingValue",
@@ -1815,10 +1619,6 @@
     "label": "modAEmptyInputs",
     "kind": "module",
     "detail": "modAEmptyInputs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modAEmptyInputs",
@@ -1833,10 +1633,6 @@
     "label": "modAEmptyInputsWithCondition",
     "kind": "module",
     "detail": "modAEmptyInputsWithCondition",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modAEmptyInputsWithCondition",
@@ -1851,10 +1647,6 @@
     "label": "modANoInputs",
     "kind": "module",
     "detail": "modANoInputs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modANoInputs",
@@ -1869,10 +1661,6 @@
     "label": "modANoInputsWithCondition",
     "kind": "module",
     "detail": "modANoInputsWithCondition",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modANoInputsWithCondition",
@@ -1887,10 +1675,6 @@
     "label": "modANoName",
     "kind": "module",
     "detail": "modANoName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modANoName",
@@ -1905,10 +1689,6 @@
     "label": "modANoNameWithCondition",
     "kind": "module",
     "detail": "modANoNameWithCondition",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modANoNameWithCondition",
@@ -1923,10 +1703,6 @@
     "label": "modAUnspecifiedInputs",
     "kind": "module",
     "detail": "modAUnspecifiedInputs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modAUnspecifiedInputs",
@@ -1941,10 +1717,6 @@
     "label": "modCycle",
     "kind": "module",
     "detail": "modCycle",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modCycle",
@@ -1959,10 +1731,6 @@
     "label": "modWithListKeysInCondition",
     "kind": "module",
     "detail": "modWithListKeysInCondition",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modWithListKeysInCondition",
@@ -1977,10 +1745,6 @@
     "label": "modWithReferenceInCondition",
     "kind": "module",
     "detail": "modWithReferenceInCondition",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modWithReferenceInCondition",
@@ -1995,10 +1759,6 @@
     "label": "moduleLoopForRuntimeCheck",
     "kind": "module",
     "detail": "moduleLoopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleLoopForRuntimeCheck",
@@ -2013,10 +1773,6 @@
     "label": "moduleLoopForRuntimeCheck2",
     "kind": "module",
     "detail": "moduleLoopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleLoopForRuntimeCheck2",
@@ -2031,10 +1787,6 @@
     "label": "moduleLoopForRuntimeCheck3",
     "kind": "module",
     "detail": "moduleLoopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleLoopForRuntimeCheck3",
@@ -2049,10 +1801,6 @@
     "label": "moduleOutputsCompletions",
     "kind": "variable",
     "detail": "moduleOutputsCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleOutputsCompletions",
@@ -2067,10 +1815,6 @@
     "label": "modulePropertyAccessCompletions",
     "kind": "variable",
     "detail": "modulePropertyAccessCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modulePropertyAccessCompletions",
@@ -2085,10 +1829,6 @@
     "label": "moduleRuntimeCheck",
     "kind": "variable",
     "detail": "moduleRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleRuntimeCheck",
@@ -2103,10 +1843,6 @@
     "label": "moduleRuntimeCheck2",
     "kind": "variable",
     "detail": "moduleRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleRuntimeCheck2",
@@ -2121,10 +1857,6 @@
     "label": "moduleRuntimeCheck3",
     "kind": "variable",
     "detail": "moduleRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleRuntimeCheck3",
@@ -2139,10 +1871,6 @@
     "label": "moduleRuntimeCheck4",
     "kind": "variable",
     "detail": "moduleRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleRuntimeCheck4",
@@ -2157,10 +1885,6 @@
     "label": "moduleWithAbsolutePath",
     "kind": "module",
     "detail": "moduleWithAbsolutePath",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithAbsolutePath",
@@ -2175,10 +1899,6 @@
     "label": "moduleWithBackslash",
     "kind": "module",
     "detail": "moduleWithBackslash",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithBackslash",
@@ -2193,10 +1913,6 @@
     "label": "moduleWithBadScope",
     "kind": "module",
     "detail": "moduleWithBadScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithBadScope",
@@ -2211,10 +1927,6 @@
     "label": "moduleWithConditionAndInterpPath",
     "kind": "module",
     "detail": "moduleWithConditionAndInterpPath",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithConditionAndInterpPath",
@@ -2229,10 +1941,6 @@
     "label": "moduleWithConditionAndSelfCycle",
     "kind": "module",
     "detail": "moduleWithConditionAndSelfCycle",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithConditionAndSelfCycle",
@@ -2247,10 +1955,6 @@
     "label": "moduleWithConditionOutputsCompletions",
     "kind": "variable",
     "detail": "moduleWithConditionOutputsCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithConditionOutputsCompletions",
@@ -2265,10 +1969,6 @@
     "label": "moduleWithConditionPropertyAccessCompletions",
     "kind": "variable",
     "detail": "moduleWithConditionPropertyAccessCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithConditionPropertyAccessCompletions",
@@ -2283,10 +1983,6 @@
     "label": "moduleWithDuplicateName1",
     "kind": "module",
     "detail": "moduleWithDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithDuplicateName1",
@@ -2301,10 +1997,6 @@
     "label": "moduleWithDuplicateName2",
     "kind": "module",
     "detail": "moduleWithDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithDuplicateName2",
@@ -2319,10 +2011,6 @@
     "label": "moduleWithEmptyPath",
     "kind": "module",
     "detail": "moduleWithEmptyPath",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithEmptyPath",
@@ -2337,10 +2025,6 @@
     "label": "moduleWithInterpPath",
     "kind": "module",
     "detail": "moduleWithInterpPath",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithInterpPath",
@@ -2355,10 +2039,6 @@
     "label": "moduleWithInvalidChar",
     "kind": "module",
     "detail": "moduleWithInvalidChar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithInvalidChar",
@@ -2373,10 +2053,6 @@
     "label": "moduleWithInvalidScope",
     "kind": "module",
     "detail": "moduleWithInvalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithInvalidScope",
@@ -2391,10 +2067,6 @@
     "label": "moduleWithInvalidScope2",
     "kind": "module",
     "detail": "moduleWithInvalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithInvalidScope2",
@@ -2409,10 +2081,6 @@
     "label": "moduleWithInvalidTerminatorChar",
     "kind": "module",
     "detail": "moduleWithInvalidTerminatorChar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithInvalidTerminatorChar",
@@ -2427,10 +2095,6 @@
     "label": "moduleWithMissingRequiredScope",
     "kind": "module",
     "detail": "moduleWithMissingRequiredScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithMissingRequiredScope",
@@ -2445,10 +2109,6 @@
     "label": "moduleWithNotAttachableDecorators",
     "kind": "module",
     "detail": "moduleWithNotAttachableDecorators",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithNotAttachableDecorators",
@@ -2463,10 +2123,6 @@
     "label": "moduleWithPath",
     "kind": "module",
     "detail": "moduleWithPath",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithPath",
@@ -2481,10 +2137,6 @@
     "label": "moduleWithSelfCycle",
     "kind": "module",
     "detail": "moduleWithSelfCycle",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithSelfCycle",
@@ -2499,10 +2151,6 @@
     "label": "moduleWithUnsupprtedScope1",
     "kind": "module",
     "detail": "moduleWithUnsupprtedScope1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithUnsupprtedScope1",
@@ -2517,10 +2165,6 @@
     "label": "moduleWithUnsupprtedScope2",
     "kind": "module",
     "detail": "moduleWithUnsupprtedScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithUnsupprtedScope2",
@@ -2535,10 +2179,6 @@
     "label": "moduleWithValidScope",
     "kind": "module",
     "detail": "moduleWithValidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithValidScope",
@@ -2553,10 +2193,6 @@
     "label": "moduleWithoutPath",
     "kind": "module",
     "detail": "moduleWithoutPath",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithoutPath",
@@ -2571,10 +2207,6 @@
     "label": "nonExistentFileRef",
     "kind": "module",
     "detail": "nonExistentFileRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentFileRef",
@@ -2589,10 +2221,6 @@
     "label": "nonExistentFileRefDuplicate",
     "kind": "module",
     "detail": "nonExistentFileRefDuplicate",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentFileRefDuplicate",
@@ -2607,10 +2235,6 @@
     "label": "nonExistentFileRefEquivalentPath",
     "kind": "module",
     "detail": "nonExistentFileRefEquivalentPath",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentFileRefEquivalentPath",
@@ -2625,10 +2249,6 @@
     "label": "nonObjectModuleBody",
     "kind": "module",
     "detail": "nonObjectModuleBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectModuleBody",
@@ -2643,10 +2263,6 @@
     "label": "nonObjectModuleBody2",
     "kind": "module",
     "detail": "nonObjectModuleBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectModuleBody2",
@@ -2661,10 +2277,6 @@
     "label": "nonObjectModuleBody3",
     "kind": "module",
     "detail": "nonObjectModuleBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectModuleBody3",
@@ -2679,10 +2291,6 @@
     "label": "nonObjectModuleBody4",
     "kind": "module",
     "detail": "nonObjectModuleBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectModuleBody4",
@@ -2697,10 +2305,6 @@
     "label": "nonexistentArrays",
     "kind": "module",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -2715,10 +2319,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -2754,10 +2354,6 @@
     "label": "paramNameCompletionsInFilteredLoops",
     "kind": "module",
     "detail": "paramNameCompletionsInFilteredLoops",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramNameCompletionsInFilteredLoops",
@@ -2814,10 +2410,6 @@
     "label": "propertyAccessCompletionsForFilteredModuleLoop",
     "kind": "variable",
     "detail": "propertyAccessCompletionsForFilteredModuleLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyAccessCompletionsForFilteredModuleLoop",
@@ -2979,10 +2571,6 @@
     "label": "runtimeInvalidModule1",
     "kind": "module",
     "detail": "runtimeInvalidModule1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidModule1",
@@ -2997,10 +2585,6 @@
     "label": "runtimeInvalidModule2",
     "kind": "module",
     "detail": "runtimeInvalidModule2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidModule2",
@@ -3015,10 +2599,6 @@
     "label": "runtimeInvalidModule3",
     "kind": "module",
     "detail": "runtimeInvalidModule3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidModule3",
@@ -3033,10 +2613,6 @@
     "label": "runtimeInvalidModule4",
     "kind": "module",
     "detail": "runtimeInvalidModule4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidModule4",
@@ -3051,10 +2627,6 @@
     "label": "runtimeInvalidModule5",
     "kind": "module",
     "detail": "runtimeInvalidModule5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidModule5",
@@ -3069,10 +2641,6 @@
     "label": "runtimeInvalidModule6",
     "kind": "module",
     "detail": "runtimeInvalidModule6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidModule6",
@@ -3087,10 +2655,6 @@
     "label": "runtimeValidModule1",
     "kind": "module",
     "detail": "runtimeValidModule1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidModule1",
@@ -3105,10 +2669,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -3126,10 +2686,6 @@
     "label": "secureModule1",
     "kind": "module",
     "detail": "secureModule1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_secureModule1",
@@ -3144,10 +2700,6 @@
     "label": "secureModule2",
     "kind": "module",
     "detail": "secureModule2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_secureModule2",
@@ -3162,10 +2714,6 @@
     "label": "singleModuleForRuntimeCheck",
     "kind": "module",
     "detail": "singleModuleForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleModuleForRuntimeCheck",
@@ -3551,10 +3099,6 @@
     "label": "unspecifiedOutput",
     "kind": "variable",
     "detail": "unspecifiedOutput",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unspecifiedOutput",
@@ -3632,10 +3176,6 @@
     "label": "wrongArrayType",
     "kind": "module",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -3650,10 +3190,6 @@
     "label": "wrongLoopBodyType",
     "kind": "module",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -3668,10 +3204,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "module",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -3686,10 +3218,6 @@
     "label": "wrongModuleParameterInFilteredLoop",
     "kind": "module",
     "detail": "wrongModuleParameterInFilteredLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongModuleParameterInFilteredLoop",
@@ -3704,10 +3232,6 @@
     "label": "wrongModuleParameterInLoop2",
     "kind": "module",
     "detail": "wrongModuleParameterInLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongModuleParameterInLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX.json
@@ -4,7 +4,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24,6 +24,10 @@
     "label": "anyTypeInScope",
     "kind": "module",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -38,6 +42,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "module",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -52,6 +60,10 @@
     "label": "anyTypeInScopeLoop",
     "kind": "module",
     "detail": "anyTypeInScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeLoop",
@@ -67,7 +79,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -87,6 +99,10 @@
     "label": "assignToOutput",
     "kind": "module",
     "detail": "assignToOutput",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_assignToOutput",
@@ -120,7 +136,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -141,7 +157,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -162,7 +178,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -183,7 +199,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -203,6 +219,10 @@
     "label": "childCompletionA",
     "kind": "module",
     "detail": "childCompletionA",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_childCompletionA",
@@ -217,6 +237,10 @@
     "label": "childCompletionB",
     "kind": "module",
     "detail": "childCompletionB",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_childCompletionB",
@@ -231,6 +255,10 @@
     "label": "childCompletionC",
     "kind": "module",
     "detail": "childCompletionC",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_childCompletionC",
@@ -245,6 +273,10 @@
     "label": "childCompletionD",
     "kind": "module",
     "detail": "childCompletionD",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_childCompletionD",
@@ -260,7 +292,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -281,7 +313,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -301,6 +333,10 @@
     "label": "completionB",
     "kind": "module",
     "detail": "completionB",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_completionB",
@@ -315,6 +351,10 @@
     "label": "completionC",
     "kind": "module",
     "detail": "completionC",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_completionC",
@@ -329,6 +369,10 @@
     "label": "completionD",
     "kind": "module",
     "detail": "completionD",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_completionD",
@@ -343,6 +387,10 @@
     "label": "completionE",
     "kind": "module",
     "detail": "completionE",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_completionE",
@@ -358,7 +406,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -379,7 +427,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -399,6 +447,10 @@
     "label": "cwdFileCompletionA",
     "kind": "module",
     "detail": "cwdFileCompletionA",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cwdFileCompletionA",
@@ -413,6 +465,10 @@
     "label": "cwdFileCompletionB",
     "kind": "module",
     "detail": "cwdFileCompletionB",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cwdFileCompletionB",
@@ -427,6 +483,10 @@
     "label": "cwdFileCompletionC",
     "kind": "module",
     "detail": "cwdFileCompletionC",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cwdFileCompletionC",
@@ -442,7 +502,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -463,7 +523,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -484,7 +544,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -505,7 +565,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -526,7 +586,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -547,7 +607,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -563,6 +623,10 @@
     "label": "directRefToCollectionViaLoopBody",
     "kind": "module",
     "detail": "directRefToCollectionViaLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefToCollectionViaLoopBody",
@@ -577,6 +641,10 @@
     "label": "directRefToCollectionViaLoopBodyWithExtraDependsOn",
     "kind": "module",
     "detail": "directRefToCollectionViaLoopBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefToCollectionViaLoopBodyWithExtraDependsOn",
@@ -591,6 +659,10 @@
     "label": "directRefToCollectionViaSingleBody",
     "kind": "module",
     "detail": "directRefToCollectionViaSingleBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefToCollectionViaSingleBody",
@@ -605,6 +677,10 @@
     "label": "directRefToCollectionViaSingleConditionalBody",
     "kind": "module",
     "detail": "directRefToCollectionViaSingleConditionalBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefToCollectionViaSingleConditionalBody",
@@ -620,7 +696,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -640,6 +716,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -655,7 +735,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -676,7 +756,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -692,6 +772,10 @@
     "label": "evenMoreDuplicates",
     "kind": "variable",
     "detail": "evenMoreDuplicates",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_evenMoreDuplicates",
@@ -706,6 +790,10 @@
     "label": "expectedArrayExpression",
     "kind": "module",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -720,6 +808,10 @@
     "label": "expectedArrayExpression2",
     "kind": "module",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -734,6 +826,10 @@
     "label": "expectedColon",
     "kind": "module",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -748,6 +844,10 @@
     "label": "expectedColon2",
     "kind": "module",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -762,6 +862,10 @@
     "label": "expectedComma",
     "kind": "module",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -776,6 +880,10 @@
     "label": "expectedForKeyword",
     "kind": "module",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -790,6 +898,10 @@
     "label": "expectedForKeyword2",
     "kind": "module",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -804,6 +916,10 @@
     "label": "expectedInKeyword",
     "kind": "module",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -818,6 +934,10 @@
     "label": "expectedInKeyword2",
     "kind": "module",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -832,6 +952,10 @@
     "label": "expectedInKeyword3",
     "kind": "module",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -846,6 +970,10 @@
     "label": "expectedIndexVarName",
     "kind": "module",
     "detail": "expectedIndexVarName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedIndexVarName",
@@ -860,6 +988,10 @@
     "label": "expectedItemVarName",
     "kind": "module",
     "detail": "expectedItemVarName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedItemVarName",
@@ -874,6 +1006,10 @@
     "label": "expectedLoopBody",
     "kind": "module",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -888,6 +1024,10 @@
     "label": "expectedLoopBody2",
     "kind": "module",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -902,6 +1042,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "module",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -916,6 +1060,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "module",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -930,6 +1078,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "module",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -944,6 +1096,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "module",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -958,6 +1114,10 @@
     "label": "expectedLoopVar",
     "kind": "module",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -973,7 +1133,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -994,7 +1154,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1015,7 +1175,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1036,7 +1196,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1057,7 +1217,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1078,7 +1238,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1113,7 +1273,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1134,7 +1294,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1154,6 +1314,10 @@
     "label": "interp",
     "kind": "variable",
     "detail": "interp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interp",
@@ -1169,7 +1333,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1189,6 +1353,10 @@
     "label": "invalidJsonMod",
     "kind": "module",
     "detail": "invalidJsonMod",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidJsonMod",
@@ -1203,6 +1371,10 @@
     "label": "issue3000",
     "kind": "module",
     "detail": "issue3000",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000",
@@ -1218,7 +1390,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1239,7 +1411,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1260,7 +1432,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1280,6 +1452,10 @@
     "label": "jsonModMissingParam",
     "kind": "module",
     "detail": "jsonModMissingParam",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_jsonModMissingParam",
@@ -1294,6 +1470,10 @@
     "label": "kv",
     "kind": "interface",
     "detail": "kv",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_kv",
@@ -1312,7 +1492,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1333,7 +1513,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1354,7 +1534,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1375,7 +1555,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1396,7 +1576,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1417,7 +1597,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1438,7 +1618,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1459,7 +1639,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1480,7 +1660,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1501,7 +1681,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1522,7 +1702,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1543,7 +1723,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1563,6 +1743,10 @@
     "label": "missingFewerLoopBodyProperties",
     "kind": "module",
     "detail": "missingFewerLoopBodyProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerLoopBodyProperties",
@@ -1577,6 +1761,10 @@
     "label": "missingLoopBodyProperties",
     "kind": "module",
     "detail": "missingLoopBodyProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingLoopBodyProperties",
@@ -1591,6 +1779,10 @@
     "label": "missingLoopBodyProperties2",
     "kind": "module",
     "detail": "missingLoopBodyProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingLoopBodyProperties2",
@@ -1605,6 +1797,10 @@
     "label": "missingValue",
     "kind": "module",
     "detail": "missingValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingValue",
@@ -1619,6 +1815,10 @@
     "label": "modAEmptyInputs",
     "kind": "module",
     "detail": "modAEmptyInputs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modAEmptyInputs",
@@ -1633,6 +1833,10 @@
     "label": "modAEmptyInputsWithCondition",
     "kind": "module",
     "detail": "modAEmptyInputsWithCondition",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modAEmptyInputsWithCondition",
@@ -1647,6 +1851,10 @@
     "label": "modANoInputs",
     "kind": "module",
     "detail": "modANoInputs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modANoInputs",
@@ -1661,6 +1869,10 @@
     "label": "modANoInputsWithCondition",
     "kind": "module",
     "detail": "modANoInputsWithCondition",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modANoInputsWithCondition",
@@ -1675,6 +1887,10 @@
     "label": "modANoName",
     "kind": "module",
     "detail": "modANoName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modANoName",
@@ -1689,6 +1905,10 @@
     "label": "modANoNameWithCondition",
     "kind": "module",
     "detail": "modANoNameWithCondition",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modANoNameWithCondition",
@@ -1703,6 +1923,10 @@
     "label": "modAUnspecifiedInputs",
     "kind": "module",
     "detail": "modAUnspecifiedInputs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modAUnspecifiedInputs",
@@ -1717,6 +1941,10 @@
     "label": "modCycle",
     "kind": "module",
     "detail": "modCycle",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modCycle",
@@ -1731,6 +1959,10 @@
     "label": "modWithListKeysInCondition",
     "kind": "module",
     "detail": "modWithListKeysInCondition",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modWithListKeysInCondition",
@@ -1745,6 +1977,10 @@
     "label": "modWithReferenceInCondition",
     "kind": "module",
     "detail": "modWithReferenceInCondition",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modWithReferenceInCondition",
@@ -1759,6 +1995,10 @@
     "label": "moduleLoopForRuntimeCheck",
     "kind": "module",
     "detail": "moduleLoopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleLoopForRuntimeCheck",
@@ -1773,6 +2013,10 @@
     "label": "moduleLoopForRuntimeCheck2",
     "kind": "module",
     "detail": "moduleLoopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleLoopForRuntimeCheck2",
@@ -1787,6 +2031,10 @@
     "label": "moduleLoopForRuntimeCheck3",
     "kind": "module",
     "detail": "moduleLoopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleLoopForRuntimeCheck3",
@@ -1801,6 +2049,10 @@
     "label": "moduleOutputsCompletions",
     "kind": "variable",
     "detail": "moduleOutputsCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleOutputsCompletions",
@@ -1815,6 +2067,10 @@
     "label": "modulePropertyAccessCompletions",
     "kind": "variable",
     "detail": "modulePropertyAccessCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modulePropertyAccessCompletions",
@@ -1829,6 +2085,10 @@
     "label": "moduleRuntimeCheck",
     "kind": "variable",
     "detail": "moduleRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleRuntimeCheck",
@@ -1843,6 +2103,10 @@
     "label": "moduleRuntimeCheck2",
     "kind": "variable",
     "detail": "moduleRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleRuntimeCheck2",
@@ -1857,6 +2121,10 @@
     "label": "moduleRuntimeCheck3",
     "kind": "variable",
     "detail": "moduleRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleRuntimeCheck3",
@@ -1871,6 +2139,10 @@
     "label": "moduleRuntimeCheck4",
     "kind": "variable",
     "detail": "moduleRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleRuntimeCheck4",
@@ -1885,6 +2157,10 @@
     "label": "moduleWithAbsolutePath",
     "kind": "module",
     "detail": "moduleWithAbsolutePath",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithAbsolutePath",
@@ -1899,6 +2175,10 @@
     "label": "moduleWithBackslash",
     "kind": "module",
     "detail": "moduleWithBackslash",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithBackslash",
@@ -1913,6 +2193,10 @@
     "label": "moduleWithBadScope",
     "kind": "module",
     "detail": "moduleWithBadScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithBadScope",
@@ -1927,6 +2211,10 @@
     "label": "moduleWithConditionAndInterpPath",
     "kind": "module",
     "detail": "moduleWithConditionAndInterpPath",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithConditionAndInterpPath",
@@ -1941,6 +2229,10 @@
     "label": "moduleWithConditionAndSelfCycle",
     "kind": "module",
     "detail": "moduleWithConditionAndSelfCycle",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithConditionAndSelfCycle",
@@ -1955,6 +2247,10 @@
     "label": "moduleWithConditionOutputsCompletions",
     "kind": "variable",
     "detail": "moduleWithConditionOutputsCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithConditionOutputsCompletions",
@@ -1969,6 +2265,10 @@
     "label": "moduleWithConditionPropertyAccessCompletions",
     "kind": "variable",
     "detail": "moduleWithConditionPropertyAccessCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithConditionPropertyAccessCompletions",
@@ -1983,6 +2283,10 @@
     "label": "moduleWithDuplicateName1",
     "kind": "module",
     "detail": "moduleWithDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithDuplicateName1",
@@ -1997,6 +2301,10 @@
     "label": "moduleWithDuplicateName2",
     "kind": "module",
     "detail": "moduleWithDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithDuplicateName2",
@@ -2011,6 +2319,10 @@
     "label": "moduleWithEmptyPath",
     "kind": "module",
     "detail": "moduleWithEmptyPath",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithEmptyPath",
@@ -2025,6 +2337,10 @@
     "label": "moduleWithInterpPath",
     "kind": "module",
     "detail": "moduleWithInterpPath",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithInterpPath",
@@ -2039,6 +2355,10 @@
     "label": "moduleWithInvalidChar",
     "kind": "module",
     "detail": "moduleWithInvalidChar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithInvalidChar",
@@ -2053,6 +2373,10 @@
     "label": "moduleWithInvalidScope",
     "kind": "module",
     "detail": "moduleWithInvalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithInvalidScope",
@@ -2067,6 +2391,10 @@
     "label": "moduleWithInvalidScope2",
     "kind": "module",
     "detail": "moduleWithInvalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithInvalidScope2",
@@ -2081,6 +2409,10 @@
     "label": "moduleWithInvalidTerminatorChar",
     "kind": "module",
     "detail": "moduleWithInvalidTerminatorChar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithInvalidTerminatorChar",
@@ -2095,6 +2427,10 @@
     "label": "moduleWithMissingRequiredScope",
     "kind": "module",
     "detail": "moduleWithMissingRequiredScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithMissingRequiredScope",
@@ -2109,6 +2445,10 @@
     "label": "moduleWithNotAttachableDecorators",
     "kind": "module",
     "detail": "moduleWithNotAttachableDecorators",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithNotAttachableDecorators",
@@ -2123,6 +2463,10 @@
     "label": "moduleWithPath",
     "kind": "module",
     "detail": "moduleWithPath",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithPath",
@@ -2137,6 +2481,10 @@
     "label": "moduleWithSelfCycle",
     "kind": "module",
     "detail": "moduleWithSelfCycle",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithSelfCycle",
@@ -2151,6 +2499,10 @@
     "label": "moduleWithUnsupprtedScope1",
     "kind": "module",
     "detail": "moduleWithUnsupprtedScope1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithUnsupprtedScope1",
@@ -2165,6 +2517,10 @@
     "label": "moduleWithUnsupprtedScope2",
     "kind": "module",
     "detail": "moduleWithUnsupprtedScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithUnsupprtedScope2",
@@ -2179,6 +2535,10 @@
     "label": "moduleWithValidScope",
     "kind": "module",
     "detail": "moduleWithValidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithValidScope",
@@ -2193,6 +2553,10 @@
     "label": "moduleWithoutPath",
     "kind": "module",
     "detail": "moduleWithoutPath",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithoutPath",
@@ -2207,6 +2571,10 @@
     "label": "nonExistentFileRef",
     "kind": "module",
     "detail": "nonExistentFileRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentFileRef",
@@ -2221,6 +2589,10 @@
     "label": "nonExistentFileRefDuplicate",
     "kind": "module",
     "detail": "nonExistentFileRefDuplicate",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentFileRefDuplicate",
@@ -2235,6 +2607,10 @@
     "label": "nonExistentFileRefEquivalentPath",
     "kind": "module",
     "detail": "nonExistentFileRefEquivalentPath",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentFileRefEquivalentPath",
@@ -2249,6 +2625,10 @@
     "label": "nonObjectModuleBody",
     "kind": "module",
     "detail": "nonObjectModuleBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectModuleBody",
@@ -2263,6 +2643,10 @@
     "label": "nonObjectModuleBody2",
     "kind": "module",
     "detail": "nonObjectModuleBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectModuleBody2",
@@ -2277,6 +2661,10 @@
     "label": "nonObjectModuleBody3",
     "kind": "module",
     "detail": "nonObjectModuleBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectModuleBody3",
@@ -2291,6 +2679,10 @@
     "label": "nonObjectModuleBody4",
     "kind": "module",
     "detail": "nonObjectModuleBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectModuleBody4",
@@ -2305,6 +2697,10 @@
     "label": "nonexistentArrays",
     "kind": "module",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -2319,6 +2715,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -2334,7 +2734,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2354,6 +2754,10 @@
     "label": "paramNameCompletionsInFilteredLoops",
     "kind": "module",
     "detail": "paramNameCompletionsInFilteredLoops",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramNameCompletionsInFilteredLoops",
@@ -2369,7 +2773,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2390,7 +2794,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2410,6 +2814,10 @@
     "label": "propertyAccessCompletionsForFilteredModuleLoop",
     "kind": "variable",
     "detail": "propertyAccessCompletionsForFilteredModuleLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyAccessCompletionsForFilteredModuleLoop",
@@ -2425,7 +2833,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2446,7 +2854,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2467,7 +2875,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2488,7 +2896,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2509,7 +2917,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2530,7 +2938,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2551,7 +2959,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2571,6 +2979,10 @@
     "label": "runtimeInvalidModule1",
     "kind": "module",
     "detail": "runtimeInvalidModule1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidModule1",
@@ -2585,6 +2997,10 @@
     "label": "runtimeInvalidModule2",
     "kind": "module",
     "detail": "runtimeInvalidModule2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidModule2",
@@ -2599,6 +3015,10 @@
     "label": "runtimeInvalidModule3",
     "kind": "module",
     "detail": "runtimeInvalidModule3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidModule3",
@@ -2613,6 +3033,10 @@
     "label": "runtimeInvalidModule4",
     "kind": "module",
     "detail": "runtimeInvalidModule4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidModule4",
@@ -2627,6 +3051,10 @@
     "label": "runtimeInvalidModule5",
     "kind": "module",
     "detail": "runtimeInvalidModule5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidModule5",
@@ -2641,6 +3069,10 @@
     "label": "runtimeInvalidModule6",
     "kind": "module",
     "detail": "runtimeInvalidModule6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidModule6",
@@ -2655,6 +3087,10 @@
     "label": "runtimeValidModule1",
     "kind": "module",
     "detail": "runtimeValidModule1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidModule1",
@@ -2669,6 +3105,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -2686,6 +3126,10 @@
     "label": "secureModule1",
     "kind": "module",
     "detail": "secureModule1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_secureModule1",
@@ -2700,6 +3144,10 @@
     "label": "secureModule2",
     "kind": "module",
     "detail": "secureModule2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_secureModule2",
@@ -2714,6 +3162,10 @@
     "label": "singleModuleForRuntimeCheck",
     "kind": "module",
     "detail": "singleModuleForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleModuleForRuntimeCheck",
@@ -2729,7 +3181,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2750,7 +3202,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2771,7 +3223,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2792,7 +3244,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2813,7 +3265,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2834,7 +3286,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2855,7 +3307,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2876,7 +3328,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2915,7 +3367,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2936,7 +3388,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2953,7 +3405,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2974,7 +3426,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2995,7 +3447,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3016,7 +3468,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3037,7 +3489,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3058,7 +3510,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3079,7 +3531,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3099,6 +3551,10 @@
     "label": "unspecifiedOutput",
     "kind": "variable",
     "detail": "unspecifiedOutput",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unspecifiedOutput",
@@ -3114,7 +3570,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3135,7 +3591,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3156,7 +3612,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3176,6 +3632,10 @@
     "label": "wrongArrayType",
     "kind": "module",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -3190,6 +3650,10 @@
     "label": "wrongLoopBodyType",
     "kind": "module",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -3204,6 +3668,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "module",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -3218,6 +3686,10 @@
     "label": "wrongModuleParameterInFilteredLoop",
     "kind": "module",
     "detail": "wrongModuleParameterInFilteredLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongModuleParameterInFilteredLoop",
@@ -3232,6 +3704,10 @@
     "label": "wrongModuleParameterInLoop2",
     "kind": "module",
     "detail": "wrongModuleParameterInLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongModuleParameterInLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX_if.json
@@ -4,7 +4,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24,6 +24,10 @@
     "label": "anyTypeInScope",
     "kind": "module",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -38,6 +42,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "module",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -52,6 +60,10 @@
     "label": "anyTypeInScopeLoop",
     "kind": "module",
     "detail": "anyTypeInScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeLoop",
@@ -67,7 +79,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -87,6 +99,10 @@
     "label": "assignToOutput",
     "kind": "module",
     "detail": "assignToOutput",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_assignToOutput",
@@ -120,7 +136,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -141,7 +157,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -162,7 +178,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -183,7 +199,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -203,6 +219,10 @@
     "label": "childCompletionA",
     "kind": "module",
     "detail": "childCompletionA",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_childCompletionA",
@@ -217,6 +237,10 @@
     "label": "childCompletionB",
     "kind": "module",
     "detail": "childCompletionB",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_childCompletionB",
@@ -231,6 +255,10 @@
     "label": "childCompletionC",
     "kind": "module",
     "detail": "childCompletionC",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_childCompletionC",
@@ -245,6 +273,10 @@
     "label": "childCompletionD",
     "kind": "module",
     "detail": "childCompletionD",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_childCompletionD",
@@ -260,7 +292,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -281,7 +313,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -301,6 +333,10 @@
     "label": "completionB",
     "kind": "module",
     "detail": "completionB",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_completionB",
@@ -315,6 +351,10 @@
     "label": "completionC",
     "kind": "module",
     "detail": "completionC",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_completionC",
@@ -329,6 +369,10 @@
     "label": "completionD",
     "kind": "module",
     "detail": "completionD",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_completionD",
@@ -343,6 +387,10 @@
     "label": "completionE",
     "kind": "module",
     "detail": "completionE",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_completionE",
@@ -358,7 +406,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -379,7 +427,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -399,6 +447,10 @@
     "label": "cwdFileCompletionA",
     "kind": "module",
     "detail": "cwdFileCompletionA",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cwdFileCompletionA",
@@ -413,6 +465,10 @@
     "label": "cwdFileCompletionB",
     "kind": "module",
     "detail": "cwdFileCompletionB",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cwdFileCompletionB",
@@ -427,6 +483,10 @@
     "label": "cwdFileCompletionC",
     "kind": "module",
     "detail": "cwdFileCompletionC",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cwdFileCompletionC",
@@ -442,7 +502,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -463,7 +523,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -484,7 +544,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -505,7 +565,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -526,7 +586,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -547,7 +607,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -563,6 +623,10 @@
     "label": "directRefToCollectionViaLoopBody",
     "kind": "module",
     "detail": "directRefToCollectionViaLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefToCollectionViaLoopBody",
@@ -577,6 +641,10 @@
     "label": "directRefToCollectionViaLoopBodyWithExtraDependsOn",
     "kind": "module",
     "detail": "directRefToCollectionViaLoopBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefToCollectionViaLoopBodyWithExtraDependsOn",
@@ -591,6 +659,10 @@
     "label": "directRefToCollectionViaSingleBody",
     "kind": "module",
     "detail": "directRefToCollectionViaSingleBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefToCollectionViaSingleBody",
@@ -605,6 +677,10 @@
     "label": "directRefToCollectionViaSingleConditionalBody",
     "kind": "module",
     "detail": "directRefToCollectionViaSingleConditionalBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefToCollectionViaSingleConditionalBody",
@@ -620,7 +696,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -640,6 +716,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -655,7 +735,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -676,7 +756,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -692,6 +772,10 @@
     "label": "evenMoreDuplicates",
     "kind": "variable",
     "detail": "evenMoreDuplicates",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_evenMoreDuplicates",
@@ -706,6 +790,10 @@
     "label": "expectedArrayExpression",
     "kind": "module",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -720,6 +808,10 @@
     "label": "expectedArrayExpression2",
     "kind": "module",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -734,6 +826,10 @@
     "label": "expectedColon",
     "kind": "module",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -748,6 +844,10 @@
     "label": "expectedColon2",
     "kind": "module",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -762,6 +862,10 @@
     "label": "expectedComma",
     "kind": "module",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -776,6 +880,10 @@
     "label": "expectedForKeyword",
     "kind": "module",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -790,6 +898,10 @@
     "label": "expectedForKeyword2",
     "kind": "module",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -804,6 +916,10 @@
     "label": "expectedInKeyword",
     "kind": "module",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -818,6 +934,10 @@
     "label": "expectedInKeyword2",
     "kind": "module",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -832,6 +952,10 @@
     "label": "expectedInKeyword3",
     "kind": "module",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -846,6 +970,10 @@
     "label": "expectedIndexVarName",
     "kind": "module",
     "detail": "expectedIndexVarName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedIndexVarName",
@@ -860,6 +988,10 @@
     "label": "expectedItemVarName",
     "kind": "module",
     "detail": "expectedItemVarName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedItemVarName",
@@ -874,6 +1006,10 @@
     "label": "expectedLoopBody",
     "kind": "module",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -888,6 +1024,10 @@
     "label": "expectedLoopBody2",
     "kind": "module",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -902,6 +1042,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "module",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -916,6 +1060,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "module",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -930,6 +1078,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "module",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -944,6 +1096,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "module",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -958,6 +1114,10 @@
     "label": "expectedLoopVar",
     "kind": "module",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -973,7 +1133,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -994,7 +1154,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1015,7 +1175,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1036,7 +1196,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1057,7 +1217,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1078,7 +1238,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1113,7 +1273,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1134,7 +1294,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1154,6 +1314,10 @@
     "label": "interp",
     "kind": "variable",
     "detail": "interp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interp",
@@ -1169,7 +1333,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1189,6 +1353,10 @@
     "label": "invalidJsonMod",
     "kind": "module",
     "detail": "invalidJsonMod",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidJsonMod",
@@ -1203,6 +1371,10 @@
     "label": "issue3000",
     "kind": "module",
     "detail": "issue3000",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000",
@@ -1218,7 +1390,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1239,7 +1411,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1260,7 +1432,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1280,6 +1452,10 @@
     "label": "jsonModMissingParam",
     "kind": "module",
     "detail": "jsonModMissingParam",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_jsonModMissingParam",
@@ -1294,6 +1470,10 @@
     "label": "kv",
     "kind": "interface",
     "detail": "kv",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_kv",
@@ -1312,7 +1492,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1333,7 +1513,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1354,7 +1534,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1375,7 +1555,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1396,7 +1576,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1417,7 +1597,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1438,7 +1618,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1459,7 +1639,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1480,7 +1660,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1501,7 +1681,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1522,7 +1702,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1543,7 +1723,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1563,6 +1743,10 @@
     "label": "missingFewerLoopBodyProperties",
     "kind": "module",
     "detail": "missingFewerLoopBodyProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerLoopBodyProperties",
@@ -1577,6 +1761,10 @@
     "label": "missingLoopBodyProperties",
     "kind": "module",
     "detail": "missingLoopBodyProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingLoopBodyProperties",
@@ -1591,6 +1779,10 @@
     "label": "missingLoopBodyProperties2",
     "kind": "module",
     "detail": "missingLoopBodyProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingLoopBodyProperties2",
@@ -1605,6 +1797,10 @@
     "label": "missingValue",
     "kind": "module",
     "detail": "missingValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingValue",
@@ -1619,6 +1815,10 @@
     "label": "modAEmptyInputs",
     "kind": "module",
     "detail": "modAEmptyInputs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modAEmptyInputs",
@@ -1633,6 +1833,10 @@
     "label": "modAEmptyInputsWithCondition",
     "kind": "module",
     "detail": "modAEmptyInputsWithCondition",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modAEmptyInputsWithCondition",
@@ -1647,6 +1851,10 @@
     "label": "modANoInputs",
     "kind": "module",
     "detail": "modANoInputs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modANoInputs",
@@ -1661,6 +1869,10 @@
     "label": "modANoInputsWithCondition",
     "kind": "module",
     "detail": "modANoInputsWithCondition",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modANoInputsWithCondition",
@@ -1675,6 +1887,10 @@
     "label": "modANoName",
     "kind": "module",
     "detail": "modANoName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modANoName",
@@ -1689,6 +1905,10 @@
     "label": "modANoNameWithCondition",
     "kind": "module",
     "detail": "modANoNameWithCondition",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modANoNameWithCondition",
@@ -1703,6 +1923,10 @@
     "label": "modAUnspecifiedInputs",
     "kind": "module",
     "detail": "modAUnspecifiedInputs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modAUnspecifiedInputs",
@@ -1717,6 +1941,10 @@
     "label": "modCycle",
     "kind": "module",
     "detail": "modCycle",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modCycle",
@@ -1731,6 +1959,10 @@
     "label": "modWithListKeysInCondition",
     "kind": "module",
     "detail": "modWithListKeysInCondition",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modWithListKeysInCondition",
@@ -1745,6 +1977,10 @@
     "label": "modWithReferenceInCondition",
     "kind": "module",
     "detail": "modWithReferenceInCondition",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modWithReferenceInCondition",
@@ -1759,6 +1995,10 @@
     "label": "moduleLoopForRuntimeCheck",
     "kind": "module",
     "detail": "moduleLoopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleLoopForRuntimeCheck",
@@ -1773,6 +2013,10 @@
     "label": "moduleLoopForRuntimeCheck2",
     "kind": "module",
     "detail": "moduleLoopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleLoopForRuntimeCheck2",
@@ -1787,6 +2031,10 @@
     "label": "moduleLoopForRuntimeCheck3",
     "kind": "module",
     "detail": "moduleLoopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleLoopForRuntimeCheck3",
@@ -1801,6 +2049,10 @@
     "label": "moduleOutputsCompletions",
     "kind": "variable",
     "detail": "moduleOutputsCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleOutputsCompletions",
@@ -1815,6 +2067,10 @@
     "label": "modulePropertyAccessCompletions",
     "kind": "variable",
     "detail": "modulePropertyAccessCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modulePropertyAccessCompletions",
@@ -1829,6 +2085,10 @@
     "label": "moduleRuntimeCheck",
     "kind": "variable",
     "detail": "moduleRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleRuntimeCheck",
@@ -1843,6 +2103,10 @@
     "label": "moduleRuntimeCheck2",
     "kind": "variable",
     "detail": "moduleRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleRuntimeCheck2",
@@ -1857,6 +2121,10 @@
     "label": "moduleRuntimeCheck3",
     "kind": "variable",
     "detail": "moduleRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleRuntimeCheck3",
@@ -1871,6 +2139,10 @@
     "label": "moduleRuntimeCheck4",
     "kind": "variable",
     "detail": "moduleRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleRuntimeCheck4",
@@ -1885,6 +2157,10 @@
     "label": "moduleWithAbsolutePath",
     "kind": "module",
     "detail": "moduleWithAbsolutePath",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithAbsolutePath",
@@ -1899,6 +2175,10 @@
     "label": "moduleWithBackslash",
     "kind": "module",
     "detail": "moduleWithBackslash",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithBackslash",
@@ -1913,6 +2193,10 @@
     "label": "moduleWithBadScope",
     "kind": "module",
     "detail": "moduleWithBadScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithBadScope",
@@ -1927,6 +2211,10 @@
     "label": "moduleWithConditionAndInterpPath",
     "kind": "module",
     "detail": "moduleWithConditionAndInterpPath",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithConditionAndInterpPath",
@@ -1941,6 +2229,10 @@
     "label": "moduleWithConditionAndSelfCycle",
     "kind": "module",
     "detail": "moduleWithConditionAndSelfCycle",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithConditionAndSelfCycle",
@@ -1955,6 +2247,10 @@
     "label": "moduleWithConditionOutputsCompletions",
     "kind": "variable",
     "detail": "moduleWithConditionOutputsCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithConditionOutputsCompletions",
@@ -1969,6 +2265,10 @@
     "label": "moduleWithConditionPropertyAccessCompletions",
     "kind": "variable",
     "detail": "moduleWithConditionPropertyAccessCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithConditionPropertyAccessCompletions",
@@ -1983,6 +2283,10 @@
     "label": "moduleWithDuplicateName1",
     "kind": "module",
     "detail": "moduleWithDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithDuplicateName1",
@@ -1997,6 +2301,10 @@
     "label": "moduleWithDuplicateName2",
     "kind": "module",
     "detail": "moduleWithDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithDuplicateName2",
@@ -2011,6 +2319,10 @@
     "label": "moduleWithEmptyPath",
     "kind": "module",
     "detail": "moduleWithEmptyPath",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithEmptyPath",
@@ -2025,6 +2337,10 @@
     "label": "moduleWithInterpPath",
     "kind": "module",
     "detail": "moduleWithInterpPath",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithInterpPath",
@@ -2039,6 +2355,10 @@
     "label": "moduleWithInvalidChar",
     "kind": "module",
     "detail": "moduleWithInvalidChar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithInvalidChar",
@@ -2053,6 +2373,10 @@
     "label": "moduleWithInvalidScope",
     "kind": "module",
     "detail": "moduleWithInvalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithInvalidScope",
@@ -2067,6 +2391,10 @@
     "label": "moduleWithInvalidScope2",
     "kind": "module",
     "detail": "moduleWithInvalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithInvalidScope2",
@@ -2081,6 +2409,10 @@
     "label": "moduleWithInvalidTerminatorChar",
     "kind": "module",
     "detail": "moduleWithInvalidTerminatorChar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithInvalidTerminatorChar",
@@ -2095,6 +2427,10 @@
     "label": "moduleWithMissingRequiredScope",
     "kind": "module",
     "detail": "moduleWithMissingRequiredScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithMissingRequiredScope",
@@ -2109,6 +2445,10 @@
     "label": "moduleWithNotAttachableDecorators",
     "kind": "module",
     "detail": "moduleWithNotAttachableDecorators",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithNotAttachableDecorators",
@@ -2123,6 +2463,10 @@
     "label": "moduleWithPath",
     "kind": "module",
     "detail": "moduleWithPath",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithPath",
@@ -2137,6 +2481,10 @@
     "label": "moduleWithSelfCycle",
     "kind": "module",
     "detail": "moduleWithSelfCycle",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithSelfCycle",
@@ -2151,6 +2499,10 @@
     "label": "moduleWithUnsupprtedScope1",
     "kind": "module",
     "detail": "moduleWithUnsupprtedScope1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithUnsupprtedScope1",
@@ -2165,6 +2517,10 @@
     "label": "moduleWithUnsupprtedScope2",
     "kind": "module",
     "detail": "moduleWithUnsupprtedScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithUnsupprtedScope2",
@@ -2179,6 +2535,10 @@
     "label": "moduleWithValidScope",
     "kind": "module",
     "detail": "moduleWithValidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithValidScope",
@@ -2193,6 +2553,10 @@
     "label": "moduleWithoutPath",
     "kind": "module",
     "detail": "moduleWithoutPath",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithoutPath",
@@ -2207,6 +2571,10 @@
     "label": "nonExistentFileRef",
     "kind": "module",
     "detail": "nonExistentFileRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentFileRef",
@@ -2221,6 +2589,10 @@
     "label": "nonExistentFileRefDuplicate",
     "kind": "module",
     "detail": "nonExistentFileRefDuplicate",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentFileRefDuplicate",
@@ -2235,6 +2607,10 @@
     "label": "nonExistentFileRefEquivalentPath",
     "kind": "module",
     "detail": "nonExistentFileRefEquivalentPath",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentFileRefEquivalentPath",
@@ -2249,6 +2625,10 @@
     "label": "nonObjectModuleBody",
     "kind": "module",
     "detail": "nonObjectModuleBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectModuleBody",
@@ -2263,6 +2643,10 @@
     "label": "nonObjectModuleBody2",
     "kind": "module",
     "detail": "nonObjectModuleBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectModuleBody2",
@@ -2277,6 +2661,10 @@
     "label": "nonObjectModuleBody3",
     "kind": "module",
     "detail": "nonObjectModuleBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectModuleBody3",
@@ -2291,6 +2679,10 @@
     "label": "nonObjectModuleBody4",
     "kind": "module",
     "detail": "nonObjectModuleBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectModuleBody4",
@@ -2305,6 +2697,10 @@
     "label": "nonexistentArrays",
     "kind": "module",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -2319,6 +2715,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -2334,7 +2734,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2354,6 +2754,10 @@
     "label": "paramNameCompletionsInFilteredLoops",
     "kind": "module",
     "detail": "paramNameCompletionsInFilteredLoops",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramNameCompletionsInFilteredLoops",
@@ -2369,7 +2773,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2390,7 +2794,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2410,6 +2814,10 @@
     "label": "propertyAccessCompletionsForFilteredModuleLoop",
     "kind": "variable",
     "detail": "propertyAccessCompletionsForFilteredModuleLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyAccessCompletionsForFilteredModuleLoop",
@@ -2425,7 +2833,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2446,7 +2854,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2467,7 +2875,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2488,7 +2896,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2509,7 +2917,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2530,7 +2938,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2551,7 +2959,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2571,6 +2979,10 @@
     "label": "runtimeInvalidModule1",
     "kind": "module",
     "detail": "runtimeInvalidModule1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidModule1",
@@ -2585,6 +2997,10 @@
     "label": "runtimeInvalidModule2",
     "kind": "module",
     "detail": "runtimeInvalidModule2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidModule2",
@@ -2599,6 +3015,10 @@
     "label": "runtimeInvalidModule3",
     "kind": "module",
     "detail": "runtimeInvalidModule3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidModule3",
@@ -2613,6 +3033,10 @@
     "label": "runtimeInvalidModule4",
     "kind": "module",
     "detail": "runtimeInvalidModule4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidModule4",
@@ -2627,6 +3051,10 @@
     "label": "runtimeInvalidModule5",
     "kind": "module",
     "detail": "runtimeInvalidModule5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidModule5",
@@ -2641,6 +3069,10 @@
     "label": "runtimeInvalidModule6",
     "kind": "module",
     "detail": "runtimeInvalidModule6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidModule6",
@@ -2655,6 +3087,10 @@
     "label": "runtimeValidModule1",
     "kind": "module",
     "detail": "runtimeValidModule1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidModule1",
@@ -2669,6 +3105,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -2686,6 +3126,10 @@
     "label": "secureModule1",
     "kind": "module",
     "detail": "secureModule1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_secureModule1",
@@ -2700,6 +3144,10 @@
     "label": "secureModule2",
     "kind": "module",
     "detail": "secureModule2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_secureModule2",
@@ -2714,6 +3162,10 @@
     "label": "singleModuleForRuntimeCheck",
     "kind": "module",
     "detail": "singleModuleForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleModuleForRuntimeCheck",
@@ -2729,7 +3181,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2750,7 +3202,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2771,7 +3223,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2792,7 +3244,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2813,7 +3265,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2834,7 +3286,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2855,7 +3307,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2876,7 +3328,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2915,7 +3367,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2936,7 +3388,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2953,7 +3405,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2974,7 +3426,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2995,7 +3447,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3016,7 +3468,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3037,7 +3489,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3058,7 +3510,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3079,7 +3531,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3099,6 +3551,10 @@
     "label": "unspecifiedOutput",
     "kind": "variable",
     "detail": "unspecifiedOutput",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unspecifiedOutput",
@@ -3114,7 +3570,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3135,7 +3591,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3156,7 +3612,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3176,6 +3632,10 @@
     "label": "wrongArrayType",
     "kind": "module",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -3190,6 +3650,10 @@
     "label": "wrongLoopBodyType",
     "kind": "module",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -3204,6 +3668,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "module",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -3218,6 +3686,10 @@
     "label": "wrongModuleParameterInLoop",
     "kind": "module",
     "detail": "wrongModuleParameterInLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongModuleParameterInLoop",
@@ -3232,6 +3704,10 @@
     "label": "wrongModuleParameterInLoop2",
     "kind": "module",
     "detail": "wrongModuleParameterInLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongModuleParameterInLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX_if.json
@@ -24,10 +24,6 @@
     "label": "anyTypeInScope",
     "kind": "module",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -42,10 +38,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "module",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -60,10 +52,6 @@
     "label": "anyTypeInScopeLoop",
     "kind": "module",
     "detail": "anyTypeInScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeLoop",
@@ -99,10 +87,6 @@
     "label": "assignToOutput",
     "kind": "module",
     "detail": "assignToOutput",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_assignToOutput",
@@ -219,10 +203,6 @@
     "label": "childCompletionA",
     "kind": "module",
     "detail": "childCompletionA",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_childCompletionA",
@@ -237,10 +217,6 @@
     "label": "childCompletionB",
     "kind": "module",
     "detail": "childCompletionB",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_childCompletionB",
@@ -255,10 +231,6 @@
     "label": "childCompletionC",
     "kind": "module",
     "detail": "childCompletionC",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_childCompletionC",
@@ -273,10 +245,6 @@
     "label": "childCompletionD",
     "kind": "module",
     "detail": "childCompletionD",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_childCompletionD",
@@ -333,10 +301,6 @@
     "label": "completionB",
     "kind": "module",
     "detail": "completionB",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_completionB",
@@ -351,10 +315,6 @@
     "label": "completionC",
     "kind": "module",
     "detail": "completionC",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_completionC",
@@ -369,10 +329,6 @@
     "label": "completionD",
     "kind": "module",
     "detail": "completionD",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_completionD",
@@ -387,10 +343,6 @@
     "label": "completionE",
     "kind": "module",
     "detail": "completionE",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_completionE",
@@ -447,10 +399,6 @@
     "label": "cwdFileCompletionA",
     "kind": "module",
     "detail": "cwdFileCompletionA",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cwdFileCompletionA",
@@ -465,10 +413,6 @@
     "label": "cwdFileCompletionB",
     "kind": "module",
     "detail": "cwdFileCompletionB",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cwdFileCompletionB",
@@ -483,10 +427,6 @@
     "label": "cwdFileCompletionC",
     "kind": "module",
     "detail": "cwdFileCompletionC",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cwdFileCompletionC",
@@ -623,10 +563,6 @@
     "label": "directRefToCollectionViaLoopBody",
     "kind": "module",
     "detail": "directRefToCollectionViaLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefToCollectionViaLoopBody",
@@ -641,10 +577,6 @@
     "label": "directRefToCollectionViaLoopBodyWithExtraDependsOn",
     "kind": "module",
     "detail": "directRefToCollectionViaLoopBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefToCollectionViaLoopBodyWithExtraDependsOn",
@@ -659,10 +591,6 @@
     "label": "directRefToCollectionViaSingleBody",
     "kind": "module",
     "detail": "directRefToCollectionViaSingleBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefToCollectionViaSingleBody",
@@ -677,10 +605,6 @@
     "label": "directRefToCollectionViaSingleConditionalBody",
     "kind": "module",
     "detail": "directRefToCollectionViaSingleConditionalBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefToCollectionViaSingleConditionalBody",
@@ -716,10 +640,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -772,10 +692,6 @@
     "label": "evenMoreDuplicates",
     "kind": "variable",
     "detail": "evenMoreDuplicates",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_evenMoreDuplicates",
@@ -790,10 +706,6 @@
     "label": "expectedArrayExpression",
     "kind": "module",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -808,10 +720,6 @@
     "label": "expectedArrayExpression2",
     "kind": "module",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -826,10 +734,6 @@
     "label": "expectedColon",
     "kind": "module",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -844,10 +748,6 @@
     "label": "expectedColon2",
     "kind": "module",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -862,10 +762,6 @@
     "label": "expectedComma",
     "kind": "module",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -880,10 +776,6 @@
     "label": "expectedForKeyword",
     "kind": "module",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -898,10 +790,6 @@
     "label": "expectedForKeyword2",
     "kind": "module",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -916,10 +804,6 @@
     "label": "expectedInKeyword",
     "kind": "module",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -934,10 +818,6 @@
     "label": "expectedInKeyword2",
     "kind": "module",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -952,10 +832,6 @@
     "label": "expectedInKeyword3",
     "kind": "module",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -970,10 +846,6 @@
     "label": "expectedIndexVarName",
     "kind": "module",
     "detail": "expectedIndexVarName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedIndexVarName",
@@ -988,10 +860,6 @@
     "label": "expectedItemVarName",
     "kind": "module",
     "detail": "expectedItemVarName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedItemVarName",
@@ -1006,10 +874,6 @@
     "label": "expectedLoopBody",
     "kind": "module",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -1024,10 +888,6 @@
     "label": "expectedLoopBody2",
     "kind": "module",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -1042,10 +902,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "module",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -1060,10 +916,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "module",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -1078,10 +930,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "module",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -1096,10 +944,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "module",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -1114,10 +958,6 @@
     "label": "expectedLoopVar",
     "kind": "module",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -1314,10 +1154,6 @@
     "label": "interp",
     "kind": "variable",
     "detail": "interp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interp",
@@ -1353,10 +1189,6 @@
     "label": "invalidJsonMod",
     "kind": "module",
     "detail": "invalidJsonMod",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidJsonMod",
@@ -1371,10 +1203,6 @@
     "label": "issue3000",
     "kind": "module",
     "detail": "issue3000",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000",
@@ -1452,10 +1280,6 @@
     "label": "jsonModMissingParam",
     "kind": "module",
     "detail": "jsonModMissingParam",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_jsonModMissingParam",
@@ -1470,10 +1294,6 @@
     "label": "kv",
     "kind": "interface",
     "detail": "kv",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_kv",
@@ -1743,10 +1563,6 @@
     "label": "missingFewerLoopBodyProperties",
     "kind": "module",
     "detail": "missingFewerLoopBodyProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerLoopBodyProperties",
@@ -1761,10 +1577,6 @@
     "label": "missingLoopBodyProperties",
     "kind": "module",
     "detail": "missingLoopBodyProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingLoopBodyProperties",
@@ -1779,10 +1591,6 @@
     "label": "missingLoopBodyProperties2",
     "kind": "module",
     "detail": "missingLoopBodyProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingLoopBodyProperties2",
@@ -1797,10 +1605,6 @@
     "label": "missingValue",
     "kind": "module",
     "detail": "missingValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingValue",
@@ -1815,10 +1619,6 @@
     "label": "modAEmptyInputs",
     "kind": "module",
     "detail": "modAEmptyInputs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modAEmptyInputs",
@@ -1833,10 +1633,6 @@
     "label": "modAEmptyInputsWithCondition",
     "kind": "module",
     "detail": "modAEmptyInputsWithCondition",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modAEmptyInputsWithCondition",
@@ -1851,10 +1647,6 @@
     "label": "modANoInputs",
     "kind": "module",
     "detail": "modANoInputs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modANoInputs",
@@ -1869,10 +1661,6 @@
     "label": "modANoInputsWithCondition",
     "kind": "module",
     "detail": "modANoInputsWithCondition",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modANoInputsWithCondition",
@@ -1887,10 +1675,6 @@
     "label": "modANoName",
     "kind": "module",
     "detail": "modANoName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modANoName",
@@ -1905,10 +1689,6 @@
     "label": "modANoNameWithCondition",
     "kind": "module",
     "detail": "modANoNameWithCondition",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modANoNameWithCondition",
@@ -1923,10 +1703,6 @@
     "label": "modAUnspecifiedInputs",
     "kind": "module",
     "detail": "modAUnspecifiedInputs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modAUnspecifiedInputs",
@@ -1941,10 +1717,6 @@
     "label": "modCycle",
     "kind": "module",
     "detail": "modCycle",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modCycle",
@@ -1959,10 +1731,6 @@
     "label": "modWithListKeysInCondition",
     "kind": "module",
     "detail": "modWithListKeysInCondition",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modWithListKeysInCondition",
@@ -1977,10 +1745,6 @@
     "label": "modWithReferenceInCondition",
     "kind": "module",
     "detail": "modWithReferenceInCondition",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modWithReferenceInCondition",
@@ -1995,10 +1759,6 @@
     "label": "moduleLoopForRuntimeCheck",
     "kind": "module",
     "detail": "moduleLoopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleLoopForRuntimeCheck",
@@ -2013,10 +1773,6 @@
     "label": "moduleLoopForRuntimeCheck2",
     "kind": "module",
     "detail": "moduleLoopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleLoopForRuntimeCheck2",
@@ -2031,10 +1787,6 @@
     "label": "moduleLoopForRuntimeCheck3",
     "kind": "module",
     "detail": "moduleLoopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleLoopForRuntimeCheck3",
@@ -2049,10 +1801,6 @@
     "label": "moduleOutputsCompletions",
     "kind": "variable",
     "detail": "moduleOutputsCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleOutputsCompletions",
@@ -2067,10 +1815,6 @@
     "label": "modulePropertyAccessCompletions",
     "kind": "variable",
     "detail": "modulePropertyAccessCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_modulePropertyAccessCompletions",
@@ -2085,10 +1829,6 @@
     "label": "moduleRuntimeCheck",
     "kind": "variable",
     "detail": "moduleRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleRuntimeCheck",
@@ -2103,10 +1843,6 @@
     "label": "moduleRuntimeCheck2",
     "kind": "variable",
     "detail": "moduleRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleRuntimeCheck2",
@@ -2121,10 +1857,6 @@
     "label": "moduleRuntimeCheck3",
     "kind": "variable",
     "detail": "moduleRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleRuntimeCheck3",
@@ -2139,10 +1871,6 @@
     "label": "moduleRuntimeCheck4",
     "kind": "variable",
     "detail": "moduleRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleRuntimeCheck4",
@@ -2157,10 +1885,6 @@
     "label": "moduleWithAbsolutePath",
     "kind": "module",
     "detail": "moduleWithAbsolutePath",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithAbsolutePath",
@@ -2175,10 +1899,6 @@
     "label": "moduleWithBackslash",
     "kind": "module",
     "detail": "moduleWithBackslash",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithBackslash",
@@ -2193,10 +1913,6 @@
     "label": "moduleWithBadScope",
     "kind": "module",
     "detail": "moduleWithBadScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithBadScope",
@@ -2211,10 +1927,6 @@
     "label": "moduleWithConditionAndInterpPath",
     "kind": "module",
     "detail": "moduleWithConditionAndInterpPath",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithConditionAndInterpPath",
@@ -2229,10 +1941,6 @@
     "label": "moduleWithConditionAndSelfCycle",
     "kind": "module",
     "detail": "moduleWithConditionAndSelfCycle",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithConditionAndSelfCycle",
@@ -2247,10 +1955,6 @@
     "label": "moduleWithConditionOutputsCompletions",
     "kind": "variable",
     "detail": "moduleWithConditionOutputsCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithConditionOutputsCompletions",
@@ -2265,10 +1969,6 @@
     "label": "moduleWithConditionPropertyAccessCompletions",
     "kind": "variable",
     "detail": "moduleWithConditionPropertyAccessCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithConditionPropertyAccessCompletions",
@@ -2283,10 +1983,6 @@
     "label": "moduleWithDuplicateName1",
     "kind": "module",
     "detail": "moduleWithDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithDuplicateName1",
@@ -2301,10 +1997,6 @@
     "label": "moduleWithDuplicateName2",
     "kind": "module",
     "detail": "moduleWithDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithDuplicateName2",
@@ -2319,10 +2011,6 @@
     "label": "moduleWithEmptyPath",
     "kind": "module",
     "detail": "moduleWithEmptyPath",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithEmptyPath",
@@ -2337,10 +2025,6 @@
     "label": "moduleWithInterpPath",
     "kind": "module",
     "detail": "moduleWithInterpPath",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithInterpPath",
@@ -2355,10 +2039,6 @@
     "label": "moduleWithInvalidChar",
     "kind": "module",
     "detail": "moduleWithInvalidChar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithInvalidChar",
@@ -2373,10 +2053,6 @@
     "label": "moduleWithInvalidScope",
     "kind": "module",
     "detail": "moduleWithInvalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithInvalidScope",
@@ -2391,10 +2067,6 @@
     "label": "moduleWithInvalidScope2",
     "kind": "module",
     "detail": "moduleWithInvalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithInvalidScope2",
@@ -2409,10 +2081,6 @@
     "label": "moduleWithInvalidTerminatorChar",
     "kind": "module",
     "detail": "moduleWithInvalidTerminatorChar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithInvalidTerminatorChar",
@@ -2427,10 +2095,6 @@
     "label": "moduleWithMissingRequiredScope",
     "kind": "module",
     "detail": "moduleWithMissingRequiredScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithMissingRequiredScope",
@@ -2445,10 +2109,6 @@
     "label": "moduleWithNotAttachableDecorators",
     "kind": "module",
     "detail": "moduleWithNotAttachableDecorators",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithNotAttachableDecorators",
@@ -2463,10 +2123,6 @@
     "label": "moduleWithPath",
     "kind": "module",
     "detail": "moduleWithPath",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithPath",
@@ -2481,10 +2137,6 @@
     "label": "moduleWithSelfCycle",
     "kind": "module",
     "detail": "moduleWithSelfCycle",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithSelfCycle",
@@ -2499,10 +2151,6 @@
     "label": "moduleWithUnsupprtedScope1",
     "kind": "module",
     "detail": "moduleWithUnsupprtedScope1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithUnsupprtedScope1",
@@ -2517,10 +2165,6 @@
     "label": "moduleWithUnsupprtedScope2",
     "kind": "module",
     "detail": "moduleWithUnsupprtedScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithUnsupprtedScope2",
@@ -2535,10 +2179,6 @@
     "label": "moduleWithValidScope",
     "kind": "module",
     "detail": "moduleWithValidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithValidScope",
@@ -2553,10 +2193,6 @@
     "label": "moduleWithoutPath",
     "kind": "module",
     "detail": "moduleWithoutPath",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moduleWithoutPath",
@@ -2571,10 +2207,6 @@
     "label": "nonExistentFileRef",
     "kind": "module",
     "detail": "nonExistentFileRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentFileRef",
@@ -2589,10 +2221,6 @@
     "label": "nonExistentFileRefDuplicate",
     "kind": "module",
     "detail": "nonExistentFileRefDuplicate",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentFileRefDuplicate",
@@ -2607,10 +2235,6 @@
     "label": "nonExistentFileRefEquivalentPath",
     "kind": "module",
     "detail": "nonExistentFileRefEquivalentPath",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentFileRefEquivalentPath",
@@ -2625,10 +2249,6 @@
     "label": "nonObjectModuleBody",
     "kind": "module",
     "detail": "nonObjectModuleBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectModuleBody",
@@ -2643,10 +2263,6 @@
     "label": "nonObjectModuleBody2",
     "kind": "module",
     "detail": "nonObjectModuleBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectModuleBody2",
@@ -2661,10 +2277,6 @@
     "label": "nonObjectModuleBody3",
     "kind": "module",
     "detail": "nonObjectModuleBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectModuleBody3",
@@ -2679,10 +2291,6 @@
     "label": "nonObjectModuleBody4",
     "kind": "module",
     "detail": "nonObjectModuleBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectModuleBody4",
@@ -2697,10 +2305,6 @@
     "label": "nonexistentArrays",
     "kind": "module",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -2715,10 +2319,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -2754,10 +2354,6 @@
     "label": "paramNameCompletionsInFilteredLoops",
     "kind": "module",
     "detail": "paramNameCompletionsInFilteredLoops",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramNameCompletionsInFilteredLoops",
@@ -2814,10 +2410,6 @@
     "label": "propertyAccessCompletionsForFilteredModuleLoop",
     "kind": "variable",
     "detail": "propertyAccessCompletionsForFilteredModuleLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyAccessCompletionsForFilteredModuleLoop",
@@ -2979,10 +2571,6 @@
     "label": "runtimeInvalidModule1",
     "kind": "module",
     "detail": "runtimeInvalidModule1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidModule1",
@@ -2997,10 +2585,6 @@
     "label": "runtimeInvalidModule2",
     "kind": "module",
     "detail": "runtimeInvalidModule2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidModule2",
@@ -3015,10 +2599,6 @@
     "label": "runtimeInvalidModule3",
     "kind": "module",
     "detail": "runtimeInvalidModule3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidModule3",
@@ -3033,10 +2613,6 @@
     "label": "runtimeInvalidModule4",
     "kind": "module",
     "detail": "runtimeInvalidModule4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidModule4",
@@ -3051,10 +2627,6 @@
     "label": "runtimeInvalidModule5",
     "kind": "module",
     "detail": "runtimeInvalidModule5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidModule5",
@@ -3069,10 +2641,6 @@
     "label": "runtimeInvalidModule6",
     "kind": "module",
     "detail": "runtimeInvalidModule6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidModule6",
@@ -3087,10 +2655,6 @@
     "label": "runtimeValidModule1",
     "kind": "module",
     "detail": "runtimeValidModule1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidModule1",
@@ -3105,10 +2669,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -3126,10 +2686,6 @@
     "label": "secureModule1",
     "kind": "module",
     "detail": "secureModule1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_secureModule1",
@@ -3144,10 +2700,6 @@
     "label": "secureModule2",
     "kind": "module",
     "detail": "secureModule2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_secureModule2",
@@ -3162,10 +2714,6 @@
     "label": "singleModuleForRuntimeCheck",
     "kind": "module",
     "detail": "singleModuleForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleModuleForRuntimeCheck",
@@ -3551,10 +3099,6 @@
     "label": "unspecifiedOutput",
     "kind": "variable",
     "detail": "unspecifiedOutput",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unspecifiedOutput",
@@ -3632,10 +3176,6 @@
     "label": "wrongArrayType",
     "kind": "module",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -3650,10 +3190,6 @@
     "label": "wrongLoopBodyType",
     "kind": "module",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -3668,10 +3204,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "module",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -3686,10 +3218,6 @@
     "label": "wrongModuleParameterInLoop",
     "kind": "module",
     "detail": "wrongModuleParameterInLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongModuleParameterInLoop",
@@ -3704,10 +3232,6 @@
     "label": "wrongModuleParameterInLoop2",
     "kind": "module",
     "detail": "wrongModuleParameterInLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongModuleParameterInLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/arrayPlusSymbols.json
@@ -18,7 +18,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -39,7 +39,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -59,6 +59,10 @@
     "label": "attemptToReferenceAnOutput",
     "kind": "variable",
     "detail": "attemptToReferenceAnOutput",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_attemptToReferenceAnOutput",
@@ -92,7 +96,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -113,7 +117,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -134,7 +138,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -155,7 +159,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -176,7 +180,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -197,7 +201,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -218,7 +222,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -239,7 +243,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -260,7 +264,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -281,7 +285,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -302,7 +306,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -323,7 +327,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -344,7 +348,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -365,7 +369,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -382,7 +386,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -403,7 +407,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -424,7 +428,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -441,7 +445,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -462,7 +466,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -483,7 +487,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -504,7 +508,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -526,7 +530,7 @@
     "detail": "for",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n[for item in list: ]\n```"
+      "value": "```bicep\n[for item in list: ]\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -544,7 +548,7 @@
     "detail": "for-indexed",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n[for (item, index) in list: ]\n```"
+      "value": "```bicep\n[for (item, index) in list: ]\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -561,7 +565,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -582,7 +586,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -617,7 +621,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -638,7 +642,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -659,7 +663,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -680,7 +684,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -701,7 +705,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -722,7 +726,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -742,6 +746,10 @@
     "label": "kv",
     "kind": "interface",
     "detail": "kv",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_kv",
@@ -760,7 +768,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -781,7 +789,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -802,7 +810,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -823,7 +831,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -844,7 +852,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -865,7 +873,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -886,7 +894,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -907,7 +915,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -928,7 +936,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -949,7 +957,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -970,7 +978,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -991,7 +999,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1012,7 +1020,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1033,7 +1041,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1054,7 +1062,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1075,7 +1083,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1096,7 +1104,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1117,7 +1125,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1138,7 +1146,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1159,7 +1167,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1180,7 +1188,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1201,7 +1209,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1222,7 +1230,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1243,7 +1251,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1264,7 +1272,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1285,7 +1293,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1306,7 +1314,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1327,7 +1335,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1348,7 +1356,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1369,7 +1377,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1408,7 +1416,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1429,7 +1437,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1446,7 +1454,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1466,6 +1474,10 @@
     "label": "testSymbol",
     "kind": "variable",
     "detail": "testSymbol",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_testSymbol",
@@ -1481,7 +1493,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1502,7 +1514,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1523,7 +1535,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1544,7 +1556,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1565,7 +1577,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1586,7 +1598,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1607,7 +1619,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1628,7 +1640,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1649,7 +1661,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/arrayPlusSymbols.json
@@ -59,10 +59,6 @@
     "label": "attemptToReferenceAnOutput",
     "kind": "variable",
     "detail": "attemptToReferenceAnOutput",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_attemptToReferenceAnOutput",
@@ -746,10 +742,6 @@
     "label": "kv",
     "kind": "interface",
     "detail": "kv",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_kv",
@@ -1474,10 +1466,6 @@
     "label": "testSymbol",
     "kind": "variable",
     "detail": "testSymbol",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_testSymbol",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/boolPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/boolPlusSymbols.json
@@ -45,10 +45,6 @@
     "label": "attemptToReferenceAnOutput",
     "kind": "variable",
     "detail": "attemptToReferenceAnOutput",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_attemptToReferenceAnOutput",
@@ -710,10 +706,6 @@
     "label": "kv",
     "kind": "interface",
     "detail": "kv",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_kv",
@@ -1438,10 +1430,6 @@
     "label": "testSymbol",
     "kind": "variable",
     "detail": "testSymbol",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_testSymbol",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/boolPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/boolPlusSymbols.json
@@ -4,7 +4,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25,7 +25,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45,6 +45,10 @@
     "label": "attemptToReferenceAnOutput",
     "kind": "variable",
     "detail": "attemptToReferenceAnOutput",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_attemptToReferenceAnOutput",
@@ -78,7 +82,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -99,7 +103,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -120,7 +124,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -141,7 +145,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -162,7 +166,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -183,7 +187,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -204,7 +208,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -225,7 +229,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -246,7 +250,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -267,7 +271,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -288,7 +292,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -309,7 +313,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -330,7 +334,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -351,7 +355,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -368,7 +372,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -389,7 +393,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -410,7 +414,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -427,7 +431,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -462,7 +466,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -483,7 +487,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -504,7 +508,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -525,7 +529,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -546,7 +550,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -581,7 +585,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -602,7 +606,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -623,7 +627,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -644,7 +648,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -665,7 +669,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -686,7 +690,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -706,6 +710,10 @@
     "label": "kv",
     "kind": "interface",
     "detail": "kv",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_kv",
@@ -724,7 +732,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -745,7 +753,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -766,7 +774,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -787,7 +795,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -808,7 +816,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -829,7 +837,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -850,7 +858,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -871,7 +879,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -892,7 +900,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -913,7 +921,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -934,7 +942,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -955,7 +963,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -976,7 +984,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -997,7 +1005,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1018,7 +1026,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1039,7 +1047,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1060,7 +1068,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1081,7 +1089,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1102,7 +1110,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1123,7 +1131,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1144,7 +1152,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1165,7 +1173,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1186,7 +1194,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1207,7 +1215,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1228,7 +1236,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1249,7 +1257,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1270,7 +1278,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1291,7 +1299,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1312,7 +1320,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1333,7 +1341,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1372,7 +1380,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1393,7 +1401,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1410,7 +1418,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1430,6 +1438,10 @@
     "label": "testSymbol",
     "kind": "variable",
     "detail": "testSymbol",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_testSymbol",
@@ -1445,7 +1457,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1466,7 +1478,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1487,7 +1499,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1508,7 +1520,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1543,7 +1555,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1564,7 +1576,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1585,7 +1597,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1606,7 +1618,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1627,7 +1639,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/decorators.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/decorators.json
@@ -4,7 +4,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nallowed(values: array): any\n\n```\n\n"
+      "value": "```bicep\nallowed(values: array): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25,7 +25,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbatchSize(batchSize: int): any\n\n```\n\n"
+      "value": "```bicep\nbatchSize(batchSize: int): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46,7 +46,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndescription(text: string): any\n\n```\n\n"
+      "value": "```bicep\ndescription(text: string): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -67,7 +67,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndiscriminator(value: string): any\n\n```\n\n"
+      "value": "```bicep\ndiscriminator(value: string): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -88,7 +88,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmaxLength(length: int): any\n\n```\n\n"
+      "value": "```bicep\nmaxLength(length: int): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -109,7 +109,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmaxValue(value: int): any\n\n```\n\n"
+      "value": "```bicep\nmaxValue(value: int): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -130,7 +130,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmetadata(object: object): any\n\n```\n\n"
+      "value": "```bicep\nmetadata(object: object): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -151,7 +151,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nminLength(length: int): any\n\n```\n\n"
+      "value": "```bicep\nminLength(length: int): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -172,7 +172,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nminValue(value: int): any\n\n```\n\n"
+      "value": "```bicep\nminValue(value: int): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -193,7 +193,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsealed(): any\n\n```\n\n"
+      "value": "```bicep\nsealed(): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -210,7 +210,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsecure(): any\n\n```\n\n"
+      "value": "```bicep\nsecure(): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/decoratorsPlusNamespace.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/decoratorsPlusNamespace.json
@@ -4,7 +4,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nallowed(values: array): any\n\n```\n\n"
+      "value": "```bicep\nallowed(values: array): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25,7 +25,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbatchSize(batchSize: int): any\n\n```\n\n"
+      "value": "```bicep\nbatchSize(batchSize: int): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46,7 +46,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndescription(text: string): any\n\n```\n\n"
+      "value": "```bicep\ndescription(text: string): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -67,7 +67,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndiscriminator(value: string): any\n\n```\n\n"
+      "value": "```bicep\ndiscriminator(value: string): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -88,7 +88,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmaxLength(length: int): any\n\n```\n\n"
+      "value": "```bicep\nmaxLength(length: int): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -109,7 +109,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmaxValue(value: int): any\n\n```\n\n"
+      "value": "```bicep\nmaxValue(value: int): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -130,7 +130,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmetadata(object: object): any\n\n```\n\n"
+      "value": "```bicep\nmetadata(object: object): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -151,7 +151,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nminLength(length: int): any\n\n```\n\n"
+      "value": "```bicep\nminLength(length: int): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -172,7 +172,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nminValue(value: int): any\n\n```\n\n"
+      "value": "```bicep\nminValue(value: int): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -193,7 +193,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsealed(): any\n\n```\n\n"
+      "value": "```bicep\nsealed(): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -210,7 +210,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsecure(): any\n\n```\n\n"
+      "value": "```bicep\nsecure(): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/objectPlusSymbols.json
@@ -4,7 +4,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25,7 +25,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45,6 +45,10 @@
     "label": "attemptToReferenceAnOutput",
     "kind": "variable",
     "detail": "attemptToReferenceAnOutput",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_attemptToReferenceAnOutput",
@@ -78,7 +82,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -99,7 +103,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -120,7 +124,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -141,7 +145,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -162,7 +166,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -183,7 +187,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -204,7 +208,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -225,7 +229,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -246,7 +250,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -267,7 +271,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -288,7 +292,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -309,7 +313,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -330,7 +334,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -351,7 +355,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -368,7 +372,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -389,7 +393,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -410,7 +414,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -427,7 +431,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -448,7 +452,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -469,7 +473,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -490,7 +494,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -511,7 +515,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -532,7 +536,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -567,7 +571,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -588,7 +592,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -609,7 +613,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -630,7 +634,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -651,7 +655,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -672,7 +676,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -692,6 +696,10 @@
     "label": "kv",
     "kind": "interface",
     "detail": "kv",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_kv",
@@ -710,7 +718,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -731,7 +739,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -752,7 +760,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -773,7 +781,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -794,7 +802,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -815,7 +823,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -836,7 +844,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -857,7 +865,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -878,7 +886,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -899,7 +907,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -920,7 +928,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -941,7 +949,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -962,7 +970,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -983,7 +991,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1004,7 +1012,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1025,7 +1033,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1046,7 +1054,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1067,7 +1075,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1088,7 +1096,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1109,7 +1117,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1130,7 +1138,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1151,7 +1159,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1172,7 +1180,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1193,7 +1201,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1214,7 +1222,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1235,7 +1243,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1256,7 +1264,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1277,7 +1285,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1298,7 +1306,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1319,7 +1327,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1358,7 +1366,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1379,7 +1387,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1396,7 +1404,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1416,6 +1424,10 @@
     "label": "testSymbol",
     "kind": "variable",
     "detail": "testSymbol",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_testSymbol",
@@ -1431,7 +1443,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1452,7 +1464,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1473,7 +1485,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1494,7 +1506,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1515,7 +1527,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1536,7 +1548,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1557,7 +1569,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1578,7 +1590,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1599,7 +1611,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1621,7 +1633,7 @@
     "detail": "{}",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n{\n\t\n}\n```"
+      "value": "```bicep\n{\n\t\n}\n```  \n"
     },
     "deprecated": false,
     "preselect": true,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/objectPlusSymbols.json
@@ -45,10 +45,6 @@
     "label": "attemptToReferenceAnOutput",
     "kind": "variable",
     "detail": "attemptToReferenceAnOutput",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_attemptToReferenceAnOutput",
@@ -696,10 +692,6 @@
     "label": "kv",
     "kind": "interface",
     "detail": "kv",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_kv",
@@ -1424,10 +1416,6 @@
     "label": "testSymbol",
     "kind": "variable",
     "detail": "testSymbol",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_testSymbol",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/symbols.json
@@ -45,10 +45,6 @@
     "label": "attemptToReferenceAnOutput",
     "kind": "variable",
     "detail": "attemptToReferenceAnOutput",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_attemptToReferenceAnOutput",
@@ -696,10 +692,6 @@
     "label": "kv",
     "kind": "interface",
     "detail": "kv",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_kv",
@@ -1424,10 +1416,6 @@
     "label": "testSymbol",
     "kind": "variable",
     "detail": "testSymbol",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_testSymbol",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/symbols.json
@@ -4,7 +4,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25,7 +25,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -45,6 +45,10 @@
     "label": "attemptToReferenceAnOutput",
     "kind": "variable",
     "detail": "attemptToReferenceAnOutput",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_attemptToReferenceAnOutput",
@@ -78,7 +82,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -99,7 +103,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -120,7 +124,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -141,7 +145,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -162,7 +166,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -183,7 +187,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -204,7 +208,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -225,7 +229,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -246,7 +250,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -267,7 +271,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -288,7 +292,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -309,7 +313,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -330,7 +334,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -351,7 +355,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -368,7 +372,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -389,7 +393,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -410,7 +414,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -427,7 +431,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -448,7 +452,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -469,7 +473,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -490,7 +494,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -511,7 +515,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -532,7 +536,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -567,7 +571,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -588,7 +592,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -609,7 +613,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -630,7 +634,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -651,7 +655,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -672,7 +676,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -692,6 +696,10 @@
     "label": "kv",
     "kind": "interface",
     "detail": "kv",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_kv",
@@ -710,7 +718,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -731,7 +739,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -752,7 +760,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -773,7 +781,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -794,7 +802,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -815,7 +823,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -836,7 +844,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -857,7 +865,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -878,7 +886,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -899,7 +907,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -920,7 +928,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -941,7 +949,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -962,7 +970,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -983,7 +991,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1004,7 +1012,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1025,7 +1033,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1046,7 +1054,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1067,7 +1075,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1088,7 +1096,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1109,7 +1117,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1130,7 +1138,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1151,7 +1159,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1172,7 +1180,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1193,7 +1201,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1214,7 +1222,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1235,7 +1243,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1256,7 +1264,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1277,7 +1285,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1298,7 +1306,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1319,7 +1327,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1358,7 +1366,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1379,7 +1387,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1396,7 +1404,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1416,6 +1424,10 @@
     "label": "testSymbol",
     "kind": "variable",
     "detail": "testSymbol",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_testSymbol",
@@ -1431,7 +1443,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1452,7 +1464,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1473,7 +1485,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1494,7 +1506,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1515,7 +1527,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1536,7 +1548,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1557,7 +1569,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1578,7 +1590,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1599,7 +1611,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/arrayPlusSymbols.json
@@ -1891,10 +1891,6 @@
     "label": "sampleResource",
     "kind": "interface",
     "detail": "sampleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sampleResource",
@@ -1912,10 +1908,6 @@
     "label": "sampleVar",
     "kind": "variable",
     "detail": "sampleVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sampleVar",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/arrayPlusSymbols.json
@@ -5,7 +5,7 @@
     "detail": "WhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLong",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -36,7 +36,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -57,7 +57,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -97,7 +97,7 @@
     "detail": "badInterpolatedString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -115,7 +115,7 @@
     "detail": "badInterpolatedString2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -132,7 +132,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -153,7 +153,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -174,7 +174,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -195,7 +195,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -217,7 +217,7 @@
     "detail": "boolCompletions",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool"
+      "value": "Type: `bool`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -234,7 +234,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -255,7 +255,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -277,7 +277,7 @@
     "detail": "commaOne",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'abc' | 'def'"
+      "value": "Type: `'abc' | 'def'`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -294,7 +294,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -315,7 +315,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -336,7 +336,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -357,7 +357,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -378,7 +378,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -399,7 +399,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -420,7 +420,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -442,7 +442,7 @@
     "detail": "defaultValueOneLinerCompletions",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -459,7 +459,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -477,7 +477,7 @@
     "detail": "duplicateDecorators",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -494,7 +494,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -516,7 +516,7 @@
     "detail": "emptyAllowedInt",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error"
+      "value": "Type: `error`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -534,7 +534,7 @@
     "detail": "emptyAllowedString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error"
+      "value": "Type: `error`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -551,7 +551,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -572,7 +572,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -590,7 +590,7 @@
     "detail": "expressionInModifier",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -607,7 +607,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -629,7 +629,7 @@
     "detail": "fatalErrorInIssue1713",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any"
+      "value": "Type: `any`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -646,7 +646,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -667,7 +667,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -688,7 +688,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -709,7 +709,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -730,7 +730,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -766,7 +766,7 @@
     "detail": "incompleteDecorators",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -783,7 +783,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -804,7 +804,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -825,7 +825,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -847,7 +847,7 @@
     "detail": "invalidDefaultWithAllowedArrayDecorator",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: ['Microsoft.AnalysisServices/servers', 'Microsoft.ApiManagement/service'] | ['Microsoft.Network/applicationGateways', 'Microsoft.Automation/automationAccounts']"
+      "value": "Type: `['Microsoft.AnalysisServices/servers', 'Microsoft.ApiManagement/service'] | ['Microsoft.Network/applicationGateways', 'Microsoft.Automation/automationAccounts']`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -865,7 +865,7 @@
     "detail": "invalidLength",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -883,7 +883,7 @@
     "detail": "invalidPermutation",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: ('Microsoft.AnalysisServices/servers' | 'Microsoft.ApiManagement/service' | 'Microsoft.Automation/automationAccounts' | 'Microsoft.ContainerInstance/containerGroups' | 'Microsoft.ContainerRegistry/registries' | 'Microsoft.ContainerService/managedClusters' | 'Microsoft.Network/applicationGateways')[]"
+      "value": "Type: `('Microsoft.AnalysisServices/servers' | 'Microsoft.ApiManagement/service' | 'Microsoft.Automation/automationAccounts' | 'Microsoft.ContainerInstance/containerGroups' | 'Microsoft.ContainerRegistry/registries' | 'Microsoft.ContainerService/managedClusters' | 'Microsoft.Network/applicationGateways')[]`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -900,7 +900,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -921,7 +921,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -942,7 +942,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -963,7 +963,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -984,7 +984,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1005,7 +1005,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1026,7 +1026,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1047,7 +1047,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1068,7 +1068,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1089,7 +1089,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1111,7 +1111,7 @@
     "detail": "malformedModifier",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 44"
+      "value": "Type: `44`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1129,7 +1129,7 @@
     "detail": "malformedType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 44"
+      "value": "Type: `44`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1147,7 +1147,7 @@
     "detail": "malformedType2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 44"
+      "value": "Type: `44`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1164,7 +1164,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1185,7 +1185,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1206,7 +1206,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1227,7 +1227,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1248,7 +1248,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1270,7 +1270,7 @@
     "detail": "missingType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any"
+      "value": "Type: `any`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1288,7 +1288,7 @@
     "detail": "missingTypeWithSpaceAfter",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any"
+      "value": "Type: `any`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1306,7 +1306,7 @@
     "detail": "missingTypeWithTabAfter",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any"
+      "value": "Type: `any`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1324,7 +1324,7 @@
     "detail": "myBool",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool"
+      "value": "Type: `bool`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1342,7 +1342,7 @@
     "detail": "myFalsehood",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool"
+      "value": "Type: `bool`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1360,7 +1360,7 @@
     "detail": "myInt",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1378,7 +1378,7 @@
     "detail": "myInt2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1396,7 +1396,7 @@
     "detail": "myString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1414,7 +1414,7 @@
     "detail": "myString2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1432,7 +1432,7 @@
     "detail": "myTruth",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool"
+      "value": "Type: `bool`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1449,7 +1449,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnewGuid(): string\n\n```\nReturns a value in the format of a globally unique identifier. **This function can only be used in the default value for a parameter**.\n"
+      "value": "```bicep\nnewGuid(): string\n\n```  \nReturns a value in the format of a globally unique identifier. **This function can only be used in the default value for a parameter**.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1467,7 +1467,7 @@
     "detail": "noValueAfterColon",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1485,7 +1485,7 @@
     "detail": "nonCompileTimeConstant",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1503,7 +1503,7 @@
     "detail": "nonConstantInDecorator",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1521,7 +1521,7 @@
     "detail": "objectCompletions",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1538,7 +1538,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1560,7 +1560,7 @@
     "detail": "paramAccessingOutput",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1578,7 +1578,7 @@
     "detail": "paramAccessingResource",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1596,7 +1596,7 @@
     "detail": "paramAccessingVar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1614,7 +1614,7 @@
     "detail": "paramDefaultOneCycle",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1632,7 +1632,7 @@
     "detail": "paramDefaultTwoCycle1",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1650,7 +1650,7 @@
     "detail": "paramDefaultTwoCycle2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1668,7 +1668,7 @@
     "detail": "paramModifierSelfCycle",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1685,7 +1685,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1707,7 +1707,7 @@
     "detail": "partialType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error"
+      "value": "Type: `error`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1724,7 +1724,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1745,7 +1745,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1766,7 +1766,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1787,7 +1787,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1808,7 +1808,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1829,7 +1829,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1850,7 +1850,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1871,7 +1871,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1891,6 +1891,10 @@
     "label": "sampleResource",
     "kind": "interface",
     "detail": "sampleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sampleResource",
@@ -1908,6 +1912,10 @@
     "label": "sampleVar",
     "kind": "variable",
     "detail": "sampleVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sampleVar",
@@ -1924,7 +1932,7 @@
     "detail": "secureInt",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1941,7 +1949,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1963,7 +1971,7 @@
     "detail": "someArray",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error"
+      "value": "Type: `error`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1981,7 +1989,7 @@
     "detail": "someInteger",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1999,7 +2007,7 @@
     "detail": "someString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2016,7 +2024,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2037,7 +2045,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2058,7 +2066,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2079,7 +2087,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2100,7 +2108,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2121,7 +2129,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2142,7 +2150,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2181,7 +2189,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2202,7 +2210,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2219,7 +2227,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2240,7 +2248,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2261,7 +2269,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2282,7 +2290,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2304,7 +2312,7 @@
     "detail": "tooManyArguments1",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2322,7 +2330,7 @@
     "detail": "tooManyArguments2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2340,7 +2348,7 @@
     "detail": "trailingSpace",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any"
+      "value": "Type: `any`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2357,7 +2365,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2379,7 +2387,7 @@
     "detail": "unaryMinusOnFunction",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2396,7 +2404,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2417,7 +2425,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2438,7 +2446,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2459,7 +2467,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2480,7 +2488,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2501,7 +2509,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nutcNow([format: string]): string\n\n```\nReturns the current (UTC) datetime value in the specified format. If no format is provided, the ISO 8601 (yyyyMMddTHHmmssZ) format is used. **This function can only be used in the default value for a parameter**.\n"
+      "value": "```bicep\nutcNow([format: string]): string\n\n```  \nReturns the current (UTC) datetime value in the specified format. If no format is provided, the ISO 8601 (yyyyMMddTHHmmssZ) format is used. **This function can only be used in the default value for a parameter**.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2523,7 +2531,7 @@
     "detail": "wrongAssignmentToken",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2541,7 +2549,7 @@
     "detail": "wrongDefaultValue",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2559,7 +2567,7 @@
     "detail": "wrongIntModifier",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2577,7 +2585,7 @@
     "detail": "wrongMetadataSchema",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2595,7 +2603,7 @@
     "detail": "wrongType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error"
+      "value": "Type: `error`  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/boolPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/boolPlusSymbols.json
@@ -1891,10 +1891,6 @@
     "label": "sampleResource",
     "kind": "interface",
     "detail": "sampleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sampleResource",
@@ -1912,10 +1908,6 @@
     "label": "sampleVar",
     "kind": "variable",
     "detail": "sampleVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sampleVar",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/boolPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/boolPlusSymbols.json
@@ -5,7 +5,7 @@
     "detail": "WhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLong",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22,7 +22,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43,7 +43,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -65,7 +65,7 @@
     "detail": "arrayCompletions",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: array"
+      "value": "Type: `array`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -101,7 +101,7 @@
     "detail": "badInterpolatedString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -119,7 +119,7 @@
     "detail": "badInterpolatedString2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -136,7 +136,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -157,7 +157,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -178,7 +178,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -199,7 +199,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -220,7 +220,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -241,7 +241,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -263,7 +263,7 @@
     "detail": "commaOne",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'abc' | 'def'"
+      "value": "Type: `'abc' | 'def'`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -280,7 +280,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -301,7 +301,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -322,7 +322,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -343,7 +343,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -364,7 +364,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -385,7 +385,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -406,7 +406,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -428,7 +428,7 @@
     "detail": "defaultValueOneLinerCompletions",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -445,7 +445,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -463,7 +463,7 @@
     "detail": "duplicateDecorators",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -480,7 +480,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -502,7 +502,7 @@
     "detail": "emptyAllowedInt",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error"
+      "value": "Type: `error`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -520,7 +520,7 @@
     "detail": "emptyAllowedString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error"
+      "value": "Type: `error`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -537,7 +537,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -558,7 +558,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -576,7 +576,7 @@
     "detail": "expressionInModifier",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -593,7 +593,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -629,7 +629,7 @@
     "detail": "fatalErrorInIssue1713",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any"
+      "value": "Type: `any`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -646,7 +646,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -667,7 +667,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -688,7 +688,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -709,7 +709,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -730,7 +730,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -766,7 +766,7 @@
     "detail": "incompleteDecorators",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -783,7 +783,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -804,7 +804,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -825,7 +825,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -847,7 +847,7 @@
     "detail": "invalidDefaultWithAllowedArrayDecorator",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: ['Microsoft.AnalysisServices/servers', 'Microsoft.ApiManagement/service'] | ['Microsoft.Network/applicationGateways', 'Microsoft.Automation/automationAccounts']"
+      "value": "Type: `['Microsoft.AnalysisServices/servers', 'Microsoft.ApiManagement/service'] | ['Microsoft.Network/applicationGateways', 'Microsoft.Automation/automationAccounts']`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -865,7 +865,7 @@
     "detail": "invalidLength",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -883,7 +883,7 @@
     "detail": "invalidPermutation",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: ('Microsoft.AnalysisServices/servers' | 'Microsoft.ApiManagement/service' | 'Microsoft.Automation/automationAccounts' | 'Microsoft.ContainerInstance/containerGroups' | 'Microsoft.ContainerRegistry/registries' | 'Microsoft.ContainerService/managedClusters' | 'Microsoft.Network/applicationGateways')[]"
+      "value": "Type: `('Microsoft.AnalysisServices/servers' | 'Microsoft.ApiManagement/service' | 'Microsoft.Automation/automationAccounts' | 'Microsoft.ContainerInstance/containerGroups' | 'Microsoft.ContainerRegistry/registries' | 'Microsoft.ContainerService/managedClusters' | 'Microsoft.Network/applicationGateways')[]`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -900,7 +900,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -921,7 +921,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -942,7 +942,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -963,7 +963,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -984,7 +984,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1005,7 +1005,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1026,7 +1026,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1047,7 +1047,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1068,7 +1068,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1089,7 +1089,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1111,7 +1111,7 @@
     "detail": "malformedModifier",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 44"
+      "value": "Type: `44`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1129,7 +1129,7 @@
     "detail": "malformedType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 44"
+      "value": "Type: `44`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1147,7 +1147,7 @@
     "detail": "malformedType2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 44"
+      "value": "Type: `44`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1164,7 +1164,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1185,7 +1185,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1206,7 +1206,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1227,7 +1227,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1248,7 +1248,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1270,7 +1270,7 @@
     "detail": "missingType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any"
+      "value": "Type: `any`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1288,7 +1288,7 @@
     "detail": "missingTypeWithSpaceAfter",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any"
+      "value": "Type: `any`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1306,7 +1306,7 @@
     "detail": "missingTypeWithTabAfter",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any"
+      "value": "Type: `any`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1324,7 +1324,7 @@
     "detail": "myBool",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool"
+      "value": "Type: `bool`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1342,7 +1342,7 @@
     "detail": "myFalsehood",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool"
+      "value": "Type: `bool`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1360,7 +1360,7 @@
     "detail": "myInt",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1378,7 +1378,7 @@
     "detail": "myInt2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1396,7 +1396,7 @@
     "detail": "myString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1414,7 +1414,7 @@
     "detail": "myString2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1432,7 +1432,7 @@
     "detail": "myTruth",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool"
+      "value": "Type: `bool`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1449,7 +1449,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnewGuid(): string\n\n```\nReturns a value in the format of a globally unique identifier. **This function can only be used in the default value for a parameter**.\n"
+      "value": "```bicep\nnewGuid(): string\n\n```  \nReturns a value in the format of a globally unique identifier. **This function can only be used in the default value for a parameter**.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1467,7 +1467,7 @@
     "detail": "noValueAfterColon",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1485,7 +1485,7 @@
     "detail": "nonCompileTimeConstant",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1503,7 +1503,7 @@
     "detail": "nonConstantInDecorator",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1521,7 +1521,7 @@
     "detail": "objectCompletions",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1538,7 +1538,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1560,7 +1560,7 @@
     "detail": "paramAccessingOutput",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1578,7 +1578,7 @@
     "detail": "paramAccessingResource",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1596,7 +1596,7 @@
     "detail": "paramAccessingVar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1614,7 +1614,7 @@
     "detail": "paramDefaultOneCycle",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1632,7 +1632,7 @@
     "detail": "paramDefaultTwoCycle1",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1650,7 +1650,7 @@
     "detail": "paramDefaultTwoCycle2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1668,7 +1668,7 @@
     "detail": "paramModifierSelfCycle",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1685,7 +1685,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1707,7 +1707,7 @@
     "detail": "partialType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error"
+      "value": "Type: `error`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1724,7 +1724,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1745,7 +1745,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1766,7 +1766,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1787,7 +1787,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1808,7 +1808,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1829,7 +1829,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1850,7 +1850,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1871,7 +1871,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1891,6 +1891,10 @@
     "label": "sampleResource",
     "kind": "interface",
     "detail": "sampleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sampleResource",
@@ -1908,6 +1912,10 @@
     "label": "sampleVar",
     "kind": "variable",
     "detail": "sampleVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sampleVar",
@@ -1924,7 +1932,7 @@
     "detail": "secureInt",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1941,7 +1949,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1963,7 +1971,7 @@
     "detail": "someArray",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error"
+      "value": "Type: `error`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1981,7 +1989,7 @@
     "detail": "someInteger",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1999,7 +2007,7 @@
     "detail": "someString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2016,7 +2024,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2037,7 +2045,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2058,7 +2066,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2079,7 +2087,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2100,7 +2108,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2121,7 +2129,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2142,7 +2150,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2181,7 +2189,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2202,7 +2210,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2219,7 +2227,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2240,7 +2248,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2261,7 +2269,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2282,7 +2290,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2304,7 +2312,7 @@
     "detail": "tooManyArguments1",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2322,7 +2330,7 @@
     "detail": "tooManyArguments2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2340,7 +2348,7 @@
     "detail": "trailingSpace",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any"
+      "value": "Type: `any`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2357,7 +2365,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2393,7 +2401,7 @@
     "detail": "unaryMinusOnFunction",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2410,7 +2418,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2431,7 +2439,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2452,7 +2460,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2473,7 +2481,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2494,7 +2502,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2515,7 +2523,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nutcNow([format: string]): string\n\n```\nReturns the current (UTC) datetime value in the specified format. If no format is provided, the ISO 8601 (yyyyMMddTHHmmssZ) format is used. **This function can only be used in the default value for a parameter**.\n"
+      "value": "```bicep\nutcNow([format: string]): string\n\n```  \nReturns the current (UTC) datetime value in the specified format. If no format is provided, the ISO 8601 (yyyyMMddTHHmmssZ) format is used. **This function can only be used in the default value for a parameter**.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2537,7 +2545,7 @@
     "detail": "wrongAssignmentToken",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2555,7 +2563,7 @@
     "detail": "wrongDefaultValue",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2573,7 +2581,7 @@
     "detail": "wrongIntModifier",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2591,7 +2599,7 @@
     "detail": "wrongMetadataSchema",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2609,7 +2617,7 @@
     "detail": "wrongType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error"
+      "value": "Type: `error`  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/intParameterDecorators.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/intParameterDecorators.json
@@ -4,7 +4,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nallowed(values: array): any\n\n```\n\n"
+      "value": "```bicep\nallowed(values: array): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25,7 +25,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndescription(text: string): any\n\n```\n\n"
+      "value": "```bicep\ndescription(text: string): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46,7 +46,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmaxValue(value: int): any\n\n```\n\n"
+      "value": "```bicep\nmaxValue(value: int): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -67,7 +67,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmetadata(object: object): any\n\n```\n\n"
+      "value": "```bicep\nmetadata(object: object): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -88,7 +88,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nminValue(value: int): any\n\n```\n\n"
+      "value": "```bicep\nminValue(value: int): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/intParameterDecoratorsPlusNamespace.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/intParameterDecoratorsPlusNamespace.json
@@ -4,7 +4,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nallowed(values: array): any\n\n```\n\n"
+      "value": "```bicep\nallowed(values: array): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25,7 +25,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndescription(text: string): any\n\n```\n\n"
+      "value": "```bicep\ndescription(text: string): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46,7 +46,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmaxValue(value: int): any\n\n```\n\n"
+      "value": "```bicep\nmaxValue(value: int): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -67,7 +67,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmetadata(object: object): any\n\n```\n\n"
+      "value": "```bicep\nmetadata(object: object): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -88,7 +88,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nminValue(value: int): any\n\n```\n\n"
+      "value": "```bicep\nminValue(value: int): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/justSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/justSymbols.json
@@ -1877,10 +1877,6 @@
     "label": "sampleResource",
     "kind": "interface",
     "detail": "sampleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sampleResource",
@@ -1898,10 +1894,6 @@
     "label": "sampleVar",
     "kind": "variable",
     "detail": "sampleVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sampleVar",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/justSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/justSymbols.json
@@ -5,7 +5,7 @@
     "detail": "WhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLong",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22,7 +22,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43,7 +43,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -65,7 +65,7 @@
     "detail": "arrayCompletions",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: array"
+      "value": "Type: `array`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -101,7 +101,7 @@
     "detail": "badInterpolatedString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -119,7 +119,7 @@
     "detail": "badInterpolatedString2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -136,7 +136,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -157,7 +157,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -178,7 +178,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -199,7 +199,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -221,7 +221,7 @@
     "detail": "boolCompletions",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool"
+      "value": "Type: `bool`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -238,7 +238,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -259,7 +259,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -281,7 +281,7 @@
     "detail": "commaOne",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'abc' | 'def'"
+      "value": "Type: `'abc' | 'def'`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -298,7 +298,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -319,7 +319,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -340,7 +340,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -361,7 +361,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -382,7 +382,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -403,7 +403,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -424,7 +424,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -445,7 +445,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -463,7 +463,7 @@
     "detail": "duplicateDecorators",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -480,7 +480,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -502,7 +502,7 @@
     "detail": "emptyAllowedInt",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error"
+      "value": "Type: `error`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -520,7 +520,7 @@
     "detail": "emptyAllowedString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error"
+      "value": "Type: `error`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -537,7 +537,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -558,7 +558,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -576,7 +576,7 @@
     "detail": "expressionInModifier",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -593,7 +593,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -615,7 +615,7 @@
     "detail": "fatalErrorInIssue1713",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any"
+      "value": "Type: `any`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -632,7 +632,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -653,7 +653,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -674,7 +674,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -695,7 +695,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -716,7 +716,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -752,7 +752,7 @@
     "detail": "incompleteDecorators",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -769,7 +769,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -790,7 +790,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -811,7 +811,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -833,7 +833,7 @@
     "detail": "invalidDefaultWithAllowedArrayDecorator",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: ['Microsoft.AnalysisServices/servers', 'Microsoft.ApiManagement/service'] | ['Microsoft.Network/applicationGateways', 'Microsoft.Automation/automationAccounts']"
+      "value": "Type: `['Microsoft.AnalysisServices/servers', 'Microsoft.ApiManagement/service'] | ['Microsoft.Network/applicationGateways', 'Microsoft.Automation/automationAccounts']`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -851,7 +851,7 @@
     "detail": "invalidLength",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -869,7 +869,7 @@
     "detail": "invalidPermutation",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: ('Microsoft.AnalysisServices/servers' | 'Microsoft.ApiManagement/service' | 'Microsoft.Automation/automationAccounts' | 'Microsoft.ContainerInstance/containerGroups' | 'Microsoft.ContainerRegistry/registries' | 'Microsoft.ContainerService/managedClusters' | 'Microsoft.Network/applicationGateways')[]"
+      "value": "Type: `('Microsoft.AnalysisServices/servers' | 'Microsoft.ApiManagement/service' | 'Microsoft.Automation/automationAccounts' | 'Microsoft.ContainerInstance/containerGroups' | 'Microsoft.ContainerRegistry/registries' | 'Microsoft.ContainerService/managedClusters' | 'Microsoft.Network/applicationGateways')[]`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -886,7 +886,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -907,7 +907,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -928,7 +928,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -949,7 +949,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -970,7 +970,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -991,7 +991,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1012,7 +1012,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1033,7 +1033,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1054,7 +1054,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1075,7 +1075,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1097,7 +1097,7 @@
     "detail": "malformedModifier",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 44"
+      "value": "Type: `44`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1115,7 +1115,7 @@
     "detail": "malformedType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 44"
+      "value": "Type: `44`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1133,7 +1133,7 @@
     "detail": "malformedType2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 44"
+      "value": "Type: `44`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1150,7 +1150,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1171,7 +1171,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1192,7 +1192,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1213,7 +1213,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1234,7 +1234,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1256,7 +1256,7 @@
     "detail": "missingType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any"
+      "value": "Type: `any`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1274,7 +1274,7 @@
     "detail": "missingTypeWithSpaceAfter",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any"
+      "value": "Type: `any`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1292,7 +1292,7 @@
     "detail": "missingTypeWithTabAfter",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any"
+      "value": "Type: `any`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1310,7 +1310,7 @@
     "detail": "myBool",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool"
+      "value": "Type: `bool`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1328,7 +1328,7 @@
     "detail": "myFalsehood",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool"
+      "value": "Type: `bool`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1346,7 +1346,7 @@
     "detail": "myInt",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1364,7 +1364,7 @@
     "detail": "myInt2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1382,7 +1382,7 @@
     "detail": "myString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1400,7 +1400,7 @@
     "detail": "myString2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1418,7 +1418,7 @@
     "detail": "myTruth",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool"
+      "value": "Type: `bool`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1435,7 +1435,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnewGuid(): string\n\n```\nReturns a value in the format of a globally unique identifier. **This function can only be used in the default value for a parameter**.\n"
+      "value": "```bicep\nnewGuid(): string\n\n```  \nReturns a value in the format of a globally unique identifier. **This function can only be used in the default value for a parameter**.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1453,7 +1453,7 @@
     "detail": "noValueAfterColon",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1471,7 +1471,7 @@
     "detail": "nonCompileTimeConstant",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1489,7 +1489,7 @@
     "detail": "nonConstantInDecorator",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1507,7 +1507,7 @@
     "detail": "objectCompletions",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1524,7 +1524,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1546,7 +1546,7 @@
     "detail": "paramAccessingOutput",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1564,7 +1564,7 @@
     "detail": "paramAccessingResource",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1582,7 +1582,7 @@
     "detail": "paramAccessingVar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1600,7 +1600,7 @@
     "detail": "paramDefaultOneCycle",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1618,7 +1618,7 @@
     "detail": "paramDefaultTwoCycle1",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1636,7 +1636,7 @@
     "detail": "paramDefaultTwoCycle2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1654,7 +1654,7 @@
     "detail": "paramModifierSelfCycle",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1671,7 +1671,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1693,7 +1693,7 @@
     "detail": "partialType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error"
+      "value": "Type: `error`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1710,7 +1710,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1731,7 +1731,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1752,7 +1752,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1773,7 +1773,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1794,7 +1794,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1815,7 +1815,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1836,7 +1836,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1857,7 +1857,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1877,6 +1877,10 @@
     "label": "sampleResource",
     "kind": "interface",
     "detail": "sampleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sampleResource",
@@ -1894,6 +1898,10 @@
     "label": "sampleVar",
     "kind": "variable",
     "detail": "sampleVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sampleVar",
@@ -1910,7 +1918,7 @@
     "detail": "secureInt",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1927,7 +1935,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1949,7 +1957,7 @@
     "detail": "someArray",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error"
+      "value": "Type: `error`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1967,7 +1975,7 @@
     "detail": "someInteger",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1985,7 +1993,7 @@
     "detail": "someString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2002,7 +2010,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2023,7 +2031,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2044,7 +2052,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2065,7 +2073,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2086,7 +2094,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2107,7 +2115,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2128,7 +2136,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2167,7 +2175,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2188,7 +2196,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2205,7 +2213,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2226,7 +2234,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2247,7 +2255,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2268,7 +2276,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2290,7 +2298,7 @@
     "detail": "tooManyArguments1",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2308,7 +2316,7 @@
     "detail": "tooManyArguments2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2326,7 +2334,7 @@
     "detail": "trailingSpace",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any"
+      "value": "Type: `any`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2343,7 +2351,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2365,7 +2373,7 @@
     "detail": "unaryMinusOnFunction",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2382,7 +2390,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2403,7 +2411,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2424,7 +2432,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2445,7 +2453,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2466,7 +2474,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2487,7 +2495,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nutcNow([format: string]): string\n\n```\nReturns the current (UTC) datetime value in the specified format. If no format is provided, the ISO 8601 (yyyyMMddTHHmmssZ) format is used. **This function can only be used in the default value for a parameter**.\n"
+      "value": "```bicep\nutcNow([format: string]): string\n\n```  \nReturns the current (UTC) datetime value in the specified format. If no format is provided, the ISO 8601 (yyyyMMddTHHmmssZ) format is used. **This function can only be used in the default value for a parameter**.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2509,7 +2517,7 @@
     "detail": "wrongAssignmentToken",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2527,7 +2535,7 @@
     "detail": "wrongDefaultValue",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2545,7 +2553,7 @@
     "detail": "wrongIntModifier",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2563,7 +2571,7 @@
     "detail": "wrongMetadataSchema",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2581,7 +2589,7 @@
     "detail": "wrongType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error"
+      "value": "Type: `error`  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/objectPlusSymbols.json
@@ -1877,10 +1877,6 @@
     "label": "sampleResource",
     "kind": "interface",
     "detail": "sampleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sampleResource",
@@ -1898,10 +1894,6 @@
     "label": "sampleVar",
     "kind": "variable",
     "detail": "sampleVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sampleVar",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/objectPlusSymbols.json
@@ -5,7 +5,7 @@
     "detail": "WhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLong",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22,7 +22,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -43,7 +43,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -65,7 +65,7 @@
     "detail": "arrayCompletions",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: array"
+      "value": "Type: `array`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -101,7 +101,7 @@
     "detail": "badInterpolatedString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -119,7 +119,7 @@
     "detail": "badInterpolatedString2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -136,7 +136,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -157,7 +157,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -178,7 +178,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -199,7 +199,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -221,7 +221,7 @@
     "detail": "boolCompletions",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool"
+      "value": "Type: `bool`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -238,7 +238,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -259,7 +259,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -281,7 +281,7 @@
     "detail": "commaOne",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'abc' | 'def'"
+      "value": "Type: `'abc' | 'def'`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -298,7 +298,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -319,7 +319,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -340,7 +340,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -361,7 +361,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -382,7 +382,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -403,7 +403,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -424,7 +424,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -446,7 +446,7 @@
     "detail": "defaultValueOneLinerCompletions",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -463,7 +463,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -481,7 +481,7 @@
     "detail": "duplicateDecorators",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -498,7 +498,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -520,7 +520,7 @@
     "detail": "emptyAllowedInt",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error"
+      "value": "Type: `error`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -538,7 +538,7 @@
     "detail": "emptyAllowedString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error"
+      "value": "Type: `error`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -555,7 +555,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -576,7 +576,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -594,7 +594,7 @@
     "detail": "expressionInModifier",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -611,7 +611,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -633,7 +633,7 @@
     "detail": "fatalErrorInIssue1713",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any"
+      "value": "Type: `any`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -650,7 +650,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -671,7 +671,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -692,7 +692,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -713,7 +713,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -734,7 +734,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -770,7 +770,7 @@
     "detail": "incompleteDecorators",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -787,7 +787,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -808,7 +808,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -829,7 +829,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -851,7 +851,7 @@
     "detail": "invalidDefaultWithAllowedArrayDecorator",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: ['Microsoft.AnalysisServices/servers', 'Microsoft.ApiManagement/service'] | ['Microsoft.Network/applicationGateways', 'Microsoft.Automation/automationAccounts']"
+      "value": "Type: `['Microsoft.AnalysisServices/servers', 'Microsoft.ApiManagement/service'] | ['Microsoft.Network/applicationGateways', 'Microsoft.Automation/automationAccounts']`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -869,7 +869,7 @@
     "detail": "invalidLength",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -887,7 +887,7 @@
     "detail": "invalidPermutation",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: ('Microsoft.AnalysisServices/servers' | 'Microsoft.ApiManagement/service' | 'Microsoft.Automation/automationAccounts' | 'Microsoft.ContainerInstance/containerGroups' | 'Microsoft.ContainerRegistry/registries' | 'Microsoft.ContainerService/managedClusters' | 'Microsoft.Network/applicationGateways')[]"
+      "value": "Type: `('Microsoft.AnalysisServices/servers' | 'Microsoft.ApiManagement/service' | 'Microsoft.Automation/automationAccounts' | 'Microsoft.ContainerInstance/containerGroups' | 'Microsoft.ContainerRegistry/registries' | 'Microsoft.ContainerService/managedClusters' | 'Microsoft.Network/applicationGateways')[]`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -904,7 +904,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -925,7 +925,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -946,7 +946,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -967,7 +967,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -988,7 +988,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1009,7 +1009,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1030,7 +1030,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1051,7 +1051,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1072,7 +1072,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1093,7 +1093,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1115,7 +1115,7 @@
     "detail": "malformedModifier",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 44"
+      "value": "Type: `44`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1133,7 +1133,7 @@
     "detail": "malformedType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 44"
+      "value": "Type: `44`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1151,7 +1151,7 @@
     "detail": "malformedType2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 44"
+      "value": "Type: `44`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1168,7 +1168,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1189,7 +1189,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1210,7 +1210,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1231,7 +1231,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1252,7 +1252,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1274,7 +1274,7 @@
     "detail": "missingType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any"
+      "value": "Type: `any`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1292,7 +1292,7 @@
     "detail": "missingTypeWithSpaceAfter",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any"
+      "value": "Type: `any`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1310,7 +1310,7 @@
     "detail": "missingTypeWithTabAfter",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any"
+      "value": "Type: `any`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1328,7 +1328,7 @@
     "detail": "myBool",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool"
+      "value": "Type: `bool`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1346,7 +1346,7 @@
     "detail": "myFalsehood",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool"
+      "value": "Type: `bool`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1364,7 +1364,7 @@
     "detail": "myInt",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1382,7 +1382,7 @@
     "detail": "myInt2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1400,7 +1400,7 @@
     "detail": "myString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1418,7 +1418,7 @@
     "detail": "myString2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1436,7 +1436,7 @@
     "detail": "myTruth",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool"
+      "value": "Type: `bool`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1453,7 +1453,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nnewGuid(): string\n\n```\nReturns a value in the format of a globally unique identifier. **This function can only be used in the default value for a parameter**.\n"
+      "value": "```bicep\nnewGuid(): string\n\n```  \nReturns a value in the format of a globally unique identifier. **This function can only be used in the default value for a parameter**.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1471,7 +1471,7 @@
     "detail": "noValueAfterColon",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1489,7 +1489,7 @@
     "detail": "nonCompileTimeConstant",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1507,7 +1507,7 @@
     "detail": "nonConstantInDecorator",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1524,7 +1524,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1546,7 +1546,7 @@
     "detail": "paramAccessingOutput",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1564,7 +1564,7 @@
     "detail": "paramAccessingResource",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1582,7 +1582,7 @@
     "detail": "paramAccessingVar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1600,7 +1600,7 @@
     "detail": "paramDefaultOneCycle",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1618,7 +1618,7 @@
     "detail": "paramDefaultTwoCycle1",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1636,7 +1636,7 @@
     "detail": "paramDefaultTwoCycle2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1654,7 +1654,7 @@
     "detail": "paramModifierSelfCycle",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1671,7 +1671,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1693,7 +1693,7 @@
     "detail": "partialType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error"
+      "value": "Type: `error`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1710,7 +1710,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1731,7 +1731,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1752,7 +1752,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1773,7 +1773,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1794,7 +1794,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1815,7 +1815,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1836,7 +1836,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1857,7 +1857,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1877,6 +1877,10 @@
     "label": "sampleResource",
     "kind": "interface",
     "detail": "sampleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sampleResource",
@@ -1894,6 +1898,10 @@
     "label": "sampleVar",
     "kind": "variable",
     "detail": "sampleVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sampleVar",
@@ -1910,7 +1918,7 @@
     "detail": "secureInt",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1927,7 +1935,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1949,7 +1957,7 @@
     "detail": "someArray",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error"
+      "value": "Type: `error`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1967,7 +1975,7 @@
     "detail": "someInteger",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1985,7 +1993,7 @@
     "detail": "someString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2002,7 +2010,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2023,7 +2031,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2044,7 +2052,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2065,7 +2073,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2086,7 +2094,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2107,7 +2115,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2128,7 +2136,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2167,7 +2175,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2188,7 +2196,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2205,7 +2213,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2226,7 +2234,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2247,7 +2255,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2268,7 +2276,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2290,7 +2298,7 @@
     "detail": "tooManyArguments1",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2308,7 +2316,7 @@
     "detail": "tooManyArguments2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2326,7 +2334,7 @@
     "detail": "trailingSpace",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any"
+      "value": "Type: `any`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2343,7 +2351,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2365,7 +2373,7 @@
     "detail": "unaryMinusOnFunction",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2382,7 +2390,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2403,7 +2411,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2424,7 +2432,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2445,7 +2453,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2466,7 +2474,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2487,7 +2495,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nutcNow([format: string]): string\n\n```\nReturns the current (UTC) datetime value in the specified format. If no format is provided, the ISO 8601 (yyyyMMddTHHmmssZ) format is used. **This function can only be used in the default value for a parameter**.\n"
+      "value": "```bicep\nutcNow([format: string]): string\n\n```  \nReturns the current (UTC) datetime value in the specified format. If no format is provided, the ISO 8601 (yyyyMMddTHHmmssZ) format is used. **This function can only be used in the default value for a parameter**.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2509,7 +2517,7 @@
     "detail": "wrongAssignmentToken",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2527,7 +2535,7 @@
     "detail": "wrongDefaultValue",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2545,7 +2553,7 @@
     "detail": "wrongIntModifier",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int"
+      "value": "Type: `int`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2563,7 +2571,7 @@
     "detail": "wrongMetadataSchema",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2581,7 +2589,7 @@
     "detail": "wrongType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error"
+      "value": "Type: `error`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2599,7 +2607,7 @@
     "detail": "{}",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n{\n\t\n}\n```"
+      "value": "```bicep\n{\n\t\n}\n```  \n"
     },
     "deprecated": false,
     "preselect": true,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/stringParameterDecorators.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/stringParameterDecorators.json
@@ -4,7 +4,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nallowed(values: array): any\n\n```\n\n"
+      "value": "```bicep\nallowed(values: array): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25,7 +25,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndescription(text: string): any\n\n```\n\n"
+      "value": "```bicep\ndescription(text: string): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46,7 +46,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmaxLength(length: int): any\n\n```\n\n"
+      "value": "```bicep\nmaxLength(length: int): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -67,7 +67,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmetadata(object: object): any\n\n```\n\n"
+      "value": "```bicep\nmetadata(object: object): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -88,7 +88,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nminLength(length: int): any\n\n```\n\n"
+      "value": "```bicep\nminLength(length: int): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -109,7 +109,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsecure(): any\n\n```\n\n"
+      "value": "```bicep\nsecure(): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/stringParameterDecoratorsPlusNamespace.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/stringParameterDecoratorsPlusNamespace.json
@@ -4,7 +4,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nallowed(values: array): any\n\n```\n\n"
+      "value": "```bicep\nallowed(values: array): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -25,7 +25,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndescription(text: string): any\n\n```\n\n"
+      "value": "```bicep\ndescription(text: string): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -46,7 +46,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmaxLength(length: int): any\n\n```\n\n"
+      "value": "```bicep\nmaxLength(length: int): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -67,7 +67,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmetadata(object: object): any\n\n```\n\n"
+      "value": "```bicep\nmetadata(object: object): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -88,7 +88,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nminLength(length: int): any\n\n```\n\n"
+      "value": "```bicep\nminLength(length: int): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -109,7 +109,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsecure(): any\n\n```\n\n"
+      "value": "```bicep\nsecure(): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
@@ -38,10 +38,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -59,10 +55,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -80,10 +72,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -101,10 +89,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -122,10 +106,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -143,10 +123,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -164,10 +140,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -206,10 +178,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -227,10 +195,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -266,10 +230,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -287,10 +247,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -308,10 +264,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -329,10 +281,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -350,10 +298,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -371,10 +315,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -392,10 +332,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -476,10 +412,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -518,10 +450,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -581,10 +509,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -602,10 +526,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -623,10 +543,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -644,10 +560,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -665,10 +577,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -686,10 +594,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -707,10 +611,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -728,10 +628,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -791,10 +687,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -812,10 +704,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -833,10 +721,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -872,10 +756,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -893,10 +773,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1019,10 +895,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1054,10 +926,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1075,10 +943,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1096,10 +960,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1117,10 +977,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1138,10 +994,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1156,10 +1008,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1177,10 +1025,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1198,10 +1042,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1219,10 +1059,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1240,10 +1076,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1261,10 +1093,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1279,10 +1107,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1297,10 +1121,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1315,10 +1135,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1333,10 +1149,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1351,10 +1163,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1369,10 +1177,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1387,10 +1191,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1405,10 +1205,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1423,10 +1219,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1441,10 +1233,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1459,10 +1247,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1477,10 +1261,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1498,10 +1278,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1519,10 +1295,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1540,10 +1312,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1561,10 +1329,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1579,10 +1343,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1597,10 +1357,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1615,10 +1371,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1633,10 +1385,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1651,10 +1399,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1669,10 +1413,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1687,10 +1427,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1705,10 +1441,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1723,10 +1455,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1741,10 +1469,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1759,10 +1483,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1777,10 +1497,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1795,10 +1511,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1813,10 +1525,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1831,10 +1539,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1849,10 +1553,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1870,10 +1570,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1891,10 +1587,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1912,10 +1604,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1933,10 +1621,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1951,10 +1635,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1969,10 +1649,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1987,10 +1663,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2005,10 +1677,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2023,10 +1691,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2041,10 +1705,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2059,10 +1719,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2077,10 +1733,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2095,10 +1747,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2113,10 +1761,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2131,10 +1775,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2149,10 +1789,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2170,10 +1806,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2191,10 +1823,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2233,10 +1861,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2289,10 +1913,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2310,10 +1930,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2331,10 +1947,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2352,10 +1964,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2373,10 +1981,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2394,10 +1998,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2415,10 +2015,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2436,10 +2032,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2457,10 +2049,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2478,10 +2066,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2499,10 +2083,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2520,10 +2100,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2541,10 +2117,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2562,10 +2134,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2583,10 +2151,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2604,10 +2168,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2625,10 +2185,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2646,10 +2202,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2667,10 +2219,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2688,10 +2236,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2709,10 +2253,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2730,10 +2270,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2751,10 +2287,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2769,10 +2301,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2874,10 +2402,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2895,10 +2419,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -3008,10 +2528,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -3071,10 +2587,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3110,10 +2622,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3131,10 +2639,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3152,10 +2656,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3173,10 +2673,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3194,10 +2690,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3215,10 +2707,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3236,10 +2724,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3257,10 +2741,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3278,10 +2758,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3299,10 +2775,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3320,10 +2792,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3341,10 +2809,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3362,10 +2826,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3383,10 +2843,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3401,10 +2857,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3419,10 +2871,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3473,10 +2921,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3512,10 +2956,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3659,10 +3099,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3677,10 +3113,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3779,10 +3211,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3800,10 +3228,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3821,10 +3245,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3842,10 +3262,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3863,10 +3279,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3884,10 +3296,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3902,10 +3310,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -4025,10 +3429,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4046,10 +3446,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4067,10 +3463,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4088,10 +3480,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4109,10 +3497,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4130,10 +3514,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4151,10 +3531,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4169,10 +3545,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4190,10 +3562,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4208,10 +3576,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4226,10 +3590,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4244,10 +3604,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4262,10 +3618,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4280,10 +3632,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4298,10 +3646,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4316,10 +3660,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4334,10 +3674,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4352,10 +3688,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4370,10 +3702,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4388,10 +3716,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4406,10 +3730,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4424,10 +3744,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4442,10 +3758,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4460,10 +3772,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4478,10 +3786,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4496,10 +3800,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4514,10 +3814,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4532,10 +3828,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4550,10 +3842,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4571,10 +3859,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4589,10 +3873,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4607,10 +3887,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4625,10 +3901,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4643,10 +3915,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4661,10 +3929,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4679,10 +3943,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4697,10 +3957,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4715,10 +3971,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4733,10 +3985,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4751,10 +3999,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4769,10 +4013,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4787,10 +4027,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4808,10 +4044,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4829,10 +4061,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4850,10 +4078,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4871,10 +4095,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4892,10 +4112,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4913,10 +4129,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4934,10 +4146,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4955,10 +4163,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4976,10 +4180,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4997,10 +4197,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -5018,10 +4214,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5039,10 +4231,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5060,10 +4248,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5081,10 +4265,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5099,10 +4279,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5117,10 +4293,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5138,10 +4310,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5159,10 +4327,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5180,10 +4344,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5201,10 +4361,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5222,10 +4378,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5243,10 +4395,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5264,10 +4412,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5285,10 +4429,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5306,10 +4446,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5327,10 +4463,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5348,10 +4480,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5369,10 +4497,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5390,10 +4514,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5411,10 +4531,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5432,10 +4548,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5516,10 +4628,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5537,10 +4645,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5558,10 +4662,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5621,10 +4721,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5747,10 +4843,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5765,10 +4857,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5801,10 +4889,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5819,10 +4903,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5837,10 +4917,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5855,10 +4931,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5873,10 +4945,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5894,10 +4962,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5915,10 +4979,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5936,10 +4996,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5957,10 +5013,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5978,10 +5030,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5999,10 +5047,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -6020,10 +5064,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6041,10 +5081,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6062,10 +5098,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6083,10 +5115,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6104,10 +5132,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6125,10 +5149,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6146,10 +5166,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6167,10 +5183,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6188,10 +5200,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6209,10 +5217,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6230,10 +5234,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6248,10 +5248,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6269,10 +5265,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6290,10 +5282,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6311,10 +5299,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6332,10 +5316,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6353,10 +5333,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6374,10 +5350,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6395,10 +5367,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6416,10 +5384,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6437,10 +5401,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6458,10 +5418,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6476,10 +5432,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6494,10 +5446,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6512,10 +5460,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6530,10 +5474,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6551,10 +5491,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6569,10 +5505,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6653,10 +5585,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6674,10 +5602,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6695,10 +5619,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6716,10 +5636,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6737,10 +5653,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6758,10 +5670,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6779,10 +5687,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6821,10 +5725,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6863,10 +5763,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -7021,10 +5917,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7126,10 +6018,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7168,10 +6056,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7294,10 +6178,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7312,10 +6192,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7333,10 +6209,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7351,10 +6223,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7369,10 +6237,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7390,10 +6254,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7411,10 +6271,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7432,10 +6288,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7453,10 +6305,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7474,10 +6322,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7495,10 +6339,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7516,10 +6356,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7537,10 +6373,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
@@ -18,7 +18,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38,6 +38,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -55,6 +59,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -72,6 +80,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -89,6 +101,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -106,6 +122,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -123,6 +143,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -140,6 +164,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -158,7 +186,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -178,6 +206,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -195,6 +227,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -230,6 +266,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -247,6 +287,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -264,6 +308,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -281,6 +329,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -298,6 +350,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -315,6 +371,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -332,6 +392,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -350,7 +414,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -371,7 +435,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -392,7 +456,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -412,6 +476,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -430,7 +498,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -450,6 +518,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -468,7 +540,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -489,7 +561,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -509,6 +581,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -526,6 +602,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -543,6 +623,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -560,6 +644,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -577,6 +665,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -594,6 +686,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -611,6 +707,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -628,6 +728,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -646,7 +750,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -667,7 +771,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -687,6 +791,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -704,6 +812,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -721,6 +833,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -740,7 +856,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -756,6 +872,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -773,6 +893,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -791,7 +915,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -812,7 +936,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -833,7 +957,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -854,7 +978,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -875,7 +999,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -895,6 +1019,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -910,7 +1038,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -926,6 +1054,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -943,6 +1075,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -960,6 +1096,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -977,6 +1117,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -994,6 +1138,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1008,6 +1156,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1025,6 +1177,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1042,6 +1198,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1059,6 +1219,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1076,6 +1240,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1093,6 +1261,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1107,6 +1279,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1121,6 +1297,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1135,6 +1315,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1149,6 +1333,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1163,6 +1351,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1177,6 +1369,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1191,6 +1387,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1205,6 +1405,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1219,6 +1423,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1233,6 +1441,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1247,6 +1459,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1261,6 +1477,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1278,6 +1498,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1295,6 +1519,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1312,6 +1540,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1329,6 +1561,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1343,6 +1579,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1357,6 +1597,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1371,6 +1615,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1385,6 +1633,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1399,6 +1651,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1413,6 +1669,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1427,6 +1687,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1441,6 +1705,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1455,6 +1723,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1469,6 +1741,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1483,6 +1759,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1497,6 +1777,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1511,6 +1795,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1525,6 +1813,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1539,6 +1831,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1553,6 +1849,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1570,6 +1870,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1587,6 +1891,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1604,6 +1912,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1621,6 +1933,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1635,6 +1951,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1649,6 +1969,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1663,6 +1987,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1677,6 +2005,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1691,6 +2023,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -1705,6 +2041,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -1719,6 +2059,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -1733,6 +2077,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -1747,6 +2095,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -1761,6 +2113,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -1775,6 +2131,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -1789,6 +2149,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -1806,6 +2170,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -1823,6 +2191,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -1841,7 +2213,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1861,6 +2233,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -1876,7 +2252,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1897,7 +2273,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1913,6 +2289,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -1930,6 +2310,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -1947,6 +2331,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -1964,6 +2352,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -1981,6 +2373,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -1998,6 +2394,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2015,6 +2415,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2032,6 +2436,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2049,6 +2457,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2066,6 +2478,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2083,6 +2499,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2100,6 +2520,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2117,6 +2541,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2134,6 +2562,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2151,6 +2583,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2168,6 +2604,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2185,6 +2625,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2202,6 +2646,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2219,6 +2667,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2236,6 +2688,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2253,6 +2709,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2270,6 +2730,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2287,6 +2751,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2301,6 +2769,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2319,7 +2791,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2340,7 +2812,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2361,7 +2833,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2382,7 +2854,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2402,6 +2874,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2419,6 +2895,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2438,7 +2918,7 @@
     "detail": "for",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n[for item in list: ]\n```"
+      "value": "```bicep\n[for item in list: ]\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2456,7 +2936,7 @@
     "detail": "for-indexed",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n[for (item, index) in list: ]\n```"
+      "value": "```bicep\n[for (item, index) in list: ]\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2473,7 +2953,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2494,7 +2974,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2528,6 +3008,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2546,7 +3030,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2567,7 +3051,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2587,6 +3071,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2602,7 +3090,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2622,6 +3110,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2639,6 +3131,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2656,6 +3152,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2673,6 +3173,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2690,6 +3194,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2707,6 +3215,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2724,6 +3236,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2741,6 +3257,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2758,6 +3278,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2775,6 +3299,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -2792,6 +3320,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -2809,6 +3341,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -2826,6 +3362,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -2843,6 +3383,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -2857,6 +3401,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -2871,6 +3419,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -2887,7 +3439,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2905,7 +3457,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2921,6 +3473,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -2940,7 +3496,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2956,6 +3512,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -2974,7 +3534,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2995,7 +3555,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3016,7 +3576,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3037,7 +3597,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3058,7 +3618,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3079,7 +3639,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3099,6 +3659,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3113,6 +3677,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3128,7 +3696,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3149,7 +3717,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3170,7 +3738,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3191,7 +3759,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3211,6 +3779,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3228,6 +3800,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3245,6 +3821,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3262,6 +3842,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3279,6 +3863,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3296,6 +3884,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3310,6 +3902,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3325,7 +3921,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3346,7 +3942,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3367,7 +3963,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3388,7 +3984,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3409,7 +4005,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3429,6 +4025,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3446,6 +4046,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3463,6 +4067,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3480,6 +4088,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3497,6 +4109,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3514,6 +4130,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3531,6 +4151,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3545,6 +4169,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3562,6 +4190,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3576,6 +4208,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3590,6 +4226,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3604,6 +4244,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3618,6 +4262,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3632,6 +4280,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3646,6 +4298,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3660,6 +4316,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3674,6 +4334,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3688,6 +4352,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3702,6 +4370,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3716,6 +4388,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3730,6 +4406,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3744,6 +4424,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3758,6 +4442,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3772,6 +4460,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -3786,6 +4478,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -3800,6 +4496,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -3814,6 +4514,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -3828,6 +4532,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -3842,6 +4550,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -3859,6 +4571,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -3873,6 +4589,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -3887,6 +4607,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -3901,6 +4625,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -3915,6 +4643,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -3929,6 +4661,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -3943,6 +4679,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -3957,6 +4697,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -3971,6 +4715,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -3985,6 +4733,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -3999,6 +4751,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4013,6 +4769,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4027,6 +4787,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4044,6 +4808,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4061,6 +4829,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4078,6 +4850,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4095,6 +4871,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4112,6 +4892,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4129,6 +4913,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4146,6 +4934,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4163,6 +4955,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4180,6 +4976,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4197,6 +4997,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4214,6 +5018,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4231,6 +5039,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4248,6 +5060,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4265,6 +5081,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4279,6 +5099,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4293,6 +5117,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4310,6 +5138,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4327,6 +5159,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4344,6 +5180,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4361,6 +5201,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4378,6 +5222,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4395,6 +5243,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4412,6 +5264,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4429,6 +5285,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4446,6 +5306,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4463,6 +5327,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4480,6 +5348,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4497,6 +5369,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4514,6 +5390,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4531,6 +5411,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4548,6 +5432,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4566,7 +5454,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4587,7 +5475,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4608,7 +5496,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4628,6 +5516,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -4645,6 +5537,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4662,6 +5558,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4680,7 +5580,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4701,7 +5601,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4721,6 +5621,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4739,7 +5643,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4760,7 +5664,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4781,7 +5685,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4802,7 +5706,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4823,7 +5727,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4843,6 +5747,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -4857,6 +5765,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -4873,7 +5785,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4889,6 +5801,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -4903,6 +5819,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -4917,6 +5837,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -4931,6 +5855,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -4945,6 +5873,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -4962,6 +5894,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -4979,6 +5915,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -4996,6 +5936,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5013,6 +5957,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5030,6 +5978,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5047,6 +5999,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5064,6 +6020,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5081,6 +6041,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5098,6 +6062,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5115,6 +6083,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5132,6 +6104,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5149,6 +6125,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5166,6 +6146,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5183,6 +6167,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5200,6 +6188,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5217,6 +6209,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5234,6 +6230,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5248,6 +6248,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5265,6 +6269,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5282,6 +6290,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5299,6 +6311,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5316,6 +6332,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5333,6 +6353,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5350,6 +6374,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5367,6 +6395,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5384,6 +6416,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5401,6 +6437,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5418,6 +6458,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5432,6 +6476,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5446,6 +6494,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5460,6 +6512,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5474,6 +6530,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5491,6 +6551,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5505,6 +6569,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5523,7 +6591,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5544,7 +6612,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5565,7 +6633,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5585,6 +6653,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5602,6 +6674,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5619,6 +6695,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5636,6 +6716,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5653,6 +6737,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5670,6 +6758,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5687,6 +6779,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5705,7 +6801,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5725,6 +6821,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5743,7 +6843,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5763,6 +6863,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -5781,7 +6885,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5802,7 +6906,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5823,7 +6927,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5863,7 +6967,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5880,7 +6984,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5901,7 +7005,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5917,6 +7021,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -5935,7 +7043,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5956,7 +7064,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5977,7 +7085,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5998,7 +7106,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6018,6 +7126,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6036,7 +7148,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6056,6 +7168,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6074,7 +7190,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6095,7 +7211,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6116,7 +7232,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6137,7 +7253,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6158,7 +7274,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6178,6 +7294,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6192,6 +7312,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6209,6 +7333,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6223,6 +7351,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6237,6 +7369,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6254,6 +7390,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6271,6 +7411,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6288,6 +7432,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6305,6 +7453,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6322,6 +7474,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6339,6 +7495,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6356,6 +7516,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6373,6 +7537,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
@@ -24,10 +24,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -45,10 +41,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -66,10 +58,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -87,10 +75,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -108,10 +92,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -129,10 +109,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -150,10 +126,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -192,10 +164,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -213,10 +181,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -252,10 +216,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -273,10 +233,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -294,10 +250,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -315,10 +267,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -336,10 +284,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -357,10 +301,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -378,10 +318,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -462,10 +398,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -546,10 +478,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -567,10 +495,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -588,10 +512,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -609,10 +529,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -630,10 +546,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -651,10 +563,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -672,10 +580,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -693,10 +597,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -756,10 +656,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -777,10 +673,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -798,10 +690,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -837,10 +725,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -858,10 +742,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -984,10 +864,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1019,10 +895,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1040,10 +912,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1061,10 +929,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1082,10 +946,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1103,10 +963,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1121,10 +977,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1142,10 +994,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1163,10 +1011,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1184,10 +1028,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1205,10 +1045,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1226,10 +1062,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1244,10 +1076,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1262,10 +1090,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1280,10 +1104,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1298,10 +1118,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1316,10 +1132,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1334,10 +1146,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1352,10 +1160,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1370,10 +1174,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1388,10 +1188,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1406,10 +1202,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1424,10 +1216,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1442,10 +1230,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1463,10 +1247,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1484,10 +1264,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1505,10 +1281,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1526,10 +1298,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1544,10 +1312,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1562,10 +1326,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1580,10 +1340,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1598,10 +1354,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1616,10 +1368,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1634,10 +1382,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1652,10 +1396,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1670,10 +1410,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1688,10 +1424,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1706,10 +1438,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1724,10 +1452,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1742,10 +1466,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1760,10 +1480,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1778,10 +1494,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1796,10 +1508,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1814,10 +1522,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1835,10 +1539,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1856,10 +1556,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1877,10 +1573,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1898,10 +1590,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1916,10 +1604,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1934,10 +1618,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1952,10 +1632,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1970,10 +1646,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1988,10 +1660,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2006,10 +1674,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2024,10 +1688,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2042,10 +1702,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2060,10 +1716,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2078,10 +1730,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2096,10 +1744,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2114,10 +1758,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2135,10 +1775,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2156,10 +1792,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2198,10 +1830,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2254,10 +1882,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2275,10 +1899,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2296,10 +1916,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2317,10 +1933,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2338,10 +1950,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2359,10 +1967,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2380,10 +1984,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2401,10 +2001,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2422,10 +2018,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2443,10 +2035,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2464,10 +2052,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2485,10 +2069,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2506,10 +2086,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2527,10 +2103,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2548,10 +2120,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2569,10 +2137,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2590,10 +2154,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2611,10 +2171,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2632,10 +2188,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2653,10 +2205,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2674,10 +2222,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2695,10 +2239,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2716,10 +2256,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2734,10 +2270,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2853,10 +2385,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2874,10 +2402,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2951,10 +2475,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2972,10 +2492,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3035,10 +2551,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3074,10 +2586,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3095,10 +2603,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3116,10 +2620,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3137,10 +2637,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3158,10 +2654,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3179,10 +2671,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3200,10 +2688,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3221,10 +2705,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3242,10 +2722,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3263,10 +2739,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3284,10 +2756,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3305,10 +2773,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3326,10 +2790,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3347,10 +2807,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3365,10 +2821,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3383,10 +2835,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3437,10 +2885,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3476,10 +2920,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3623,10 +3063,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3641,10 +3077,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3743,10 +3175,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3764,10 +3192,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3785,10 +3209,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3806,10 +3226,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3827,10 +3243,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3848,10 +3260,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3866,10 +3274,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3989,10 +3393,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4010,10 +3410,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4031,10 +3427,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4052,10 +3444,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4073,10 +3461,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4094,10 +3478,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4115,10 +3495,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4133,10 +3509,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4154,10 +3526,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4172,10 +3540,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4190,10 +3554,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4208,10 +3568,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4226,10 +3582,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4244,10 +3596,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4262,10 +3610,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4280,10 +3624,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4298,10 +3638,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4316,10 +3652,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4334,10 +3666,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4352,10 +3680,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4370,10 +3694,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4388,10 +3708,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4406,10 +3722,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4424,10 +3736,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4442,10 +3750,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4460,10 +3764,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4478,10 +3778,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4496,10 +3792,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4514,10 +3806,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4535,10 +3823,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4553,10 +3837,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4571,10 +3851,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4589,10 +3865,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4607,10 +3879,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4625,10 +3893,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4643,10 +3907,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4661,10 +3921,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4679,10 +3935,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4697,10 +3949,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4715,10 +3963,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4733,10 +3977,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4751,10 +3991,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4772,10 +4008,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4793,10 +4025,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4814,10 +4042,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4835,10 +4059,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4856,10 +4076,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4877,10 +4093,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4898,10 +4110,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4919,10 +4127,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4940,10 +4144,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4961,10 +4161,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4982,10 +4178,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5003,10 +4195,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5024,10 +4212,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5045,10 +4229,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5063,10 +4243,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5081,10 +4257,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5102,10 +4274,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5123,10 +4291,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5144,10 +4308,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5165,10 +4325,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5186,10 +4342,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5207,10 +4359,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5228,10 +4376,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5249,10 +4393,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5270,10 +4410,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5291,10 +4427,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5312,10 +4444,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5333,10 +4461,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5354,10 +4478,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5375,10 +4495,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5396,10 +4512,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5480,10 +4592,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5501,10 +4609,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5522,10 +4626,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5585,10 +4685,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5711,10 +4807,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5729,10 +4821,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5765,10 +4853,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5783,10 +4867,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5801,10 +4881,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5819,10 +4895,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5837,10 +4909,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5858,10 +4926,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5879,10 +4943,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5900,10 +4960,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5921,10 +4977,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5942,10 +4994,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5963,10 +5011,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5984,10 +5028,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6005,10 +5045,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6026,10 +5062,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6047,10 +5079,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6068,10 +5096,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6089,10 +5113,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6110,10 +5130,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6131,10 +5147,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6152,10 +5164,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6173,10 +5181,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6194,10 +5198,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6212,10 +5212,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6233,10 +5229,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6254,10 +5246,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6275,10 +5263,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6296,10 +5280,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6317,10 +5297,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6338,10 +5314,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6359,10 +5331,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6380,10 +5348,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6401,10 +5365,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6422,10 +5382,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6440,10 +5396,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6458,10 +5410,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6476,10 +5424,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6494,10 +5438,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6515,10 +5455,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6533,10 +5469,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6617,10 +5549,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6638,10 +5566,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6659,10 +5583,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6680,10 +5600,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6701,10 +5617,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6722,10 +5634,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6743,10 +5651,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6785,10 +5689,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6827,10 +5727,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -6985,10 +5881,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7090,10 +5982,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7146,10 +6034,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7272,10 +6156,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7290,10 +6170,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7311,10 +6187,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7329,10 +6201,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7347,10 +6215,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7368,10 +6232,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7389,10 +6249,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7410,10 +6266,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7431,10 +6283,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7452,10 +6300,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7473,10 +6317,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7494,10 +6334,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7515,10 +6351,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
@@ -4,7 +4,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24,6 +24,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -41,6 +45,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -58,6 +66,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -75,6 +87,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -92,6 +108,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -109,6 +129,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -126,6 +150,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -144,7 +172,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -164,6 +192,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -181,6 +213,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -216,6 +252,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -233,6 +273,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -250,6 +294,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -267,6 +315,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -284,6 +336,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -301,6 +357,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -318,6 +378,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -336,7 +400,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -357,7 +421,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -378,7 +442,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -398,6 +462,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -416,7 +484,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -437,7 +505,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -458,7 +526,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -478,6 +546,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -495,6 +567,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -512,6 +588,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -529,6 +609,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -546,6 +630,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -563,6 +651,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -580,6 +672,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -597,6 +693,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -615,7 +715,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -636,7 +736,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -656,6 +756,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -673,6 +777,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -690,6 +798,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -709,7 +821,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -725,6 +837,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -742,6 +858,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -760,7 +880,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -781,7 +901,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -802,7 +922,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -823,7 +943,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -844,7 +964,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -864,6 +984,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -879,7 +1003,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -895,6 +1019,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -912,6 +1040,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -929,6 +1061,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -946,6 +1082,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -963,6 +1103,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -977,6 +1121,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -994,6 +1142,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1011,6 +1163,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1028,6 +1184,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1045,6 +1205,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1062,6 +1226,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1076,6 +1244,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1090,6 +1262,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1104,6 +1280,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1118,6 +1298,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1132,6 +1316,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1146,6 +1334,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1160,6 +1352,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1174,6 +1370,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1188,6 +1388,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1202,6 +1406,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1216,6 +1424,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1230,6 +1442,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1247,6 +1463,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1264,6 +1484,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1281,6 +1505,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1298,6 +1526,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1312,6 +1544,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1326,6 +1562,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1340,6 +1580,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1354,6 +1598,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1368,6 +1616,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1382,6 +1634,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1396,6 +1652,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1410,6 +1670,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1424,6 +1688,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1438,6 +1706,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1452,6 +1724,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1466,6 +1742,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1480,6 +1760,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1494,6 +1778,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1508,6 +1796,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1522,6 +1814,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1539,6 +1835,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1556,6 +1856,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1573,6 +1877,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1590,6 +1898,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1604,6 +1916,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1618,6 +1934,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1632,6 +1952,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1646,6 +1970,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1660,6 +1988,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -1674,6 +2006,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -1688,6 +2024,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -1702,6 +2042,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -1716,6 +2060,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -1730,6 +2078,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -1744,6 +2096,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -1758,6 +2114,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -1775,6 +2135,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -1792,6 +2156,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -1810,7 +2178,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1830,6 +2198,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -1845,7 +2217,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1866,7 +2238,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1882,6 +2254,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -1899,6 +2275,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -1916,6 +2296,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -1933,6 +2317,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -1950,6 +2338,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -1967,6 +2359,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -1984,6 +2380,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2001,6 +2401,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2018,6 +2422,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2035,6 +2443,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2052,6 +2464,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2069,6 +2485,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2086,6 +2506,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2103,6 +2527,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2120,6 +2548,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2137,6 +2569,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2154,6 +2590,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2171,6 +2611,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2188,6 +2632,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2205,6 +2653,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2222,6 +2674,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2239,6 +2695,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2256,6 +2716,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2270,6 +2734,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2288,7 +2756,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2323,7 +2791,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2344,7 +2812,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2365,7 +2833,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2385,6 +2853,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2402,6 +2874,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2420,7 +2896,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2441,7 +2917,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2475,6 +2951,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2492,6 +2972,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -2510,7 +2994,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2531,7 +3015,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2551,6 +3035,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2566,7 +3054,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2586,6 +3074,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2603,6 +3095,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2620,6 +3116,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2637,6 +3137,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2654,6 +3158,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2671,6 +3179,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2688,6 +3200,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2705,6 +3221,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2722,6 +3242,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2739,6 +3263,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -2756,6 +3284,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -2773,6 +3305,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -2790,6 +3326,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -2807,6 +3347,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -2821,6 +3365,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -2835,6 +3383,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -2851,7 +3403,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2869,7 +3421,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2885,6 +3437,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -2904,7 +3460,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2920,6 +3476,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -2938,7 +3498,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2959,7 +3519,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2980,7 +3540,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3001,7 +3561,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3022,7 +3582,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3043,7 +3603,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3063,6 +3623,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3077,6 +3641,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3092,7 +3660,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3113,7 +3681,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3134,7 +3702,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3155,7 +3723,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3175,6 +3743,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3192,6 +3764,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3209,6 +3785,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3226,6 +3806,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3243,6 +3827,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3260,6 +3848,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3274,6 +3866,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3289,7 +3885,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3310,7 +3906,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3331,7 +3927,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3352,7 +3948,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3373,7 +3969,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3393,6 +3989,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3410,6 +4010,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3427,6 +4031,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3444,6 +4052,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3461,6 +4073,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3478,6 +4094,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3495,6 +4115,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3509,6 +4133,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3526,6 +4154,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3540,6 +4172,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3554,6 +4190,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3568,6 +4208,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3582,6 +4226,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3596,6 +4244,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3610,6 +4262,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3624,6 +4280,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3638,6 +4298,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3652,6 +4316,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3666,6 +4334,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3680,6 +4352,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3694,6 +4370,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3708,6 +4388,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3722,6 +4406,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3736,6 +4424,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -3750,6 +4442,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -3764,6 +4460,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -3778,6 +4478,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -3792,6 +4496,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -3806,6 +4514,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -3823,6 +4535,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -3837,6 +4553,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -3851,6 +4571,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -3865,6 +4589,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -3879,6 +4607,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -3893,6 +4625,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -3907,6 +4643,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -3921,6 +4661,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -3935,6 +4679,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -3949,6 +4697,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -3963,6 +4715,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -3977,6 +4733,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -3991,6 +4751,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4008,6 +4772,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4025,6 +4793,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4042,6 +4814,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4059,6 +4835,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4076,6 +4856,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4093,6 +4877,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4110,6 +4898,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4127,6 +4919,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4144,6 +4940,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4161,6 +4961,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4178,6 +4982,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4195,6 +5003,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4212,6 +5024,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4229,6 +5045,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4243,6 +5063,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4257,6 +5081,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4274,6 +5102,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4291,6 +5123,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4308,6 +5144,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4325,6 +5165,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4342,6 +5186,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4359,6 +5207,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4376,6 +5228,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4393,6 +5249,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4410,6 +5270,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4427,6 +5291,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4444,6 +5312,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4461,6 +5333,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4478,6 +5354,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4495,6 +5375,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4512,6 +5396,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4530,7 +5418,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4551,7 +5439,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4572,7 +5460,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4592,6 +5480,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -4609,6 +5501,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4626,6 +5522,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4644,7 +5544,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4665,7 +5565,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4685,6 +5585,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4703,7 +5607,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4724,7 +5628,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4745,7 +5649,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4766,7 +5670,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4787,7 +5691,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4807,6 +5711,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -4821,6 +5729,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -4837,7 +5749,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4853,6 +5765,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -4867,6 +5783,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -4881,6 +5801,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -4895,6 +5819,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -4909,6 +5837,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -4926,6 +5858,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -4943,6 +5879,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -4960,6 +5900,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -4977,6 +5921,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -4994,6 +5942,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5011,6 +5963,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5028,6 +5984,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5045,6 +6005,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5062,6 +6026,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5079,6 +6047,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5096,6 +6068,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5113,6 +6089,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5130,6 +6110,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5147,6 +6131,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5164,6 +6152,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5181,6 +6173,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5198,6 +6194,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5212,6 +6212,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5229,6 +6233,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5246,6 +6254,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5263,6 +6275,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5280,6 +6296,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5297,6 +6317,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5314,6 +6338,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5331,6 +6359,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5348,6 +6380,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5365,6 +6401,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5382,6 +6422,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5396,6 +6440,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5410,6 +6458,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5424,6 +6476,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5438,6 +6494,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5455,6 +6515,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5469,6 +6533,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5487,7 +6555,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5508,7 +6576,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5529,7 +6597,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5549,6 +6617,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5566,6 +6638,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5583,6 +6659,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5600,6 +6680,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5617,6 +6701,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5634,6 +6722,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5651,6 +6743,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5669,7 +6765,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5689,6 +6785,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5707,7 +6807,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5727,6 +6827,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -5745,7 +6849,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5766,7 +6870,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5787,7 +6891,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5827,7 +6931,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5844,7 +6948,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5865,7 +6969,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5881,6 +6985,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -5899,7 +7007,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5920,7 +7028,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5941,7 +7049,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5962,7 +7070,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5982,6 +7090,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6000,7 +7112,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6034,6 +7146,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6052,7 +7168,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6073,7 +7189,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6094,7 +7210,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6115,7 +7231,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6136,7 +7252,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6156,6 +7272,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6170,6 +7290,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6187,6 +7311,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6201,6 +7329,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6215,6 +7347,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6232,6 +7368,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6249,6 +7389,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6266,6 +7410,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6283,6 +7431,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6300,6 +7452,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6317,6 +7473,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6334,6 +7494,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6351,6 +7515,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
@@ -46,7 +46,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -66,6 +66,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -83,6 +87,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -100,6 +108,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -117,6 +129,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -134,6 +150,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -151,6 +171,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -168,6 +192,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -186,7 +214,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -206,6 +234,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -223,6 +255,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -258,6 +294,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -275,6 +315,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -292,6 +336,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -309,6 +357,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -326,6 +378,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -343,6 +399,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -360,6 +420,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -378,7 +442,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -399,7 +463,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -420,7 +484,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -440,6 +504,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -458,7 +526,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -478,6 +546,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -496,7 +568,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -517,7 +589,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -537,6 +609,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -554,6 +630,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -571,6 +651,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -588,6 +672,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -605,6 +693,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -622,6 +714,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -639,6 +735,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -656,6 +756,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -674,7 +778,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -695,7 +799,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -715,6 +819,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -732,6 +840,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -749,6 +861,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -768,7 +884,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -784,6 +900,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -801,6 +921,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -819,7 +943,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -840,7 +964,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -861,7 +985,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -882,7 +1006,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -903,7 +1027,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -923,6 +1047,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -938,7 +1066,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -954,6 +1082,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -971,6 +1103,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -988,6 +1124,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1005,6 +1145,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1022,6 +1166,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1036,6 +1184,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1053,6 +1205,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1070,6 +1226,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1087,6 +1247,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1104,6 +1268,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1121,6 +1289,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1135,6 +1307,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1149,6 +1325,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1163,6 +1343,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1177,6 +1361,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1191,6 +1379,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1205,6 +1397,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1219,6 +1415,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1233,6 +1433,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1247,6 +1451,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1261,6 +1469,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1275,6 +1487,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1289,6 +1505,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1306,6 +1526,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1323,6 +1547,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1340,6 +1568,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1357,6 +1589,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1371,6 +1607,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1385,6 +1625,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1399,6 +1643,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1413,6 +1661,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1427,6 +1679,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1441,6 +1697,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1455,6 +1715,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1469,6 +1733,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1483,6 +1751,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1497,6 +1769,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1511,6 +1787,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1525,6 +1805,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1539,6 +1823,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1553,6 +1841,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1567,6 +1859,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1581,6 +1877,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1598,6 +1898,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1615,6 +1919,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1632,6 +1940,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1649,6 +1961,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1663,6 +1979,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1677,6 +1997,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1691,6 +2015,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1705,6 +2033,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1719,6 +2051,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -1733,6 +2069,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -1747,6 +2087,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -1761,6 +2105,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -1775,6 +2123,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -1789,6 +2141,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -1803,6 +2159,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -1817,6 +2177,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -1834,6 +2198,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -1851,6 +2219,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -1869,7 +2241,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1889,6 +2261,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -1904,7 +2280,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1925,7 +2301,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1941,6 +2317,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -1958,6 +2338,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -1975,6 +2359,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -1992,6 +2380,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2009,6 +2401,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2026,6 +2422,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2043,6 +2443,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2060,6 +2464,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2077,6 +2485,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2094,6 +2506,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2111,6 +2527,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2128,6 +2548,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2145,6 +2569,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2162,6 +2590,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2179,6 +2611,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2196,6 +2632,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2213,6 +2653,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2230,6 +2674,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2247,6 +2695,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2264,6 +2716,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2281,6 +2737,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2298,6 +2758,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2315,6 +2779,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2329,6 +2797,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2347,7 +2819,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2368,7 +2840,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2389,7 +2861,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2410,7 +2882,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2430,6 +2902,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2447,6 +2923,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2465,7 +2945,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2486,7 +2966,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2520,6 +3000,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2538,7 +3022,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2559,7 +3043,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2579,6 +3063,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2594,7 +3082,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2614,6 +3102,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2631,6 +3123,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2648,6 +3144,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2665,6 +3165,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2682,6 +3186,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2699,6 +3207,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2716,6 +3228,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2733,6 +3249,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2750,6 +3270,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2767,6 +3291,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -2784,6 +3312,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -2801,6 +3333,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -2818,6 +3354,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -2835,6 +3375,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -2849,6 +3393,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -2863,6 +3411,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -2879,7 +3431,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2897,7 +3449,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2913,6 +3465,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -2932,7 +3488,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2948,6 +3504,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -2966,7 +3526,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2987,7 +3547,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3008,7 +3568,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3029,7 +3589,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3050,7 +3610,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3071,7 +3631,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3091,6 +3651,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3105,6 +3669,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3120,7 +3688,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3141,7 +3709,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3162,7 +3730,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3183,7 +3751,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3203,6 +3771,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3220,6 +3792,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3237,6 +3813,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3254,6 +3834,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3271,6 +3855,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3288,6 +3876,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3302,6 +3894,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3317,7 +3913,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3338,7 +3934,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3359,7 +3955,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3380,7 +3976,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3401,7 +3997,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3421,6 +4017,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3438,6 +4038,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3455,6 +4059,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3472,6 +4080,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3489,6 +4101,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3506,6 +4122,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3523,6 +4143,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3537,6 +4161,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3554,6 +4182,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3568,6 +4200,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3582,6 +4218,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3596,6 +4236,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3610,6 +4254,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3624,6 +4272,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3638,6 +4290,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3652,6 +4308,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3666,6 +4326,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3680,6 +4344,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3694,6 +4362,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3708,6 +4380,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3722,6 +4398,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3736,6 +4416,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3750,6 +4434,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3764,6 +4452,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -3778,6 +4470,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -3792,6 +4488,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -3806,6 +4506,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -3820,6 +4524,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -3834,6 +4542,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -3851,6 +4563,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -3865,6 +4581,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -3879,6 +4599,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -3893,6 +4617,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -3907,6 +4635,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -3921,6 +4653,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -3935,6 +4671,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -3949,6 +4689,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -3963,6 +4707,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -3977,6 +4725,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -3991,6 +4743,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4005,6 +4761,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4019,6 +4779,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4036,6 +4800,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4053,6 +4821,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4070,6 +4842,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4087,6 +4863,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4104,6 +4884,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4121,6 +4905,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4138,6 +4926,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4155,6 +4947,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4172,6 +4968,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4189,6 +4989,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4206,6 +5010,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4223,6 +5031,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4240,6 +5052,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4257,6 +5073,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4271,6 +5091,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4285,6 +5109,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4302,6 +5130,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4319,6 +5151,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4336,6 +5172,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4353,6 +5193,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4370,6 +5214,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4387,6 +5235,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4404,6 +5256,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4421,6 +5277,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4438,6 +5298,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4455,6 +5319,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4472,6 +5340,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4489,6 +5361,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4506,6 +5382,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4523,6 +5403,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4540,6 +5424,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4558,7 +5446,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4579,7 +5467,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4600,7 +5488,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4620,6 +5508,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -4637,6 +5529,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4654,6 +5550,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4672,7 +5572,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4693,7 +5593,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4713,6 +5613,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4731,7 +5635,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4752,7 +5656,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4773,7 +5677,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4794,7 +5698,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4815,7 +5719,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4835,6 +5739,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -4849,6 +5757,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -4865,7 +5777,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4881,6 +5793,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -4895,6 +5811,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -4909,6 +5829,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -4923,6 +5847,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -4937,6 +5865,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -4954,6 +5886,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -4971,6 +5907,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -4988,6 +5928,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5005,6 +5949,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5022,6 +5970,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5039,6 +5991,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5056,6 +6012,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5073,6 +6033,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5090,6 +6054,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5107,6 +6075,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5124,6 +6096,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5141,6 +6117,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5158,6 +6138,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5175,6 +6159,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5192,6 +6180,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5209,6 +6201,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5226,6 +6222,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5240,6 +6240,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5257,6 +6261,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5274,6 +6282,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5291,6 +6303,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5308,6 +6324,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5325,6 +6345,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5342,6 +6366,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5359,6 +6387,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5376,6 +6408,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5393,6 +6429,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5410,6 +6450,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5424,6 +6468,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5438,6 +6486,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5452,6 +6504,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5466,6 +6522,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5483,6 +6543,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5497,6 +6561,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5515,7 +6583,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5536,7 +6604,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5557,7 +6625,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5577,6 +6645,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5594,6 +6666,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5611,6 +6687,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5628,6 +6708,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5645,6 +6729,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5662,6 +6750,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5679,6 +6771,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5697,7 +6793,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5717,6 +6813,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5735,7 +6835,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5755,6 +6855,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -5773,7 +6877,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5794,7 +6898,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5815,7 +6919,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5855,7 +6959,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5872,7 +6976,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5893,7 +6997,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5909,6 +7013,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -5927,7 +7035,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5948,7 +7056,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5969,7 +7077,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5990,7 +7098,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6010,6 +7118,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6028,7 +7140,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6048,6 +7160,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6066,7 +7182,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6087,7 +7203,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6108,7 +7224,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6129,7 +7245,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6150,7 +7266,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6170,6 +7286,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6184,6 +7304,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6201,6 +7325,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6215,6 +7343,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6229,6 +7361,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6246,6 +7382,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6263,6 +7403,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6280,6 +7424,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6297,6 +7445,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6314,6 +7466,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6331,6 +7487,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6348,6 +7508,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6365,6 +7529,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
@@ -66,10 +66,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -87,10 +83,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -108,10 +100,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -129,10 +117,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -150,10 +134,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -171,10 +151,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -192,10 +168,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -234,10 +206,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -255,10 +223,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -294,10 +258,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -315,10 +275,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -336,10 +292,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -357,10 +309,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -378,10 +326,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -399,10 +343,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -420,10 +360,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -504,10 +440,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -546,10 +478,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -609,10 +537,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -630,10 +554,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -651,10 +571,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -672,10 +588,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -693,10 +605,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -714,10 +622,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -735,10 +639,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -756,10 +656,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -819,10 +715,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -840,10 +732,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -861,10 +749,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -900,10 +784,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -921,10 +801,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1047,10 +923,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1082,10 +954,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1103,10 +971,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1124,10 +988,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1145,10 +1005,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1166,10 +1022,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1184,10 +1036,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1205,10 +1053,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1226,10 +1070,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1247,10 +1087,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1268,10 +1104,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1289,10 +1121,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1307,10 +1135,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1325,10 +1149,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1343,10 +1163,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1361,10 +1177,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1379,10 +1191,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1397,10 +1205,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1415,10 +1219,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1433,10 +1233,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1451,10 +1247,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1469,10 +1261,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1487,10 +1275,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1505,10 +1289,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1526,10 +1306,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1547,10 +1323,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1568,10 +1340,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1589,10 +1357,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1607,10 +1371,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1625,10 +1385,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1643,10 +1399,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1661,10 +1413,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1679,10 +1427,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1697,10 +1441,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1715,10 +1455,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1733,10 +1469,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1751,10 +1483,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1769,10 +1497,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1787,10 +1511,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1805,10 +1525,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1823,10 +1539,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1841,10 +1553,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1859,10 +1567,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1877,10 +1581,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1898,10 +1598,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1919,10 +1615,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1940,10 +1632,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1961,10 +1649,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1979,10 +1663,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1997,10 +1677,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -2015,10 +1691,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2033,10 +1705,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2051,10 +1719,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2069,10 +1733,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2087,10 +1747,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2105,10 +1761,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2123,10 +1775,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2141,10 +1789,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2159,10 +1803,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2177,10 +1817,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2198,10 +1834,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2219,10 +1851,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2261,10 +1889,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2317,10 +1941,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2338,10 +1958,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2359,10 +1975,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2380,10 +1992,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2401,10 +2009,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2422,10 +2026,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2443,10 +2043,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2464,10 +2060,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2485,10 +2077,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2506,10 +2094,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2527,10 +2111,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2548,10 +2128,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2569,10 +2145,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2590,10 +2162,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2611,10 +2179,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2632,10 +2196,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2653,10 +2213,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2674,10 +2230,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2695,10 +2247,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2716,10 +2264,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2737,10 +2281,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2758,10 +2298,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2779,10 +2315,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2797,10 +2329,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2902,10 +2430,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2923,10 +2447,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -3000,10 +2520,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -3063,10 +2579,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3102,10 +2614,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3123,10 +2631,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3144,10 +2648,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3165,10 +2665,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3186,10 +2682,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3207,10 +2699,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3228,10 +2716,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3249,10 +2733,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3270,10 +2750,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3291,10 +2767,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3312,10 +2784,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3333,10 +2801,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3354,10 +2818,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3375,10 +2835,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3393,10 +2849,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3411,10 +2863,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3465,10 +2913,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3504,10 +2948,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3651,10 +3091,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3669,10 +3105,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3771,10 +3203,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3792,10 +3220,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3813,10 +3237,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3834,10 +3254,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3855,10 +3271,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3876,10 +3288,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3894,10 +3302,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -4017,10 +3421,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4038,10 +3438,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4059,10 +3455,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4080,10 +3472,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4101,10 +3489,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4122,10 +3506,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4143,10 +3523,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4161,10 +3537,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4182,10 +3554,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4200,10 +3568,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4218,10 +3582,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4236,10 +3596,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4254,10 +3610,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4272,10 +3624,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4290,10 +3638,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4308,10 +3652,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4326,10 +3666,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4344,10 +3680,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4362,10 +3694,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4380,10 +3708,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4398,10 +3722,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4416,10 +3736,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4434,10 +3750,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4452,10 +3764,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4470,10 +3778,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4488,10 +3792,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4506,10 +3806,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4524,10 +3820,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4542,10 +3834,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4563,10 +3851,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4581,10 +3865,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4599,10 +3879,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4617,10 +3893,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4635,10 +3907,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4653,10 +3921,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4671,10 +3935,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4689,10 +3949,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4707,10 +3963,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4725,10 +3977,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4743,10 +3991,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4761,10 +4005,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4779,10 +4019,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4800,10 +4036,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4821,10 +4053,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4842,10 +4070,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4863,10 +4087,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4884,10 +4104,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4905,10 +4121,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4926,10 +4138,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4947,10 +4155,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4968,10 +4172,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4989,10 +4189,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -5010,10 +4206,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5031,10 +4223,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5052,10 +4240,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5073,10 +4257,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5091,10 +4271,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5109,10 +4285,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5130,10 +4302,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5151,10 +4319,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5172,10 +4336,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5193,10 +4353,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5214,10 +4370,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5235,10 +4387,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5256,10 +4404,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5277,10 +4421,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5298,10 +4438,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5319,10 +4455,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5340,10 +4472,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5361,10 +4489,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5382,10 +4506,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5403,10 +4523,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5424,10 +4540,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5508,10 +4620,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5529,10 +4637,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5550,10 +4654,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5613,10 +4713,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5739,10 +4835,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5757,10 +4849,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5793,10 +4881,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5811,10 +4895,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5829,10 +4909,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5847,10 +4923,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5865,10 +4937,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5886,10 +4954,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5907,10 +4971,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5928,10 +4988,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5949,10 +5005,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5970,10 +5022,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5991,10 +5039,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -6012,10 +5056,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6033,10 +5073,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6054,10 +5090,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6075,10 +5107,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6096,10 +5124,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6117,10 +5141,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6138,10 +5158,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6159,10 +5175,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6180,10 +5192,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6201,10 +5209,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6222,10 +5226,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6240,10 +5240,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6261,10 +5257,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6282,10 +5274,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6303,10 +5291,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6324,10 +5308,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6345,10 +5325,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6366,10 +5342,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6387,10 +5359,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6408,10 +5376,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6429,10 +5393,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6450,10 +5410,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6468,10 +5424,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6486,10 +5438,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6504,10 +5452,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6522,10 +5466,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6543,10 +5483,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6561,10 +5497,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6645,10 +5577,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6666,10 +5594,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6687,10 +5611,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6708,10 +5628,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6729,10 +5645,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6750,10 +5662,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6771,10 +5679,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6813,10 +5717,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6855,10 +5755,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -7013,10 +5909,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7118,10 +6010,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7160,10 +6048,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7286,10 +6170,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7304,10 +6184,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7325,10 +6201,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7343,10 +6215,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7361,10 +6229,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7382,10 +6246,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7403,10 +6263,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7424,10 +6280,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7445,10 +6297,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7466,10 +6314,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7487,10 +6331,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7508,10 +6348,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7529,10 +6365,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
@@ -274,7 +274,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -294,6 +294,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -311,6 +315,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -328,6 +336,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -345,6 +357,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -362,6 +378,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -379,6 +399,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -396,6 +420,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -414,7 +442,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -434,6 +462,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -451,6 +483,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -486,6 +522,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -503,6 +543,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -520,6 +564,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -537,6 +585,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -554,6 +606,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -571,6 +627,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -588,6 +648,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -606,7 +670,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -627,7 +691,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -648,7 +712,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -668,6 +732,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -686,7 +754,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -706,6 +774,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -724,7 +796,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -745,7 +817,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -765,6 +837,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -782,6 +858,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -799,6 +879,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -816,6 +900,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -833,6 +921,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -850,6 +942,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -867,6 +963,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -884,6 +984,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -902,7 +1006,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -923,7 +1027,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -943,6 +1047,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -960,6 +1068,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -977,6 +1089,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -996,7 +1112,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1012,6 +1128,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -1029,6 +1149,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1047,7 +1171,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1068,7 +1192,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1089,7 +1213,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1110,7 +1234,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1131,7 +1255,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1151,6 +1275,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1166,7 +1294,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1182,6 +1310,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1199,6 +1331,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1216,6 +1352,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1233,6 +1373,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1250,6 +1394,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1264,6 +1412,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1281,6 +1433,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1298,6 +1454,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1315,6 +1475,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1332,6 +1496,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1349,6 +1517,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1363,6 +1535,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1377,6 +1553,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1391,6 +1571,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1405,6 +1589,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1419,6 +1607,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1433,6 +1625,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1447,6 +1643,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1461,6 +1661,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1475,6 +1679,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1489,6 +1697,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1503,6 +1715,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1520,6 +1736,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1537,6 +1757,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1554,6 +1778,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1571,6 +1799,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1585,6 +1817,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1599,6 +1835,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1613,6 +1853,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1627,6 +1871,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1641,6 +1889,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1655,6 +1907,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1669,6 +1925,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1683,6 +1943,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1697,6 +1961,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1711,6 +1979,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1725,6 +1997,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1739,6 +2015,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1753,6 +2033,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1767,6 +2051,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1781,6 +2069,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1795,6 +2087,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1812,6 +2108,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1829,6 +2129,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1846,6 +2150,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1863,6 +2171,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1877,6 +2189,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1891,6 +2207,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1905,6 +2225,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1919,6 +2243,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1933,6 +2261,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -1947,6 +2279,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -1961,6 +2297,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -1975,6 +2315,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -1989,6 +2333,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2003,6 +2351,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2017,6 +2369,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2031,6 +2387,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2048,6 +2408,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2065,6 +2429,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2083,7 +2451,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2103,6 +2471,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2118,7 +2490,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2139,7 +2511,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2155,6 +2527,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2172,6 +2548,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2189,6 +2569,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2206,6 +2590,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2223,6 +2611,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2240,6 +2632,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2257,6 +2653,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2274,6 +2674,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2291,6 +2695,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2308,6 +2716,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2325,6 +2737,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2342,6 +2758,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2359,6 +2779,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2376,6 +2800,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2393,6 +2821,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2410,6 +2842,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2427,6 +2863,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2444,6 +2884,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2461,6 +2905,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2478,6 +2926,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2495,6 +2947,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2512,6 +2968,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2529,6 +2989,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2543,6 +3007,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2561,7 +3029,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2582,7 +3050,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2603,7 +3071,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2624,7 +3092,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2644,6 +3112,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2661,6 +3133,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2679,7 +3155,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2700,7 +3176,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2734,6 +3210,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2751,6 +3231,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -2769,7 +3253,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2790,7 +3274,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2810,6 +3294,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2825,7 +3313,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2845,6 +3333,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2862,6 +3354,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2879,6 +3375,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2896,6 +3396,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2913,6 +3417,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2930,6 +3438,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2947,6 +3459,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2964,6 +3480,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2981,6 +3501,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2998,6 +3522,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3015,6 +3543,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3032,6 +3564,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3049,6 +3585,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3066,6 +3606,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3080,6 +3624,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3094,6 +3642,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3110,7 +3662,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3128,7 +3680,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3144,6 +3696,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3163,7 +3719,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3179,6 +3735,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3197,7 +3757,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3218,7 +3778,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3239,7 +3799,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3260,7 +3820,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3281,7 +3841,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3302,7 +3862,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3322,6 +3882,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3336,6 +3900,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3351,7 +3919,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3372,7 +3940,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3393,7 +3961,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3414,7 +3982,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3434,6 +4002,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3451,6 +4023,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3468,6 +4044,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3485,6 +4065,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3502,6 +4086,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3519,6 +4107,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3533,6 +4125,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3548,7 +4144,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3569,7 +4165,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3590,7 +4186,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3611,7 +4207,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3632,7 +4228,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3652,6 +4248,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3669,6 +4269,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3686,6 +4290,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3703,6 +4311,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3720,6 +4332,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3737,6 +4353,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3754,6 +4374,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3768,6 +4392,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3785,6 +4413,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3799,6 +4431,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3813,6 +4449,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3827,6 +4467,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3841,6 +4485,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3855,6 +4503,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3869,6 +4521,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3883,6 +4539,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3897,6 +4557,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3911,6 +4575,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3925,6 +4593,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3939,6 +4611,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3953,6 +4629,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3967,6 +4647,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3981,6 +4665,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3995,6 +4683,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4009,6 +4701,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4023,6 +4719,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4037,6 +4737,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4051,6 +4755,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4065,6 +4773,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4082,6 +4794,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4096,6 +4812,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4110,6 +4830,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4124,6 +4848,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4138,6 +4866,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4152,6 +4884,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4166,6 +4902,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4180,6 +4920,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4194,6 +4938,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4208,6 +4956,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4222,6 +4974,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4236,6 +4992,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4250,6 +5010,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4267,6 +5031,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4284,6 +5052,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4301,6 +5073,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4318,6 +5094,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4335,6 +5115,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4352,6 +5136,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4369,6 +5157,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4386,6 +5178,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4403,6 +5199,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4420,6 +5220,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4437,6 +5241,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4454,6 +5262,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4471,6 +5283,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4488,6 +5304,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4502,6 +5322,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4516,6 +5340,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4533,6 +5361,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4550,6 +5382,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4567,6 +5403,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4584,6 +5424,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4601,6 +5445,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4618,6 +5466,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4635,6 +5487,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4652,6 +5508,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4669,6 +5529,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4686,6 +5550,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4703,6 +5571,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4720,6 +5592,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4737,6 +5613,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4754,6 +5634,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4771,6 +5655,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4789,7 +5677,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4810,7 +5698,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4831,7 +5719,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4851,6 +5739,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -4868,6 +5760,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4885,6 +5781,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4903,7 +5803,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4924,7 +5824,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4944,6 +5844,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4962,7 +5866,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4983,7 +5887,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5004,7 +5908,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5025,7 +5929,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5046,7 +5950,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5066,6 +5970,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5080,6 +5988,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5096,7 +6008,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5112,6 +6024,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5126,6 +6042,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5140,6 +6060,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5154,6 +6078,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5168,6 +6096,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5185,6 +6117,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5202,6 +6138,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5219,6 +6159,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5236,6 +6180,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5253,6 +6201,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5270,6 +6222,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5287,6 +6243,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5304,6 +6264,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5321,6 +6285,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5338,6 +6306,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5355,6 +6327,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5372,6 +6348,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5389,6 +6369,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5406,6 +6390,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5423,6 +6411,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5440,6 +6432,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5457,6 +6453,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5471,6 +6471,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5488,6 +6492,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5505,6 +6513,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5522,6 +6534,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5539,6 +6555,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5556,6 +6576,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5573,6 +6597,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5590,6 +6618,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5607,6 +6639,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5624,6 +6660,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5641,6 +6681,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5655,6 +6699,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5669,6 +6717,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5683,6 +6735,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5697,6 +6753,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5714,6 +6774,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5728,6 +6792,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5746,7 +6814,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5767,7 +6835,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5788,7 +6856,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5808,6 +6876,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5825,6 +6897,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5842,6 +6918,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5859,6 +6939,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5876,6 +6960,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5893,6 +6981,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5910,6 +7002,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5928,7 +7024,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5948,6 +7044,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5966,7 +7066,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5986,6 +7086,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -6004,7 +7108,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6025,7 +7129,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6046,7 +7150,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6086,7 +7190,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6103,7 +7207,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6124,7 +7228,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6140,6 +7244,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -6158,7 +7266,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6179,7 +7287,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6200,7 +7308,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6221,7 +7329,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6241,6 +7349,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6259,7 +7371,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6279,6 +7391,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6297,7 +7413,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6318,7 +7434,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6339,7 +7455,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6360,7 +7476,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6381,7 +7497,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6401,6 +7517,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6415,6 +7535,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6432,6 +7556,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6446,6 +7574,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6460,6 +7592,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6477,6 +7613,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6494,6 +7634,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6511,6 +7655,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6528,6 +7676,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6545,6 +7697,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6562,6 +7718,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6579,6 +7739,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6596,6 +7760,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
@@ -294,10 +294,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -315,10 +311,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -336,10 +328,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -357,10 +345,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -378,10 +362,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -399,10 +379,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -420,10 +396,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -462,10 +434,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -483,10 +451,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -522,10 +486,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -543,10 +503,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -564,10 +520,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -585,10 +537,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -606,10 +554,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -627,10 +571,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -648,10 +588,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -732,10 +668,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -774,10 +706,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -837,10 +765,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -858,10 +782,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -879,10 +799,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -900,10 +816,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -921,10 +833,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -942,10 +850,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -963,10 +867,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -984,10 +884,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -1047,10 +943,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -1068,10 +960,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -1089,10 +977,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -1128,10 +1012,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -1149,10 +1029,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1275,10 +1151,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1310,10 +1182,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1331,10 +1199,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1352,10 +1216,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1373,10 +1233,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1394,10 +1250,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1412,10 +1264,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1433,10 +1281,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1454,10 +1298,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1475,10 +1315,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1496,10 +1332,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1517,10 +1349,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1535,10 +1363,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1553,10 +1377,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1571,10 +1391,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1589,10 +1405,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1607,10 +1419,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1625,10 +1433,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1643,10 +1447,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1661,10 +1461,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1679,10 +1475,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1697,10 +1489,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1715,10 +1503,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1736,10 +1520,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1757,10 +1537,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1778,10 +1554,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1799,10 +1571,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1817,10 +1585,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1835,10 +1599,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1853,10 +1613,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1871,10 +1627,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1889,10 +1641,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1907,10 +1655,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1925,10 +1669,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1943,10 +1683,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1961,10 +1697,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1979,10 +1711,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1997,10 +1725,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -2015,10 +1739,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -2033,10 +1753,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -2051,10 +1767,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -2069,10 +1781,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -2087,10 +1795,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -2108,10 +1812,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -2129,10 +1829,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -2150,10 +1846,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -2171,10 +1863,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -2189,10 +1877,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -2207,10 +1891,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -2225,10 +1905,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2243,10 +1919,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2261,10 +1933,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2279,10 +1947,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2297,10 +1961,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2315,10 +1975,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2333,10 +1989,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2351,10 +2003,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2369,10 +2017,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2387,10 +2031,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2408,10 +2048,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2429,10 +2065,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2471,10 +2103,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2527,10 +2155,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2548,10 +2172,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2569,10 +2189,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2590,10 +2206,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2611,10 +2223,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2632,10 +2240,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2653,10 +2257,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2674,10 +2274,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2695,10 +2291,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2716,10 +2308,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2737,10 +2325,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2758,10 +2342,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2779,10 +2359,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2800,10 +2376,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2821,10 +2393,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2842,10 +2410,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2863,10 +2427,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2884,10 +2444,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2905,10 +2461,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2926,10 +2478,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2947,10 +2495,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2968,10 +2512,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2989,10 +2529,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -3007,10 +2543,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -3112,10 +2644,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -3133,10 +2661,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -3210,10 +2734,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -3231,10 +2751,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3294,10 +2810,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3333,10 +2845,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3354,10 +2862,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3375,10 +2879,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3396,10 +2896,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3417,10 +2913,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3438,10 +2930,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3459,10 +2947,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3480,10 +2964,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3501,10 +2981,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3522,10 +2998,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3543,10 +3015,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3564,10 +3032,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3585,10 +3049,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3606,10 +3066,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3624,10 +3080,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3642,10 +3094,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3696,10 +3144,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3735,10 +3179,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3882,10 +3322,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3900,10 +3336,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -4002,10 +3434,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -4023,10 +3451,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -4044,10 +3468,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -4065,10 +3485,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -4086,10 +3502,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -4107,10 +3519,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -4125,10 +3533,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -4248,10 +3652,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4269,10 +3669,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4290,10 +3686,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4311,10 +3703,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4332,10 +3720,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4353,10 +3737,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4374,10 +3754,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4392,10 +3768,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4413,10 +3785,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4431,10 +3799,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4449,10 +3813,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4467,10 +3827,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4485,10 +3841,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4503,10 +3855,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4521,10 +3869,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4539,10 +3883,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4557,10 +3897,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4575,10 +3911,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4593,10 +3925,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4611,10 +3939,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4629,10 +3953,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4647,10 +3967,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4665,10 +3981,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4683,10 +3995,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4701,10 +4009,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4719,10 +4023,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4737,10 +4037,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4755,10 +4051,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4773,10 +4065,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4794,10 +4082,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4812,10 +4096,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4830,10 +4110,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4848,10 +4124,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4866,10 +4138,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4884,10 +4152,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4902,10 +4166,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4920,10 +4180,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4938,10 +4194,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4956,10 +4208,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4974,10 +4222,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4992,10 +4236,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -5010,10 +4250,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -5031,10 +4267,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -5052,10 +4284,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -5073,10 +4301,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -5094,10 +4318,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -5115,10 +4335,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -5136,10 +4352,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -5157,10 +4369,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -5178,10 +4386,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -5199,10 +4403,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -5220,10 +4420,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -5241,10 +4437,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5262,10 +4454,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5283,10 +4471,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5304,10 +4488,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5322,10 +4502,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5340,10 +4516,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5361,10 +4533,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5382,10 +4550,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5403,10 +4567,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5424,10 +4584,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5445,10 +4601,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5466,10 +4618,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5487,10 +4635,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5508,10 +4652,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5529,10 +4669,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5550,10 +4686,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5571,10 +4703,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5592,10 +4720,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5613,10 +4737,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5634,10 +4754,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5655,10 +4771,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5739,10 +4851,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5760,10 +4868,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5781,10 +4885,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5844,10 +4944,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5970,10 +5066,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5988,10 +5080,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -6024,10 +5112,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -6042,10 +5126,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -6060,10 +5140,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -6078,10 +5154,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -6096,10 +5168,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -6117,10 +5185,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -6138,10 +5202,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -6159,10 +5219,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -6180,10 +5236,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -6201,10 +5253,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -6222,10 +5270,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -6243,10 +5287,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6264,10 +5304,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6285,10 +5321,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6306,10 +5338,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6327,10 +5355,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6348,10 +5372,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6369,10 +5389,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6390,10 +5406,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6411,10 +5423,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6432,10 +5440,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6453,10 +5457,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6471,10 +5471,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6492,10 +5488,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6513,10 +5505,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6534,10 +5522,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6555,10 +5539,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6576,10 +5556,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6597,10 +5573,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6618,10 +5590,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6639,10 +5607,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6660,10 +5624,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6681,10 +5641,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6699,10 +5655,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6717,10 +5669,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6735,10 +5683,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6753,10 +5697,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6774,10 +5714,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6792,10 +5728,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6876,10 +5808,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6897,10 +5825,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6918,10 +5842,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6939,10 +5859,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6960,10 +5876,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6981,10 +5893,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -7002,10 +5910,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -7044,10 +5948,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -7086,10 +5986,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -7244,10 +6140,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7349,10 +6241,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7391,10 +6279,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7517,10 +6401,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7535,10 +6415,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7556,10 +6432,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7574,10 +6446,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7592,10 +6460,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7613,10 +6477,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7634,10 +6494,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7655,10 +6511,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7676,10 +6528,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7697,10 +6545,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7718,10 +6562,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7739,10 +6579,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7760,10 +6596,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
@@ -294,10 +294,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -315,10 +311,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -336,10 +328,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -357,10 +345,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -378,10 +362,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -399,10 +379,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -420,10 +396,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -462,10 +434,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -483,10 +451,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -522,10 +486,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -543,10 +503,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -564,10 +520,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -585,10 +537,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -606,10 +554,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -627,10 +571,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -648,10 +588,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -732,10 +668,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -774,10 +706,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -837,10 +765,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -858,10 +782,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -879,10 +799,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -900,10 +816,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -921,10 +833,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -942,10 +850,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -963,10 +867,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -984,10 +884,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -1047,10 +943,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -1068,10 +960,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -1089,10 +977,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -1128,10 +1012,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -1149,10 +1029,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1275,10 +1151,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1310,10 +1182,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1331,10 +1199,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1352,10 +1216,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1373,10 +1233,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1394,10 +1250,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1412,10 +1264,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1433,10 +1281,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1454,10 +1298,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1475,10 +1315,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1496,10 +1332,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1517,10 +1349,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1535,10 +1363,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1553,10 +1377,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1571,10 +1391,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1589,10 +1405,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1607,10 +1419,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1625,10 +1433,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1643,10 +1447,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1661,10 +1461,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1679,10 +1475,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1697,10 +1489,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1715,10 +1503,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1736,10 +1520,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1757,10 +1537,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1778,10 +1554,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1799,10 +1571,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1817,10 +1585,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1835,10 +1599,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1853,10 +1613,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1871,10 +1627,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1889,10 +1641,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1907,10 +1655,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1925,10 +1669,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1943,10 +1683,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1961,10 +1697,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1979,10 +1711,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1997,10 +1725,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -2015,10 +1739,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -2033,10 +1753,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -2051,10 +1767,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -2069,10 +1781,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -2087,10 +1795,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -2108,10 +1812,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -2129,10 +1829,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -2150,10 +1846,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -2171,10 +1863,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -2189,10 +1877,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -2207,10 +1891,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -2225,10 +1905,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2243,10 +1919,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2261,10 +1933,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2279,10 +1947,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2297,10 +1961,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2315,10 +1975,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2333,10 +1989,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2351,10 +2003,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2369,10 +2017,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2387,10 +2031,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2408,10 +2048,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2429,10 +2065,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2471,10 +2103,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2527,10 +2155,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2548,10 +2172,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2569,10 +2189,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2590,10 +2206,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2611,10 +2223,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2632,10 +2240,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2653,10 +2257,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2674,10 +2274,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2695,10 +2291,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2716,10 +2308,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2737,10 +2325,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2758,10 +2342,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2779,10 +2359,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2800,10 +2376,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2821,10 +2393,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2842,10 +2410,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2863,10 +2427,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2884,10 +2444,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2905,10 +2461,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2926,10 +2478,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2947,10 +2495,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2968,10 +2512,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2989,10 +2529,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -3007,10 +2543,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -3112,10 +2644,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -3133,10 +2661,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -3210,10 +2734,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -3231,10 +2751,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3294,10 +2810,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3333,10 +2845,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3354,10 +2862,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3375,10 +2879,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3396,10 +2896,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3417,10 +2913,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3438,10 +2930,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3459,10 +2947,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3480,10 +2964,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3501,10 +2981,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3522,10 +2998,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3543,10 +3015,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3564,10 +3032,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3585,10 +3049,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3606,10 +3066,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3624,10 +3080,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3642,10 +3094,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3696,10 +3144,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3735,10 +3179,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3882,10 +3322,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3900,10 +3336,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -4002,10 +3434,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -4023,10 +3451,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -4044,10 +3468,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -4065,10 +3485,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -4086,10 +3502,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -4107,10 +3519,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -4125,10 +3533,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -4248,10 +3652,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4269,10 +3669,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4290,10 +3686,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4311,10 +3703,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4332,10 +3720,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4353,10 +3737,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4374,10 +3754,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4392,10 +3768,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4413,10 +3785,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4431,10 +3799,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4449,10 +3813,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4467,10 +3827,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4485,10 +3841,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4503,10 +3855,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4521,10 +3869,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4539,10 +3883,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4557,10 +3897,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4575,10 +3911,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4593,10 +3925,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4611,10 +3939,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4629,10 +3953,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4647,10 +3967,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4665,10 +3981,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4683,10 +3995,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4701,10 +4009,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4719,10 +4023,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4737,10 +4037,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4755,10 +4051,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4773,10 +4065,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4794,10 +4082,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4812,10 +4096,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4830,10 +4110,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4848,10 +4124,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4866,10 +4138,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4884,10 +4152,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4902,10 +4166,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4920,10 +4180,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4938,10 +4194,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4956,10 +4208,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4974,10 +4222,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4992,10 +4236,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -5010,10 +4250,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -5031,10 +4267,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -5052,10 +4284,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -5073,10 +4301,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -5094,10 +4318,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -5115,10 +4335,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -5136,10 +4352,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -5157,10 +4369,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -5178,10 +4386,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -5199,10 +4403,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -5220,10 +4420,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -5241,10 +4437,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5262,10 +4454,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5283,10 +4471,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5304,10 +4488,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5322,10 +4502,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5340,10 +4516,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5361,10 +4533,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5382,10 +4550,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5403,10 +4567,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5424,10 +4584,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5445,10 +4601,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5466,10 +4618,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5487,10 +4635,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5508,10 +4652,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5529,10 +4669,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5550,10 +4686,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5571,10 +4703,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5592,10 +4720,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5613,10 +4737,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5634,10 +4754,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5655,10 +4771,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5739,10 +4851,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5760,10 +4868,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5781,10 +4885,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5844,10 +4944,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5970,10 +5066,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5988,10 +5080,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -6024,10 +5112,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -6042,10 +5126,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -6060,10 +5140,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -6078,10 +5154,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -6096,10 +5168,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -6117,10 +5185,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -6138,10 +5202,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -6159,10 +5219,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -6180,10 +5236,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -6201,10 +5253,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -6222,10 +5270,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -6243,10 +5287,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6264,10 +5304,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6285,10 +5321,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6306,10 +5338,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6327,10 +5355,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6348,10 +5372,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6369,10 +5389,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6390,10 +5406,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6411,10 +5423,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6432,10 +5440,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6453,10 +5457,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6471,10 +5471,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6492,10 +5488,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6513,10 +5505,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6534,10 +5522,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6555,10 +5539,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6576,10 +5556,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6597,10 +5573,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6618,10 +5590,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6639,10 +5607,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6660,10 +5624,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6681,10 +5641,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6699,10 +5655,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6717,10 +5669,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6735,10 +5683,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6753,10 +5697,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6774,10 +5714,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6792,10 +5728,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6876,10 +5808,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6897,10 +5825,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6918,10 +5842,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6939,10 +5859,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6960,10 +5876,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6981,10 +5893,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -7002,10 +5910,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -7044,10 +5948,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -7086,10 +5986,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -7244,10 +6140,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7349,10 +6241,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7391,10 +6279,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7517,10 +6401,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7535,10 +6415,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7556,10 +6432,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7574,10 +6446,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7592,10 +6460,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7613,10 +6477,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7634,10 +6494,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7655,10 +6511,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7676,10 +6528,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7697,10 +6545,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7718,10 +6562,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7739,10 +6579,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7760,10 +6596,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
@@ -274,7 +274,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -294,6 +294,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -311,6 +315,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -328,6 +336,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -345,6 +357,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -362,6 +378,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -379,6 +399,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -396,6 +420,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -414,7 +442,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -434,6 +462,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -451,6 +483,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -486,6 +522,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -503,6 +543,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -520,6 +564,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -537,6 +585,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -554,6 +606,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -571,6 +627,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -588,6 +648,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -606,7 +670,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -627,7 +691,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -648,7 +712,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -668,6 +732,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -686,7 +754,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -706,6 +774,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -724,7 +796,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -745,7 +817,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -765,6 +837,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -782,6 +858,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -799,6 +879,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -816,6 +900,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -833,6 +921,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -850,6 +942,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -867,6 +963,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -884,6 +984,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -902,7 +1006,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -923,7 +1027,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -943,6 +1047,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -960,6 +1068,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -977,6 +1089,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -996,7 +1112,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1012,6 +1128,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -1029,6 +1149,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1047,7 +1171,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1068,7 +1192,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1089,7 +1213,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1110,7 +1234,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1131,7 +1255,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1151,6 +1275,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1166,7 +1294,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1182,6 +1310,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1199,6 +1331,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1216,6 +1352,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1233,6 +1373,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1250,6 +1394,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1264,6 +1412,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1281,6 +1433,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1298,6 +1454,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1315,6 +1475,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1332,6 +1496,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1349,6 +1517,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1363,6 +1535,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1377,6 +1553,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1391,6 +1571,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1405,6 +1589,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1419,6 +1607,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1433,6 +1625,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1447,6 +1643,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1461,6 +1661,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1475,6 +1679,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1489,6 +1697,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1503,6 +1715,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1520,6 +1736,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1537,6 +1757,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1554,6 +1778,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1571,6 +1799,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1585,6 +1817,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1599,6 +1835,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1613,6 +1853,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1627,6 +1871,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1641,6 +1889,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1655,6 +1907,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1669,6 +1925,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1683,6 +1943,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1697,6 +1961,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1711,6 +1979,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1725,6 +1997,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1739,6 +2015,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1753,6 +2033,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1767,6 +2051,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1781,6 +2069,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1795,6 +2087,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1812,6 +2108,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1829,6 +2129,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1846,6 +2150,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1863,6 +2171,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1877,6 +2189,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1891,6 +2207,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1905,6 +2225,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1919,6 +2243,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1933,6 +2261,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -1947,6 +2279,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -1961,6 +2297,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -1975,6 +2315,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -1989,6 +2333,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2003,6 +2351,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2017,6 +2369,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2031,6 +2387,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2048,6 +2408,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2065,6 +2429,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2083,7 +2451,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2103,6 +2471,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2118,7 +2490,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2139,7 +2511,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2155,6 +2527,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2172,6 +2548,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2189,6 +2569,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2206,6 +2590,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2223,6 +2611,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2240,6 +2632,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2257,6 +2653,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2274,6 +2674,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2291,6 +2695,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2308,6 +2716,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2325,6 +2737,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2342,6 +2758,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2359,6 +2779,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2376,6 +2800,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2393,6 +2821,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2410,6 +2842,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2427,6 +2863,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2444,6 +2884,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2461,6 +2905,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2478,6 +2926,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2495,6 +2947,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2512,6 +2968,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2529,6 +2989,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2543,6 +3007,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2561,7 +3029,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2582,7 +3050,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2603,7 +3071,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2624,7 +3092,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2644,6 +3112,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2661,6 +3133,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2679,7 +3155,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2700,7 +3176,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2734,6 +3210,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2751,6 +3231,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -2769,7 +3253,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2790,7 +3274,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2810,6 +3294,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2825,7 +3313,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2845,6 +3333,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2862,6 +3354,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2879,6 +3375,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2896,6 +3396,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2913,6 +3417,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2930,6 +3438,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2947,6 +3459,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2964,6 +3480,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2981,6 +3501,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2998,6 +3522,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3015,6 +3543,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3032,6 +3564,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3049,6 +3585,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3066,6 +3606,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3080,6 +3624,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3094,6 +3642,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3110,7 +3662,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3128,7 +3680,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3144,6 +3696,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3163,7 +3719,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3179,6 +3735,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3197,7 +3757,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3218,7 +3778,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3239,7 +3799,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3260,7 +3820,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3281,7 +3841,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3302,7 +3862,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3322,6 +3882,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3336,6 +3900,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3351,7 +3919,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3372,7 +3940,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3393,7 +3961,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3414,7 +3982,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3434,6 +4002,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3451,6 +4023,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3468,6 +4044,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3485,6 +4065,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3502,6 +4086,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3519,6 +4107,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3533,6 +4125,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3548,7 +4144,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3569,7 +4165,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3590,7 +4186,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3611,7 +4207,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3632,7 +4228,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3652,6 +4248,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3669,6 +4269,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3686,6 +4290,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3703,6 +4311,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3720,6 +4332,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3737,6 +4353,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3754,6 +4374,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3768,6 +4392,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3785,6 +4413,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3799,6 +4431,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3813,6 +4449,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3827,6 +4467,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3841,6 +4485,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3855,6 +4503,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3869,6 +4521,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3883,6 +4539,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3897,6 +4557,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3911,6 +4575,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3925,6 +4593,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3939,6 +4611,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3953,6 +4629,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3967,6 +4647,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3981,6 +4665,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3995,6 +4683,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4009,6 +4701,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4023,6 +4719,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4037,6 +4737,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4051,6 +4755,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4065,6 +4773,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4082,6 +4794,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4096,6 +4812,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4110,6 +4830,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4124,6 +4848,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4138,6 +4866,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4152,6 +4884,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4166,6 +4902,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4180,6 +4920,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4194,6 +4938,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4208,6 +4956,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4222,6 +4974,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4236,6 +4992,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4250,6 +5010,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4267,6 +5031,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4284,6 +5052,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4301,6 +5073,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4318,6 +5094,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4335,6 +5115,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4352,6 +5136,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4369,6 +5157,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4386,6 +5178,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4403,6 +5199,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4420,6 +5220,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4437,6 +5241,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4454,6 +5262,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4471,6 +5283,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4488,6 +5304,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4502,6 +5322,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4516,6 +5340,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4533,6 +5361,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4550,6 +5382,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4567,6 +5403,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4584,6 +5424,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4601,6 +5445,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4618,6 +5466,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4635,6 +5487,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4652,6 +5508,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4669,6 +5529,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4686,6 +5550,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4703,6 +5571,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4720,6 +5592,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4737,6 +5613,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4754,6 +5634,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4771,6 +5655,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4789,7 +5677,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4810,7 +5698,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4831,7 +5719,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4851,6 +5739,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -4868,6 +5760,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4885,6 +5781,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4903,7 +5803,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4924,7 +5824,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4944,6 +5844,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4962,7 +5866,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4983,7 +5887,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5004,7 +5908,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5025,7 +5929,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5046,7 +5950,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5066,6 +5970,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5080,6 +5988,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5096,7 +6008,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5112,6 +6024,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5126,6 +6042,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5140,6 +6060,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5154,6 +6078,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5168,6 +6096,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5185,6 +6117,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5202,6 +6138,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5219,6 +6159,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5236,6 +6180,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5253,6 +6201,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5270,6 +6222,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5287,6 +6243,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5304,6 +6264,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5321,6 +6285,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5338,6 +6306,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5355,6 +6327,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5372,6 +6348,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5389,6 +6369,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5406,6 +6390,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5423,6 +6411,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5440,6 +6432,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5457,6 +6453,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5471,6 +6471,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5488,6 +6492,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5505,6 +6513,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5522,6 +6534,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5539,6 +6555,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5556,6 +6576,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5573,6 +6597,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5590,6 +6618,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5607,6 +6639,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5624,6 +6660,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5641,6 +6681,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5655,6 +6699,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5669,6 +6717,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5683,6 +6735,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5697,6 +6753,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5714,6 +6774,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5728,6 +6792,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5746,7 +6814,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5767,7 +6835,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5788,7 +6856,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5808,6 +6876,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5825,6 +6897,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5842,6 +6918,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5859,6 +6939,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5876,6 +6960,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5893,6 +6981,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5910,6 +7002,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5928,7 +7024,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5948,6 +7044,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5966,7 +7066,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5986,6 +7086,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -6004,7 +7108,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6025,7 +7129,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6046,7 +7150,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6086,7 +7190,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6103,7 +7207,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6124,7 +7228,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6140,6 +7244,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -6158,7 +7266,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6179,7 +7287,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6200,7 +7308,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6221,7 +7329,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6241,6 +7349,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6259,7 +7371,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6279,6 +7391,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6297,7 +7413,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6318,7 +7434,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6339,7 +7455,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6360,7 +7476,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6381,7 +7497,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6401,6 +7517,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6415,6 +7535,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6432,6 +7556,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6446,6 +7574,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6460,6 +7592,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6477,6 +7613,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6494,6 +7634,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6511,6 +7655,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6528,6 +7676,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6545,6 +7697,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6562,6 +7718,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6579,6 +7739,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6596,6 +7760,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
@@ -274,7 +274,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -294,6 +294,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -311,6 +315,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -328,6 +336,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -345,6 +357,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -362,6 +378,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -379,6 +399,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -396,6 +420,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -414,7 +442,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -434,6 +462,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -451,6 +483,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -486,6 +522,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -503,6 +543,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -520,6 +564,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -537,6 +585,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -554,6 +606,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -571,6 +627,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -588,6 +648,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -606,7 +670,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -627,7 +691,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -648,7 +712,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -668,6 +732,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -686,7 +754,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -706,6 +774,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -724,7 +796,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -745,7 +817,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -765,6 +837,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -782,6 +858,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -799,6 +879,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -816,6 +900,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -833,6 +921,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -850,6 +942,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -867,6 +963,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -884,6 +984,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -902,7 +1006,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -923,7 +1027,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -943,6 +1047,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -960,6 +1068,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -977,6 +1089,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -996,7 +1112,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1012,6 +1128,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -1029,6 +1149,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1047,7 +1171,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1068,7 +1192,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1089,7 +1213,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1110,7 +1234,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1131,7 +1255,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1151,6 +1275,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1166,7 +1294,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1182,6 +1310,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1199,6 +1331,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1216,6 +1352,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1233,6 +1373,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1250,6 +1394,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1264,6 +1412,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1281,6 +1433,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1298,6 +1454,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1315,6 +1475,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1332,6 +1496,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1349,6 +1517,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1363,6 +1535,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1377,6 +1553,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1391,6 +1571,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1405,6 +1589,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1419,6 +1607,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1433,6 +1625,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1447,6 +1643,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1461,6 +1661,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1475,6 +1679,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1489,6 +1697,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1503,6 +1715,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1520,6 +1736,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1537,6 +1757,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1554,6 +1778,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1571,6 +1799,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1585,6 +1817,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1599,6 +1835,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1613,6 +1853,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1627,6 +1871,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1641,6 +1889,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1655,6 +1907,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1669,6 +1925,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1683,6 +1943,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1697,6 +1961,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1711,6 +1979,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1725,6 +1997,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1739,6 +2015,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1753,6 +2033,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1767,6 +2051,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1781,6 +2069,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1795,6 +2087,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1812,6 +2108,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1829,6 +2129,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1846,6 +2150,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1863,6 +2171,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1877,6 +2189,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1891,6 +2207,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1905,6 +2225,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1919,6 +2243,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1933,6 +2261,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -1947,6 +2279,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -1961,6 +2297,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -1975,6 +2315,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -1989,6 +2333,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2003,6 +2351,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2017,6 +2369,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2031,6 +2387,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2048,6 +2408,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2065,6 +2429,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2083,7 +2451,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2103,6 +2471,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2118,7 +2490,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2139,7 +2511,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2155,6 +2527,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2172,6 +2548,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2189,6 +2569,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2206,6 +2590,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2223,6 +2611,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2240,6 +2632,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2257,6 +2653,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2274,6 +2674,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2291,6 +2695,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2308,6 +2716,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2325,6 +2737,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2342,6 +2758,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2359,6 +2779,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2376,6 +2800,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2393,6 +2821,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2410,6 +2842,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2427,6 +2863,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2444,6 +2884,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2461,6 +2905,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2478,6 +2926,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2495,6 +2947,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2512,6 +2968,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2529,6 +2989,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2543,6 +3007,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2561,7 +3029,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2582,7 +3050,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2603,7 +3071,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2624,7 +3092,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2644,6 +3112,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2661,6 +3133,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2679,7 +3155,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2700,7 +3176,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2734,6 +3210,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2751,6 +3231,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -2769,7 +3253,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2790,7 +3274,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2810,6 +3294,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2825,7 +3313,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2845,6 +3333,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2862,6 +3354,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2879,6 +3375,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2896,6 +3396,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2913,6 +3417,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2930,6 +3438,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2947,6 +3459,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2964,6 +3480,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2981,6 +3501,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2998,6 +3522,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3015,6 +3543,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3032,6 +3564,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3049,6 +3585,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3066,6 +3606,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3080,6 +3624,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3094,6 +3642,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3110,7 +3662,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3128,7 +3680,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3144,6 +3696,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3163,7 +3719,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3179,6 +3735,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3197,7 +3757,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3218,7 +3778,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3239,7 +3799,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3260,7 +3820,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3281,7 +3841,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3302,7 +3862,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3322,6 +3882,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3336,6 +3900,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3351,7 +3919,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3372,7 +3940,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3393,7 +3961,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3414,7 +3982,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3434,6 +4002,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3451,6 +4023,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3468,6 +4044,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3485,6 +4065,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3502,6 +4086,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3519,6 +4107,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3533,6 +4125,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3548,7 +4144,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3569,7 +4165,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3590,7 +4186,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3611,7 +4207,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3632,7 +4228,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3652,6 +4248,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3669,6 +4269,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3686,6 +4290,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3703,6 +4311,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3720,6 +4332,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3737,6 +4353,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3754,6 +4374,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3768,6 +4392,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3785,6 +4413,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3799,6 +4431,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3813,6 +4449,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3827,6 +4467,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3841,6 +4485,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3855,6 +4503,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3869,6 +4521,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3883,6 +4539,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3897,6 +4557,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3911,6 +4575,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3925,6 +4593,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3939,6 +4611,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3953,6 +4629,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3967,6 +4647,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3981,6 +4665,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3995,6 +4683,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4009,6 +4701,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4023,6 +4719,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4037,6 +4737,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4051,6 +4755,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4065,6 +4773,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4082,6 +4794,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4096,6 +4812,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4110,6 +4830,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4124,6 +4848,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4138,6 +4866,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4152,6 +4884,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4166,6 +4902,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4180,6 +4920,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4194,6 +4938,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4208,6 +4956,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4222,6 +4974,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4236,6 +4992,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4250,6 +5010,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4267,6 +5031,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4284,6 +5052,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4301,6 +5073,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4318,6 +5094,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4335,6 +5115,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4352,6 +5136,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4369,6 +5157,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4386,6 +5178,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4403,6 +5199,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4420,6 +5220,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4437,6 +5241,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4454,6 +5262,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4471,6 +5283,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4488,6 +5304,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4502,6 +5322,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4516,6 +5340,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4533,6 +5361,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4550,6 +5382,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4567,6 +5403,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4584,6 +5424,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4601,6 +5445,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4618,6 +5466,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4635,6 +5487,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4652,6 +5508,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4669,6 +5529,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4686,6 +5550,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4703,6 +5571,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4720,6 +5592,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4737,6 +5613,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4754,6 +5634,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4771,6 +5655,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4789,7 +5677,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4810,7 +5698,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4831,7 +5719,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4851,6 +5739,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -4868,6 +5760,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4885,6 +5781,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4903,7 +5803,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4924,7 +5824,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4944,6 +5844,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4962,7 +5866,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4983,7 +5887,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5004,7 +5908,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5025,7 +5929,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5046,7 +5950,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5066,6 +5970,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5080,6 +5988,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5096,7 +6008,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5112,6 +6024,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5126,6 +6042,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5140,6 +6060,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5154,6 +6078,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5168,6 +6096,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5185,6 +6117,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5202,6 +6138,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5219,6 +6159,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5236,6 +6180,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5253,6 +6201,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5270,6 +6222,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5287,6 +6243,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5304,6 +6264,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5321,6 +6285,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5338,6 +6306,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5355,6 +6327,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5372,6 +6348,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5389,6 +6369,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5406,6 +6390,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5423,6 +6411,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5440,6 +6432,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5457,6 +6453,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5471,6 +6471,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5488,6 +6492,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5505,6 +6513,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5522,6 +6534,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5539,6 +6555,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5556,6 +6576,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5573,6 +6597,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5590,6 +6618,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5607,6 +6639,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5624,6 +6660,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5641,6 +6681,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5655,6 +6699,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5669,6 +6717,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5683,6 +6735,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5697,6 +6753,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5714,6 +6774,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5728,6 +6792,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5746,7 +6814,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5767,7 +6835,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5788,7 +6856,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5808,6 +6876,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5825,6 +6897,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5842,6 +6918,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5859,6 +6939,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5876,6 +6960,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5893,6 +6981,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5910,6 +7002,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5928,7 +7024,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5948,6 +7044,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5966,7 +7066,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5986,6 +7086,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -6004,7 +7108,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6025,7 +7129,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6046,7 +7150,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6086,7 +7190,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6103,7 +7207,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6124,7 +7228,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6140,6 +7244,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -6158,7 +7266,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6179,7 +7287,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6200,7 +7308,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6221,7 +7329,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6241,6 +7349,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6259,7 +7371,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6279,6 +7391,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6297,7 +7413,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6318,7 +7434,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6339,7 +7455,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6360,7 +7476,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6381,7 +7497,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6401,6 +7517,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6415,6 +7535,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6432,6 +7556,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6446,6 +7574,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6460,6 +7592,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6477,6 +7613,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6494,6 +7634,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6511,6 +7655,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6528,6 +7676,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6545,6 +7697,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6562,6 +7718,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6579,6 +7739,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6596,6 +7760,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
@@ -294,10 +294,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -315,10 +311,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -336,10 +328,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -357,10 +345,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -378,10 +362,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -399,10 +379,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -420,10 +396,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -462,10 +434,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -483,10 +451,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -522,10 +486,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -543,10 +503,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -564,10 +520,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -585,10 +537,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -606,10 +554,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -627,10 +571,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -648,10 +588,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -732,10 +668,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -774,10 +706,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -837,10 +765,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -858,10 +782,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -879,10 +799,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -900,10 +816,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -921,10 +833,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -942,10 +850,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -963,10 +867,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -984,10 +884,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -1047,10 +943,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -1068,10 +960,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -1089,10 +977,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -1128,10 +1012,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -1149,10 +1029,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1275,10 +1151,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1310,10 +1182,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1331,10 +1199,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1352,10 +1216,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1373,10 +1233,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1394,10 +1250,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1412,10 +1264,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1433,10 +1281,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1454,10 +1298,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1475,10 +1315,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1496,10 +1332,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1517,10 +1349,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1535,10 +1363,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1553,10 +1377,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1571,10 +1391,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1589,10 +1405,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1607,10 +1419,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1625,10 +1433,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1643,10 +1447,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1661,10 +1461,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1679,10 +1475,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1697,10 +1489,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1715,10 +1503,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1736,10 +1520,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1757,10 +1537,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1778,10 +1554,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1799,10 +1571,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1817,10 +1585,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1835,10 +1599,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1853,10 +1613,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1871,10 +1627,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1889,10 +1641,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1907,10 +1655,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1925,10 +1669,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1943,10 +1683,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1961,10 +1697,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1979,10 +1711,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1997,10 +1725,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -2015,10 +1739,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -2033,10 +1753,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -2051,10 +1767,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -2069,10 +1781,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -2087,10 +1795,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -2108,10 +1812,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -2129,10 +1829,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -2150,10 +1846,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -2171,10 +1863,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -2189,10 +1877,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -2207,10 +1891,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -2225,10 +1905,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2243,10 +1919,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2261,10 +1933,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2279,10 +1947,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2297,10 +1961,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2315,10 +1975,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2333,10 +1989,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2351,10 +2003,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2369,10 +2017,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2387,10 +2031,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2408,10 +2048,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2429,10 +2065,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2471,10 +2103,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2527,10 +2155,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2548,10 +2172,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2569,10 +2189,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2590,10 +2206,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2611,10 +2223,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2632,10 +2240,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2653,10 +2257,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2674,10 +2274,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2695,10 +2291,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2716,10 +2308,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2737,10 +2325,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2758,10 +2342,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2779,10 +2359,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2800,10 +2376,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2821,10 +2393,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2842,10 +2410,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2863,10 +2427,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2884,10 +2444,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2905,10 +2461,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2926,10 +2478,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2947,10 +2495,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2968,10 +2512,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2989,10 +2529,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -3007,10 +2543,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -3112,10 +2644,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -3133,10 +2661,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -3210,10 +2734,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -3231,10 +2751,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3294,10 +2810,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3333,10 +2845,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3354,10 +2862,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3375,10 +2879,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3396,10 +2896,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3417,10 +2913,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3438,10 +2930,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3459,10 +2947,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3480,10 +2964,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3501,10 +2981,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3522,10 +2998,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3543,10 +3015,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3564,10 +3032,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3585,10 +3049,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3606,10 +3066,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3624,10 +3080,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3642,10 +3094,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3696,10 +3144,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3735,10 +3179,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3882,10 +3322,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3900,10 +3336,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -4002,10 +3434,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -4023,10 +3451,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -4044,10 +3468,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -4065,10 +3485,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -4086,10 +3502,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -4107,10 +3519,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -4125,10 +3533,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -4248,10 +3652,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4269,10 +3669,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4290,10 +3686,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4311,10 +3703,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4332,10 +3720,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4353,10 +3737,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4374,10 +3754,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4392,10 +3768,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4413,10 +3785,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4431,10 +3799,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4449,10 +3813,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4467,10 +3827,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4485,10 +3841,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4503,10 +3855,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4521,10 +3869,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4539,10 +3883,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4557,10 +3897,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4575,10 +3911,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4593,10 +3925,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4611,10 +3939,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4629,10 +3953,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4647,10 +3967,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4665,10 +3981,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4683,10 +3995,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4701,10 +4009,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4719,10 +4023,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4737,10 +4037,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4755,10 +4051,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4773,10 +4065,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4794,10 +4082,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4812,10 +4096,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4830,10 +4110,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4848,10 +4124,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4866,10 +4138,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4884,10 +4152,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4902,10 +4166,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4920,10 +4180,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4938,10 +4194,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4956,10 +4208,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4974,10 +4222,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4992,10 +4236,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -5010,10 +4250,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -5031,10 +4267,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -5052,10 +4284,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -5073,10 +4301,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -5094,10 +4318,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -5115,10 +4335,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -5136,10 +4352,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -5157,10 +4369,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -5178,10 +4386,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -5199,10 +4403,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -5220,10 +4420,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -5241,10 +4437,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5262,10 +4454,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5283,10 +4471,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5304,10 +4488,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5322,10 +4502,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5340,10 +4516,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5361,10 +4533,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5382,10 +4550,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5403,10 +4567,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5424,10 +4584,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5445,10 +4601,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5466,10 +4618,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5487,10 +4635,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5508,10 +4652,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5529,10 +4669,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5550,10 +4686,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5571,10 +4703,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5592,10 +4720,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5613,10 +4737,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5634,10 +4754,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5655,10 +4771,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5739,10 +4851,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5760,10 +4868,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5781,10 +4885,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5844,10 +4944,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5970,10 +5066,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5988,10 +5080,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -6024,10 +5112,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -6042,10 +5126,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -6060,10 +5140,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -6078,10 +5154,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -6096,10 +5168,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -6117,10 +5185,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -6138,10 +5202,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -6159,10 +5219,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -6180,10 +5236,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -6201,10 +5253,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -6222,10 +5270,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -6243,10 +5287,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6264,10 +5304,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6285,10 +5321,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6306,10 +5338,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6327,10 +5355,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6348,10 +5372,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6369,10 +5389,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6390,10 +5406,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6411,10 +5423,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6432,10 +5440,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6453,10 +5457,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6471,10 +5471,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6492,10 +5488,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6513,10 +5505,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6534,10 +5522,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6555,10 +5539,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6576,10 +5556,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6597,10 +5573,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6618,10 +5590,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6639,10 +5607,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6660,10 +5624,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6681,10 +5641,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6699,10 +5655,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6717,10 +5669,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6735,10 +5683,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6753,10 +5697,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6774,10 +5714,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6792,10 +5728,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6876,10 +5808,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6897,10 +5825,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6918,10 +5842,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6939,10 +5859,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6960,10 +5876,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6981,10 +5893,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -7002,10 +5910,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -7044,10 +5948,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -7086,10 +5986,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -7244,10 +6140,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7349,10 +6241,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7391,10 +6279,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7517,10 +6401,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7535,10 +6415,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7556,10 +6432,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7574,10 +6446,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7592,10 +6460,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7613,10 +6477,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7634,10 +6494,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7655,10 +6511,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7676,10 +6528,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7697,10 +6545,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7718,10 +6562,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7739,10 +6579,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7760,10 +6596,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
@@ -274,7 +274,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -294,6 +294,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -311,6 +315,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -328,6 +336,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -345,6 +357,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -362,6 +378,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -379,6 +399,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -396,6 +420,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -414,7 +442,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -434,6 +462,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -451,6 +483,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -486,6 +522,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -503,6 +543,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -520,6 +564,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -537,6 +585,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -554,6 +606,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -571,6 +627,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -588,6 +648,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -606,7 +670,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -627,7 +691,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -648,7 +712,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -668,6 +732,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -686,7 +754,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -706,6 +774,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -724,7 +796,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -745,7 +817,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -765,6 +837,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -782,6 +858,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -799,6 +879,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -816,6 +900,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -833,6 +921,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -850,6 +942,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -867,6 +963,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -884,6 +984,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -902,7 +1006,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -923,7 +1027,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -943,6 +1047,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -960,6 +1068,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -977,6 +1089,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -996,7 +1112,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1012,6 +1128,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -1029,6 +1149,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1047,7 +1171,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1068,7 +1192,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1089,7 +1213,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1110,7 +1234,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1131,7 +1255,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1151,6 +1275,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1166,7 +1294,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1182,6 +1310,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1199,6 +1331,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1216,6 +1352,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1233,6 +1373,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1250,6 +1394,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1264,6 +1412,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1281,6 +1433,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1298,6 +1454,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1315,6 +1475,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1332,6 +1496,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1349,6 +1517,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1363,6 +1535,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1377,6 +1553,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1391,6 +1571,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1405,6 +1589,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1419,6 +1607,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1433,6 +1625,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1447,6 +1643,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1461,6 +1661,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1475,6 +1679,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1489,6 +1697,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1503,6 +1715,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1520,6 +1736,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1537,6 +1757,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1554,6 +1778,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1571,6 +1799,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1585,6 +1817,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1599,6 +1835,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1613,6 +1853,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1627,6 +1871,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1641,6 +1889,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1655,6 +1907,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1669,6 +1925,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1683,6 +1943,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1697,6 +1961,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1711,6 +1979,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1725,6 +1997,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1739,6 +2015,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1753,6 +2033,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1767,6 +2051,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1781,6 +2069,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1795,6 +2087,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1812,6 +2108,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1829,6 +2129,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1846,6 +2150,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1863,6 +2171,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1877,6 +2189,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1891,6 +2207,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1905,6 +2225,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1919,6 +2243,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1933,6 +2261,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -1947,6 +2279,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -1961,6 +2297,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -1975,6 +2315,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -1989,6 +2333,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2003,6 +2351,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2017,6 +2369,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2031,6 +2387,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2048,6 +2408,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2065,6 +2429,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2083,7 +2451,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2103,6 +2471,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2118,7 +2490,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2139,7 +2511,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2155,6 +2527,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2172,6 +2548,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2189,6 +2569,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2206,6 +2590,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2223,6 +2611,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2240,6 +2632,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2257,6 +2653,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2274,6 +2674,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2291,6 +2695,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2308,6 +2716,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2325,6 +2737,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2342,6 +2758,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2359,6 +2779,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2376,6 +2800,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2393,6 +2821,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2410,6 +2842,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2427,6 +2863,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2444,6 +2884,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2461,6 +2905,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2478,6 +2926,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2495,6 +2947,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2512,6 +2968,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2529,6 +2989,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2543,6 +3007,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2561,7 +3029,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2582,7 +3050,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2603,7 +3071,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2624,7 +3092,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2644,6 +3112,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2661,6 +3133,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2679,7 +3155,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2700,7 +3176,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2734,6 +3210,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2751,6 +3231,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -2769,7 +3253,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2790,7 +3274,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2810,6 +3294,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2825,7 +3313,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2845,6 +3333,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2862,6 +3354,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2879,6 +3375,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2896,6 +3396,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2913,6 +3417,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2930,6 +3438,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2947,6 +3459,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2964,6 +3480,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2981,6 +3501,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2998,6 +3522,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3015,6 +3543,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3032,6 +3564,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3049,6 +3585,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3066,6 +3606,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3080,6 +3624,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3094,6 +3642,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3110,7 +3662,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3128,7 +3680,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3144,6 +3696,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3163,7 +3719,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3179,6 +3735,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3197,7 +3757,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3218,7 +3778,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3239,7 +3799,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3260,7 +3820,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3281,7 +3841,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3302,7 +3862,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3322,6 +3882,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3336,6 +3900,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3351,7 +3919,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3372,7 +3940,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3393,7 +3961,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3414,7 +3982,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3434,6 +4002,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3451,6 +4023,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3468,6 +4044,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3485,6 +4065,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3502,6 +4086,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3519,6 +4107,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3533,6 +4125,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3548,7 +4144,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3569,7 +4165,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3590,7 +4186,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3611,7 +4207,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3632,7 +4228,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3652,6 +4248,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3669,6 +4269,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3686,6 +4290,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3703,6 +4311,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3720,6 +4332,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3737,6 +4353,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3754,6 +4374,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3768,6 +4392,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3785,6 +4413,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3799,6 +4431,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3813,6 +4449,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3827,6 +4467,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3841,6 +4485,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3855,6 +4503,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3869,6 +4521,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3883,6 +4539,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3897,6 +4557,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3911,6 +4575,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3925,6 +4593,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3939,6 +4611,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3953,6 +4629,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3967,6 +4647,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3981,6 +4665,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3995,6 +4683,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4009,6 +4701,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4023,6 +4719,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4037,6 +4737,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4051,6 +4755,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4065,6 +4773,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4082,6 +4794,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4096,6 +4812,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4110,6 +4830,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4124,6 +4848,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4138,6 +4866,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4152,6 +4884,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4166,6 +4902,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4180,6 +4920,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4194,6 +4938,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4208,6 +4956,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4222,6 +4974,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4236,6 +4992,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4250,6 +5010,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4267,6 +5031,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4284,6 +5052,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4301,6 +5073,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4318,6 +5094,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4335,6 +5115,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4352,6 +5136,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4369,6 +5157,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4386,6 +5178,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4403,6 +5199,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4420,6 +5220,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4437,6 +5241,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4454,6 +5262,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4471,6 +5283,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4488,6 +5304,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4502,6 +5322,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4516,6 +5340,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4533,6 +5361,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4550,6 +5382,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4567,6 +5403,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4584,6 +5424,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4601,6 +5445,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4618,6 +5466,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4635,6 +5487,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4652,6 +5508,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4669,6 +5529,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4686,6 +5550,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4703,6 +5571,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4720,6 +5592,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4737,6 +5613,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4754,6 +5634,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4771,6 +5655,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4789,7 +5677,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4810,7 +5698,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4831,7 +5719,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4851,6 +5739,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -4868,6 +5760,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4885,6 +5781,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4903,7 +5803,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4924,7 +5824,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4944,6 +5844,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4962,7 +5866,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4983,7 +5887,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5004,7 +5908,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5025,7 +5929,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5046,7 +5950,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5066,6 +5970,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5080,6 +5988,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5096,7 +6008,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5112,6 +6024,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5126,6 +6042,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5140,6 +6060,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5154,6 +6078,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5168,6 +6096,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5185,6 +6117,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5202,6 +6138,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5219,6 +6159,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5236,6 +6180,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5253,6 +6201,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5270,6 +6222,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5287,6 +6243,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5304,6 +6264,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5321,6 +6285,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5338,6 +6306,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5355,6 +6327,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5372,6 +6348,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5389,6 +6369,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5406,6 +6390,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5423,6 +6411,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5440,6 +6432,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5457,6 +6453,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5471,6 +6471,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5488,6 +6492,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5505,6 +6513,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5522,6 +6534,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5539,6 +6555,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5556,6 +6576,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5573,6 +6597,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5590,6 +6618,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5607,6 +6639,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5624,6 +6660,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5641,6 +6681,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5655,6 +6699,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5669,6 +6717,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5683,6 +6735,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5697,6 +6753,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5714,6 +6774,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5728,6 +6792,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5746,7 +6814,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5767,7 +6835,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5788,7 +6856,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5808,6 +6876,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5825,6 +6897,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5842,6 +6918,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5859,6 +6939,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5876,6 +6960,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5893,6 +6981,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5910,6 +7002,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5928,7 +7024,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5948,6 +7044,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5966,7 +7066,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5986,6 +7086,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -6004,7 +7108,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6025,7 +7129,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6046,7 +7150,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6086,7 +7190,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6103,7 +7207,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6124,7 +7228,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6140,6 +7244,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -6158,7 +7266,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6179,7 +7287,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6200,7 +7308,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6221,7 +7329,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6241,6 +7349,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6259,7 +7371,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6279,6 +7391,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6297,7 +7413,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6318,7 +7434,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6339,7 +7455,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6360,7 +7476,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6381,7 +7497,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6401,6 +7517,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6415,6 +7535,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6432,6 +7556,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6446,6 +7574,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6460,6 +7592,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6477,6 +7613,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6494,6 +7634,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6511,6 +7655,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6528,6 +7676,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6545,6 +7697,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6562,6 +7718,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6579,6 +7739,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6596,6 +7760,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
@@ -294,10 +294,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -315,10 +311,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -336,10 +328,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -357,10 +345,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -378,10 +362,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -399,10 +379,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -420,10 +396,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -462,10 +434,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -483,10 +451,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -522,10 +486,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -543,10 +503,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -564,10 +520,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -585,10 +537,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -606,10 +554,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -627,10 +571,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -648,10 +588,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -732,10 +668,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -774,10 +706,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -837,10 +765,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -858,10 +782,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -879,10 +799,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -900,10 +816,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -921,10 +833,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -942,10 +850,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -963,10 +867,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -984,10 +884,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -1047,10 +943,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -1068,10 +960,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -1089,10 +977,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -1128,10 +1012,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -1149,10 +1029,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1275,10 +1151,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1310,10 +1182,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1331,10 +1199,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1352,10 +1216,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1373,10 +1233,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1394,10 +1250,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1412,10 +1264,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1433,10 +1281,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1454,10 +1298,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1475,10 +1315,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1496,10 +1332,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1517,10 +1349,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1535,10 +1363,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1553,10 +1377,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1571,10 +1391,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1589,10 +1405,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1607,10 +1419,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1625,10 +1433,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1643,10 +1447,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1661,10 +1461,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1679,10 +1475,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1697,10 +1489,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1715,10 +1503,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1736,10 +1520,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1757,10 +1537,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1778,10 +1554,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1799,10 +1571,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1817,10 +1585,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1835,10 +1599,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1853,10 +1613,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1871,10 +1627,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1889,10 +1641,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1907,10 +1655,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1925,10 +1669,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1943,10 +1683,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1961,10 +1697,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1979,10 +1711,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1997,10 +1725,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -2015,10 +1739,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -2033,10 +1753,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -2051,10 +1767,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -2069,10 +1781,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -2087,10 +1795,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -2108,10 +1812,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -2129,10 +1829,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -2150,10 +1846,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -2171,10 +1863,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -2189,10 +1877,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -2207,10 +1891,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -2225,10 +1905,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2243,10 +1919,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2261,10 +1933,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2279,10 +1947,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2297,10 +1961,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2315,10 +1975,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2333,10 +1989,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2351,10 +2003,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2369,10 +2017,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2387,10 +2031,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2408,10 +2048,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2429,10 +2065,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2471,10 +2103,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2527,10 +2155,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2548,10 +2172,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2569,10 +2189,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2590,10 +2206,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2611,10 +2223,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2632,10 +2240,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2653,10 +2257,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2674,10 +2274,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2695,10 +2291,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2716,10 +2308,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2737,10 +2325,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2758,10 +2342,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2779,10 +2359,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2800,10 +2376,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2821,10 +2393,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2842,10 +2410,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2863,10 +2427,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2884,10 +2444,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2905,10 +2461,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2926,10 +2478,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2947,10 +2495,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2968,10 +2512,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2989,10 +2529,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -3007,10 +2543,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -3112,10 +2644,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -3133,10 +2661,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -3210,10 +2734,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -3231,10 +2751,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3294,10 +2810,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3333,10 +2845,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3354,10 +2862,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3375,10 +2879,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3396,10 +2896,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3417,10 +2913,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3438,10 +2930,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3459,10 +2947,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3480,10 +2964,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3501,10 +2981,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3522,10 +2998,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3543,10 +3015,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3564,10 +3032,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3585,10 +3049,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3606,10 +3066,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3624,10 +3080,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3642,10 +3094,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3696,10 +3144,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3735,10 +3179,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3882,10 +3322,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3900,10 +3336,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -4002,10 +3434,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -4023,10 +3451,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -4044,10 +3468,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -4065,10 +3485,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -4086,10 +3502,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -4107,10 +3519,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -4125,10 +3533,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -4248,10 +3652,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4269,10 +3669,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4290,10 +3686,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4311,10 +3703,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4332,10 +3720,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4353,10 +3737,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4374,10 +3754,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4392,10 +3768,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4413,10 +3785,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4431,10 +3799,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4449,10 +3813,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4467,10 +3827,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4485,10 +3841,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4503,10 +3855,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4521,10 +3869,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4539,10 +3883,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4557,10 +3897,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4575,10 +3911,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4593,10 +3925,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4611,10 +3939,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4629,10 +3953,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4647,10 +3967,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4665,10 +3981,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4683,10 +3995,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4701,10 +4009,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4719,10 +4023,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4737,10 +4037,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4755,10 +4051,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4773,10 +4065,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4794,10 +4082,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4812,10 +4096,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4830,10 +4110,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4848,10 +4124,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4866,10 +4138,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4884,10 +4152,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4902,10 +4166,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4920,10 +4180,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4938,10 +4194,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4956,10 +4208,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4974,10 +4222,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4992,10 +4236,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -5010,10 +4250,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -5031,10 +4267,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -5052,10 +4284,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -5073,10 +4301,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -5094,10 +4318,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -5115,10 +4335,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -5136,10 +4352,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -5157,10 +4369,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -5178,10 +4386,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -5199,10 +4403,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -5220,10 +4420,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -5241,10 +4437,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5262,10 +4454,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5283,10 +4471,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5304,10 +4488,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5322,10 +4502,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5340,10 +4516,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5361,10 +4533,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5382,10 +4550,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5403,10 +4567,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5424,10 +4584,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5445,10 +4601,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5466,10 +4618,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5487,10 +4635,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5508,10 +4652,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5529,10 +4669,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5550,10 +4686,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5571,10 +4703,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5592,10 +4720,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5613,10 +4737,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5634,10 +4754,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5655,10 +4771,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5739,10 +4851,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5760,10 +4868,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5781,10 +4885,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5844,10 +4944,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5970,10 +5066,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5988,10 +5080,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -6024,10 +5112,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -6042,10 +5126,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -6060,10 +5140,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -6078,10 +5154,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -6096,10 +5168,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -6117,10 +5185,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -6138,10 +5202,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -6159,10 +5219,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -6180,10 +5236,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -6201,10 +5253,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -6222,10 +5270,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -6243,10 +5287,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6264,10 +5304,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6285,10 +5321,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6306,10 +5338,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6327,10 +5355,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6348,10 +5372,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6369,10 +5389,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6390,10 +5406,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6411,10 +5423,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6432,10 +5440,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6453,10 +5457,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6471,10 +5471,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6492,10 +5488,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6513,10 +5505,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6534,10 +5522,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6555,10 +5539,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6576,10 +5556,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6597,10 +5573,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6618,10 +5590,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6639,10 +5607,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6660,10 +5624,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6681,10 +5641,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6699,10 +5655,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6717,10 +5669,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6735,10 +5683,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6753,10 +5697,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6774,10 +5714,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6792,10 +5728,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6876,10 +5808,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6897,10 +5825,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6918,10 +5842,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6939,10 +5859,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6960,10 +5876,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6981,10 +5893,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -7002,10 +5910,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -7044,10 +5948,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -7086,10 +5986,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -7244,10 +6140,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7349,10 +6241,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7391,10 +6279,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7517,10 +6401,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7535,10 +6415,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7556,10 +6432,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7574,10 +6446,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7592,10 +6460,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7613,10 +6477,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7634,10 +6494,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7655,10 +6511,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7676,10 +6528,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7697,10 +6545,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7718,10 +6562,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7739,10 +6579,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7760,10 +6596,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
@@ -22,7 +22,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42,6 +42,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -59,6 +63,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -76,6 +84,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -93,6 +105,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -110,6 +126,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -127,6 +147,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -144,6 +168,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -162,7 +190,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -182,6 +210,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -199,6 +231,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -234,6 +270,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -251,6 +291,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -268,6 +312,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -285,6 +333,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -302,6 +354,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -319,6 +375,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -336,6 +396,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -354,7 +418,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -375,7 +439,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -396,7 +460,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -416,6 +480,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -434,7 +502,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -454,6 +522,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -472,7 +544,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -493,7 +565,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -513,6 +585,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -530,6 +606,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -547,6 +627,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -564,6 +648,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -581,6 +669,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -598,6 +690,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -615,6 +711,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -632,6 +732,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -650,7 +754,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -671,7 +775,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -691,6 +795,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -708,6 +816,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -725,6 +837,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -744,7 +860,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -760,6 +876,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -777,6 +897,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -795,7 +919,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -816,7 +940,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -837,7 +961,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -858,7 +982,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -879,7 +1003,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -899,6 +1023,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -914,7 +1042,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -930,6 +1058,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -947,6 +1079,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -964,6 +1100,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -981,6 +1121,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -998,6 +1142,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1012,6 +1160,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1029,6 +1181,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1046,6 +1202,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1063,6 +1223,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1080,6 +1244,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1097,6 +1265,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1111,6 +1283,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1125,6 +1301,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1139,6 +1319,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1153,6 +1337,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1167,6 +1355,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1181,6 +1373,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1195,6 +1391,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1209,6 +1409,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1223,6 +1427,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1237,6 +1445,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1251,6 +1463,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1265,6 +1481,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1282,6 +1502,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1299,6 +1523,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1316,6 +1544,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1333,6 +1565,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1347,6 +1583,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1361,6 +1601,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1375,6 +1619,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1389,6 +1637,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1403,6 +1655,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1417,6 +1673,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1431,6 +1691,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1445,6 +1709,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1459,6 +1727,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1473,6 +1745,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1487,6 +1763,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1501,6 +1781,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1515,6 +1799,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1529,6 +1817,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1543,6 +1835,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1557,6 +1853,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1574,6 +1874,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1591,6 +1895,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1608,6 +1916,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1625,6 +1937,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1639,6 +1955,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1653,6 +1973,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1667,6 +1991,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1681,6 +2009,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1695,6 +2027,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -1709,6 +2045,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -1723,6 +2063,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -1737,6 +2081,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -1751,6 +2099,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -1765,6 +2117,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -1779,6 +2135,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -1793,6 +2153,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -1810,6 +2174,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -1827,6 +2195,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -1845,7 +2217,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1865,6 +2237,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -1880,7 +2256,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1901,7 +2277,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1917,6 +2293,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -1934,6 +2314,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -1951,6 +2335,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -1968,6 +2356,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -1985,6 +2377,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2002,6 +2398,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2019,6 +2419,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2036,6 +2440,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2053,6 +2461,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2070,6 +2482,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2087,6 +2503,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2104,6 +2524,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2121,6 +2545,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2138,6 +2566,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2155,6 +2587,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2172,6 +2608,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2189,6 +2629,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2206,6 +2650,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2223,6 +2671,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2240,6 +2692,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2257,6 +2713,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2274,6 +2734,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2291,6 +2755,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2305,6 +2773,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2323,7 +2795,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2344,7 +2816,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2365,7 +2837,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2386,7 +2858,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2406,6 +2878,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2423,6 +2899,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2441,7 +2921,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2462,7 +2942,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2496,6 +2976,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2513,6 +2997,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -2531,7 +3019,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2552,7 +3040,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2572,6 +3060,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2587,7 +3079,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2607,6 +3099,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2624,6 +3120,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2641,6 +3141,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2658,6 +3162,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2675,6 +3183,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2692,6 +3204,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2709,6 +3225,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2726,6 +3246,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2743,6 +3267,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2760,6 +3288,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -2777,6 +3309,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -2794,6 +3330,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -2811,6 +3351,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -2828,6 +3372,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -2842,6 +3390,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -2856,6 +3408,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -2872,7 +3428,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2890,7 +3446,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2906,6 +3462,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -2925,7 +3485,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2941,6 +3501,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -2959,7 +3523,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2980,7 +3544,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3001,7 +3565,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3022,7 +3586,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3043,7 +3607,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3064,7 +3628,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3084,6 +3648,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3098,6 +3666,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3113,7 +3685,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3134,7 +3706,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3155,7 +3727,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3176,7 +3748,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3196,6 +3768,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3213,6 +3789,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3230,6 +3810,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3247,6 +3831,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3264,6 +3852,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3281,6 +3873,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3295,6 +3891,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3310,7 +3910,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3331,7 +3931,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3352,7 +3952,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3373,7 +3973,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3394,7 +3994,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3414,6 +4014,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3431,6 +4035,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3448,6 +4056,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3465,6 +4077,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3482,6 +4098,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3499,6 +4119,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3516,6 +4140,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3530,6 +4158,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3547,6 +4179,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3561,6 +4197,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3575,6 +4215,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3589,6 +4233,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3603,6 +4251,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3617,6 +4269,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3631,6 +4287,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3645,6 +4305,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3659,6 +4323,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3673,6 +4341,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3687,6 +4359,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3701,6 +4377,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3715,6 +4395,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3729,6 +4413,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3743,6 +4431,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3757,6 +4449,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -3771,6 +4467,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -3785,6 +4485,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -3799,6 +4503,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -3813,6 +4521,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -3827,6 +4539,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -3844,6 +4560,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -3858,6 +4578,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -3872,6 +4596,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -3886,6 +4614,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -3900,6 +4632,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -3914,6 +4650,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -3928,6 +4668,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -3942,6 +4686,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -3956,6 +4704,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -3970,6 +4722,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -3984,6 +4740,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -3998,6 +4758,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4015,6 +4779,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4032,6 +4800,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4049,6 +4821,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4066,6 +4842,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4083,6 +4863,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4100,6 +4884,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4117,6 +4905,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4134,6 +4926,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4151,6 +4947,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4168,6 +4968,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4185,6 +4989,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4202,6 +5010,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4219,6 +5031,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4236,6 +5052,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4250,6 +5070,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4264,6 +5088,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4281,6 +5109,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4298,6 +5130,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4315,6 +5151,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4332,6 +5172,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4349,6 +5193,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4366,6 +5214,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4383,6 +5235,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4400,6 +5256,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4417,6 +5277,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4434,6 +5298,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4451,6 +5319,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4468,6 +5340,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4485,6 +5361,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4502,6 +5382,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4519,6 +5403,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4537,7 +5425,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4558,7 +5446,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4579,7 +5467,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4599,6 +5487,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -4616,6 +5508,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4633,6 +5529,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4651,7 +5551,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4672,7 +5572,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4692,6 +5592,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4710,7 +5614,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4731,7 +5635,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4752,7 +5656,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4773,7 +5677,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4794,7 +5698,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4814,6 +5718,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -4828,6 +5736,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -4844,7 +5756,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4860,6 +5772,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -4874,6 +5790,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -4888,6 +5808,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -4902,6 +5826,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -4916,6 +5844,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -4933,6 +5865,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -4950,6 +5886,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -4967,6 +5907,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -4984,6 +5928,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5001,6 +5949,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5018,6 +5970,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5035,6 +5991,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5052,6 +6012,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5069,6 +6033,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5086,6 +6054,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5103,6 +6075,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5120,6 +6096,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5137,6 +6117,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5154,6 +6138,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5171,6 +6159,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5188,6 +6180,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5205,6 +6201,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5219,6 +6219,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5236,6 +6240,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5253,6 +6261,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5270,6 +6282,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5287,6 +6303,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5304,6 +6324,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5321,6 +6345,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5338,6 +6366,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5355,6 +6387,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5372,6 +6408,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5389,6 +6429,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5403,6 +6447,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5417,6 +6465,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5431,6 +6483,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5445,6 +6501,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5462,6 +6522,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5476,6 +6540,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5494,7 +6562,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5515,7 +6583,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5536,7 +6604,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5556,6 +6624,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5573,6 +6645,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5590,6 +6666,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5607,6 +6687,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5624,6 +6708,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5641,6 +6729,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5658,6 +6750,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5676,7 +6772,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5696,6 +6792,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5714,7 +6814,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5734,6 +6834,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -5752,7 +6856,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5773,7 +6877,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5794,7 +6898,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5834,7 +6938,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5851,7 +6955,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5872,7 +6976,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5888,6 +6992,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -5906,7 +7014,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5927,7 +7035,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5948,7 +7056,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5969,7 +7077,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5989,6 +7097,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6007,7 +7119,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6027,6 +7139,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6045,7 +7161,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6066,7 +7182,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6087,7 +7203,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6108,7 +7224,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6129,7 +7245,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6149,6 +7265,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6163,6 +7283,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6180,6 +7304,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6194,6 +7322,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6208,6 +7340,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6225,6 +7361,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6242,6 +7382,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6259,6 +7403,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6276,6 +7424,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6293,6 +7445,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6310,6 +7466,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6327,6 +7487,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6344,6 +7508,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
@@ -42,10 +42,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -63,10 +59,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -84,10 +76,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -105,10 +93,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -126,10 +110,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -147,10 +127,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -168,10 +144,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -210,10 +182,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -231,10 +199,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -270,10 +234,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -291,10 +251,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -312,10 +268,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -333,10 +285,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -354,10 +302,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -375,10 +319,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -396,10 +336,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -480,10 +416,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -522,10 +454,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -585,10 +513,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -606,10 +530,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -627,10 +547,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -648,10 +564,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -669,10 +581,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -690,10 +598,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -711,10 +615,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -732,10 +632,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -795,10 +691,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -816,10 +708,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -837,10 +725,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -876,10 +760,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -897,10 +777,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1023,10 +899,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1058,10 +930,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1079,10 +947,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1100,10 +964,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1121,10 +981,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1142,10 +998,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1160,10 +1012,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1181,10 +1029,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1202,10 +1046,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1223,10 +1063,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1244,10 +1080,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1265,10 +1097,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1283,10 +1111,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1301,10 +1125,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1319,10 +1139,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1337,10 +1153,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1355,10 +1167,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1373,10 +1181,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1391,10 +1195,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1409,10 +1209,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1427,10 +1223,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1445,10 +1237,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1463,10 +1251,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1481,10 +1265,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1502,10 +1282,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1523,10 +1299,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1544,10 +1316,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1565,10 +1333,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1583,10 +1347,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1601,10 +1361,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1619,10 +1375,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1637,10 +1389,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1655,10 +1403,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1673,10 +1417,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1691,10 +1431,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1709,10 +1445,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1727,10 +1459,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1745,10 +1473,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1763,10 +1487,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1781,10 +1501,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1799,10 +1515,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1817,10 +1529,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1835,10 +1543,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1853,10 +1557,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1874,10 +1574,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1895,10 +1591,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1916,10 +1608,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1937,10 +1625,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1955,10 +1639,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1973,10 +1653,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1991,10 +1667,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2009,10 +1681,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2027,10 +1695,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2045,10 +1709,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2063,10 +1723,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2081,10 +1737,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2099,10 +1751,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2117,10 +1765,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2135,10 +1779,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2153,10 +1793,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2174,10 +1810,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2195,10 +1827,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2237,10 +1865,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2293,10 +1917,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2314,10 +1934,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2335,10 +1951,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2356,10 +1968,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2377,10 +1985,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2398,10 +2002,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2419,10 +2019,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2440,10 +2036,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2461,10 +2053,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2482,10 +2070,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2503,10 +2087,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2524,10 +2104,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2545,10 +2121,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2566,10 +2138,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2587,10 +2155,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2608,10 +2172,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2629,10 +2189,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2650,10 +2206,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2671,10 +2223,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2692,10 +2240,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2713,10 +2257,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2734,10 +2274,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2755,10 +2291,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2773,10 +2305,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2878,10 +2406,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2899,10 +2423,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2976,10 +2496,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2997,10 +2513,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3060,10 +2572,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3099,10 +2607,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3120,10 +2624,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3141,10 +2641,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3162,10 +2658,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3183,10 +2675,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3204,10 +2692,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3225,10 +2709,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3246,10 +2726,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3267,10 +2743,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3288,10 +2760,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3309,10 +2777,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3330,10 +2794,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3351,10 +2811,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3372,10 +2828,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3390,10 +2842,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3408,10 +2856,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3462,10 +2906,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3501,10 +2941,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3648,10 +3084,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3666,10 +3098,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3768,10 +3196,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3789,10 +3213,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3810,10 +3230,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3831,10 +3247,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3852,10 +3264,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3873,10 +3281,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3891,10 +3295,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -4014,10 +3414,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4035,10 +3431,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4056,10 +3448,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4077,10 +3465,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4098,10 +3482,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4119,10 +3499,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4140,10 +3516,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4158,10 +3530,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4179,10 +3547,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4197,10 +3561,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4215,10 +3575,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4233,10 +3589,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4251,10 +3603,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4269,10 +3617,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4287,10 +3631,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4305,10 +3645,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4323,10 +3659,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4341,10 +3673,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4359,10 +3687,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4377,10 +3701,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4395,10 +3715,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4413,10 +3729,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4431,10 +3743,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4449,10 +3757,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4467,10 +3771,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4485,10 +3785,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4503,10 +3799,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4521,10 +3813,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4539,10 +3827,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4560,10 +3844,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4578,10 +3858,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4596,10 +3872,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4614,10 +3886,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4632,10 +3900,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4650,10 +3914,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4668,10 +3928,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4686,10 +3942,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4704,10 +3956,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4722,10 +3970,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4740,10 +3984,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4758,10 +3998,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4779,10 +4015,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4800,10 +4032,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4821,10 +4049,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4842,10 +4066,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4863,10 +4083,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4884,10 +4100,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4905,10 +4117,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4926,10 +4134,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4947,10 +4151,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4968,10 +4168,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4989,10 +4185,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5010,10 +4202,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5031,10 +4219,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5052,10 +4236,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5070,10 +4250,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5088,10 +4264,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5109,10 +4281,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5130,10 +4298,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5151,10 +4315,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5172,10 +4332,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5193,10 +4349,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5214,10 +4366,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5235,10 +4383,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5256,10 +4400,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5277,10 +4417,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5298,10 +4434,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5319,10 +4451,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5340,10 +4468,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5361,10 +4485,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5382,10 +4502,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5403,10 +4519,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5487,10 +4599,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5508,10 +4616,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5529,10 +4633,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5592,10 +4692,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5718,10 +4814,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5736,10 +4828,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5772,10 +4860,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5790,10 +4874,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5808,10 +4888,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5826,10 +4902,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5844,10 +4916,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5865,10 +4933,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5886,10 +4950,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5907,10 +4967,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5928,10 +4984,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5949,10 +5001,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5970,10 +5018,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5991,10 +5035,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6012,10 +5052,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6033,10 +5069,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6054,10 +5086,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6075,10 +5103,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6096,10 +5120,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6117,10 +5137,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6138,10 +5154,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6159,10 +5171,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6180,10 +5188,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6201,10 +5205,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6219,10 +5219,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6240,10 +5236,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6261,10 +5253,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6282,10 +5270,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6303,10 +5287,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6324,10 +5304,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6345,10 +5321,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6366,10 +5338,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6387,10 +5355,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6408,10 +5372,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6429,10 +5389,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6447,10 +5403,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6465,10 +5417,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6483,10 +5431,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6501,10 +5445,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6522,10 +5462,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6540,10 +5476,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6624,10 +5556,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6645,10 +5573,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6666,10 +5590,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6687,10 +5607,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6708,10 +5624,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6729,10 +5641,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6750,10 +5658,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6792,10 +5696,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6834,10 +5734,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -6992,10 +5888,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7097,10 +5989,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7139,10 +6027,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7265,10 +6149,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7283,10 +6163,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7304,10 +6180,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7322,10 +6194,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7340,10 +6208,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7361,10 +6225,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7382,10 +6242,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7403,10 +6259,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7424,10 +6276,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7445,10 +6293,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7466,10 +6310,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7487,10 +6327,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7508,10 +6344,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
@@ -22,7 +22,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42,6 +42,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -59,6 +63,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -76,6 +84,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -93,6 +105,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -110,6 +126,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -127,6 +147,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -144,6 +168,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -162,7 +190,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -182,6 +210,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -199,6 +231,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -234,6 +270,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -251,6 +291,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -268,6 +312,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -285,6 +333,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -302,6 +354,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -319,6 +375,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -336,6 +396,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -354,7 +418,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -375,7 +439,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -396,7 +460,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -416,6 +480,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -434,7 +502,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -454,6 +522,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -472,7 +544,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -493,7 +565,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -513,6 +585,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -530,6 +606,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -547,6 +627,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -564,6 +648,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -581,6 +669,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -598,6 +690,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -615,6 +711,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -632,6 +732,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -650,7 +754,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -671,7 +775,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -691,6 +795,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -708,6 +816,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -725,6 +837,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -744,7 +860,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -760,6 +876,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -777,6 +897,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -795,7 +919,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -816,7 +940,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -837,7 +961,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -858,7 +982,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -879,7 +1003,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -899,6 +1023,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -914,7 +1042,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -930,6 +1058,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -947,6 +1079,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -964,6 +1100,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -981,6 +1121,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -998,6 +1142,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1012,6 +1160,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1029,6 +1181,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1046,6 +1202,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1063,6 +1223,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1080,6 +1244,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1097,6 +1265,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1111,6 +1283,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1125,6 +1301,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1139,6 +1319,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1153,6 +1337,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1167,6 +1355,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1181,6 +1373,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1195,6 +1391,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1209,6 +1409,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1223,6 +1427,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1237,6 +1445,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1251,6 +1463,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1265,6 +1481,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1282,6 +1502,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1299,6 +1523,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1316,6 +1544,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1333,6 +1565,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1347,6 +1583,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1361,6 +1601,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1375,6 +1619,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1389,6 +1637,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1403,6 +1655,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1417,6 +1673,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1431,6 +1691,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1445,6 +1709,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1459,6 +1727,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1473,6 +1745,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1487,6 +1763,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1501,6 +1781,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1515,6 +1799,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1529,6 +1817,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1543,6 +1835,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1557,6 +1853,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1574,6 +1874,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1591,6 +1895,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1608,6 +1916,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1625,6 +1937,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1639,6 +1955,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1653,6 +1973,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1667,6 +1991,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1681,6 +2009,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1695,6 +2027,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -1709,6 +2045,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -1723,6 +2063,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -1737,6 +2081,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -1751,6 +2099,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -1765,6 +2117,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -1779,6 +2135,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -1793,6 +2153,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -1810,6 +2174,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -1827,6 +2195,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -1845,7 +2217,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1865,6 +2237,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -1880,7 +2256,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1901,7 +2277,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1917,6 +2293,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -1934,6 +2314,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -1951,6 +2335,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -1968,6 +2356,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -1985,6 +2377,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2002,6 +2398,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2019,6 +2419,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2036,6 +2440,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2053,6 +2461,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2070,6 +2482,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2087,6 +2503,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2104,6 +2524,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2121,6 +2545,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2138,6 +2566,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2155,6 +2587,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2172,6 +2608,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2189,6 +2629,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2206,6 +2650,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2223,6 +2671,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2240,6 +2692,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2257,6 +2713,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2274,6 +2734,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2291,6 +2755,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2305,6 +2773,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2323,7 +2795,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2344,7 +2816,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2365,7 +2837,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2386,7 +2858,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2406,6 +2878,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2423,6 +2899,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2441,7 +2921,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2462,7 +2942,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2496,6 +2976,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2513,6 +2997,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -2531,7 +3019,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2552,7 +3040,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2572,6 +3060,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2587,7 +3079,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2607,6 +3099,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2624,6 +3120,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2641,6 +3141,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2658,6 +3162,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2675,6 +3183,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2692,6 +3204,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2709,6 +3225,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2726,6 +3246,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2743,6 +3267,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2760,6 +3288,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -2777,6 +3309,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -2794,6 +3330,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -2811,6 +3351,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -2828,6 +3372,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -2842,6 +3390,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -2856,6 +3408,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -2872,7 +3428,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2890,7 +3446,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2906,6 +3462,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -2925,7 +3485,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2941,6 +3501,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -2959,7 +3523,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2980,7 +3544,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3001,7 +3565,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3022,7 +3586,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3043,7 +3607,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3064,7 +3628,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3084,6 +3648,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3098,6 +3666,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3113,7 +3685,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3134,7 +3706,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3155,7 +3727,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3176,7 +3748,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3196,6 +3768,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3213,6 +3789,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3230,6 +3810,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3247,6 +3831,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3264,6 +3852,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3281,6 +3873,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3295,6 +3891,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3310,7 +3910,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3331,7 +3931,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3352,7 +3952,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3373,7 +3973,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3394,7 +3994,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3414,6 +4014,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3431,6 +4035,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3448,6 +4056,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3465,6 +4077,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3482,6 +4098,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3499,6 +4119,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3516,6 +4140,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3530,6 +4158,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3547,6 +4179,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3561,6 +4197,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3575,6 +4215,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3589,6 +4233,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3603,6 +4251,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3617,6 +4269,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3631,6 +4287,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3645,6 +4305,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3659,6 +4323,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3673,6 +4341,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3687,6 +4359,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3701,6 +4377,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3715,6 +4395,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3729,6 +4413,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3743,6 +4431,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3757,6 +4449,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -3771,6 +4467,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -3785,6 +4485,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -3799,6 +4503,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -3813,6 +4521,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -3827,6 +4539,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -3844,6 +4560,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -3858,6 +4578,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -3872,6 +4596,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -3886,6 +4614,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -3900,6 +4632,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -3914,6 +4650,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -3928,6 +4668,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -3942,6 +4686,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -3956,6 +4704,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -3970,6 +4722,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -3984,6 +4740,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -3998,6 +4758,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4015,6 +4779,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4032,6 +4800,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4049,6 +4821,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4066,6 +4842,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4083,6 +4863,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4100,6 +4884,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4117,6 +4905,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4134,6 +4926,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4151,6 +4947,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4168,6 +4968,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4185,6 +4989,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4202,6 +5010,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4219,6 +5031,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4236,6 +5052,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4250,6 +5070,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4264,6 +5088,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4281,6 +5109,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4298,6 +5130,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4315,6 +5151,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4332,6 +5172,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4349,6 +5193,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4366,6 +5214,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4383,6 +5235,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4400,6 +5256,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4417,6 +5277,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4434,6 +5298,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4451,6 +5319,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4468,6 +5340,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4485,6 +5361,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4502,6 +5382,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4519,6 +5403,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4537,7 +5425,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4558,7 +5446,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4579,7 +5467,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4599,6 +5487,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -4616,6 +5508,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4633,6 +5529,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4651,7 +5551,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4672,7 +5572,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4692,6 +5592,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4710,7 +5614,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4731,7 +5635,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4752,7 +5656,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4773,7 +5677,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4794,7 +5698,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4814,6 +5718,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -4828,6 +5736,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -4844,7 +5756,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4860,6 +5772,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -4874,6 +5790,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -4888,6 +5808,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -4902,6 +5826,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -4916,6 +5844,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -4933,6 +5865,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -4950,6 +5886,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -4967,6 +5907,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -4984,6 +5928,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5001,6 +5949,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5018,6 +5970,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5035,6 +5991,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5052,6 +6012,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5069,6 +6033,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5086,6 +6054,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5103,6 +6075,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5120,6 +6096,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5137,6 +6117,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5154,6 +6138,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5171,6 +6159,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5188,6 +6180,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5205,6 +6201,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5219,6 +6219,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5236,6 +6240,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5253,6 +6261,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5270,6 +6282,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5287,6 +6303,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5304,6 +6324,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5321,6 +6345,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5338,6 +6366,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5355,6 +6387,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5372,6 +6408,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5389,6 +6429,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5403,6 +6447,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5417,6 +6465,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5431,6 +6483,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5445,6 +6501,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5462,6 +6522,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5476,6 +6540,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5494,7 +6562,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5515,7 +6583,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5536,7 +6604,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5556,6 +6624,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5573,6 +6645,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5590,6 +6666,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5607,6 +6687,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5624,6 +6708,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5641,6 +6729,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5658,6 +6750,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5676,7 +6772,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5696,6 +6792,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5714,7 +6814,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5734,6 +6834,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -5752,7 +6856,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5773,7 +6877,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5794,7 +6898,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5834,7 +6938,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5851,7 +6955,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5872,7 +6976,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5888,6 +6992,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -5906,7 +7014,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5927,7 +7035,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5948,7 +7056,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5969,7 +7077,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5989,6 +7097,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6007,7 +7119,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6027,6 +7139,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6045,7 +7161,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6066,7 +7182,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6087,7 +7203,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6108,7 +7224,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6129,7 +7245,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6149,6 +7265,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6163,6 +7283,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6180,6 +7304,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6194,6 +7322,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6208,6 +7340,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6225,6 +7361,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6242,6 +7382,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6259,6 +7403,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6276,6 +7424,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6293,6 +7445,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6310,6 +7466,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6327,6 +7487,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6344,6 +7508,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
@@ -42,10 +42,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -63,10 +59,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -84,10 +76,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -105,10 +93,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -126,10 +110,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -147,10 +127,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -168,10 +144,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -210,10 +182,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -231,10 +199,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -270,10 +234,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -291,10 +251,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -312,10 +268,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -333,10 +285,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -354,10 +302,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -375,10 +319,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -396,10 +336,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -480,10 +416,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -522,10 +454,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -585,10 +513,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -606,10 +530,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -627,10 +547,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -648,10 +564,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -669,10 +581,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -690,10 +598,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -711,10 +615,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -732,10 +632,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -795,10 +691,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -816,10 +708,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -837,10 +725,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -876,10 +760,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -897,10 +777,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1023,10 +899,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1058,10 +930,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1079,10 +947,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1100,10 +964,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1121,10 +981,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1142,10 +998,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1160,10 +1012,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1181,10 +1029,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1202,10 +1046,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1223,10 +1063,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1244,10 +1080,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1265,10 +1097,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1283,10 +1111,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1301,10 +1125,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1319,10 +1139,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1337,10 +1153,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1355,10 +1167,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1373,10 +1181,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1391,10 +1195,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1409,10 +1209,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1427,10 +1223,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1445,10 +1237,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1463,10 +1251,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1481,10 +1265,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1502,10 +1282,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1523,10 +1299,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1544,10 +1316,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1565,10 +1333,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1583,10 +1347,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1601,10 +1361,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1619,10 +1375,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1637,10 +1389,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1655,10 +1403,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1673,10 +1417,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1691,10 +1431,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1709,10 +1445,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1727,10 +1459,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1745,10 +1473,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1763,10 +1487,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1781,10 +1501,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1799,10 +1515,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1817,10 +1529,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1835,10 +1543,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1853,10 +1557,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1874,10 +1574,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1895,10 +1591,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1916,10 +1608,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1937,10 +1625,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1955,10 +1639,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1973,10 +1653,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1991,10 +1667,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2009,10 +1681,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2027,10 +1695,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2045,10 +1709,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2063,10 +1723,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2081,10 +1737,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2099,10 +1751,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2117,10 +1765,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2135,10 +1779,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2153,10 +1793,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2174,10 +1810,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2195,10 +1827,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2237,10 +1865,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2293,10 +1917,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2314,10 +1934,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2335,10 +1951,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2356,10 +1968,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2377,10 +1985,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2398,10 +2002,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2419,10 +2019,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2440,10 +2036,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2461,10 +2053,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2482,10 +2070,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2503,10 +2087,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2524,10 +2104,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2545,10 +2121,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2566,10 +2138,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2587,10 +2155,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2608,10 +2172,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2629,10 +2189,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2650,10 +2206,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2671,10 +2223,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2692,10 +2240,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2713,10 +2257,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2734,10 +2274,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2755,10 +2291,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2773,10 +2305,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2878,10 +2406,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2899,10 +2423,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2976,10 +2496,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2997,10 +2513,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3060,10 +2572,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3099,10 +2607,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3120,10 +2624,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3141,10 +2641,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3162,10 +2658,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3183,10 +2675,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3204,10 +2692,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3225,10 +2709,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3246,10 +2726,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3267,10 +2743,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3288,10 +2760,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3309,10 +2777,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3330,10 +2794,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3351,10 +2811,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3372,10 +2828,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3390,10 +2842,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3408,10 +2856,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3462,10 +2906,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3501,10 +2941,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3648,10 +3084,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3666,10 +3098,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3768,10 +3196,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3789,10 +3213,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3810,10 +3230,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3831,10 +3247,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3852,10 +3264,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3873,10 +3281,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3891,10 +3295,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -4014,10 +3414,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4035,10 +3431,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4056,10 +3448,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4077,10 +3465,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4098,10 +3482,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4119,10 +3499,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4140,10 +3516,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4158,10 +3530,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4179,10 +3547,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4197,10 +3561,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4215,10 +3575,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4233,10 +3589,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4251,10 +3603,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4269,10 +3617,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4287,10 +3631,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4305,10 +3645,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4323,10 +3659,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4341,10 +3673,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4359,10 +3687,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4377,10 +3701,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4395,10 +3715,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4413,10 +3729,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4431,10 +3743,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4449,10 +3757,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4467,10 +3771,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4485,10 +3785,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4503,10 +3799,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4521,10 +3813,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4539,10 +3827,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4560,10 +3844,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4578,10 +3858,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4596,10 +3872,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4614,10 +3886,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4632,10 +3900,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4650,10 +3914,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4668,10 +3928,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4686,10 +3942,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4704,10 +3956,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4722,10 +3970,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4740,10 +3984,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4758,10 +3998,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4779,10 +4015,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4800,10 +4032,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4821,10 +4049,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4842,10 +4066,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4863,10 +4083,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4884,10 +4100,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4905,10 +4117,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4926,10 +4134,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4947,10 +4151,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4968,10 +4168,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4989,10 +4185,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5010,10 +4202,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5031,10 +4219,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5052,10 +4236,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5070,10 +4250,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5088,10 +4264,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5109,10 +4281,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5130,10 +4298,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5151,10 +4315,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5172,10 +4332,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5193,10 +4349,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5214,10 +4366,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5235,10 +4383,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5256,10 +4400,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5277,10 +4417,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5298,10 +4434,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5319,10 +4451,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5340,10 +4468,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5361,10 +4485,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5382,10 +4502,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5403,10 +4519,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5487,10 +4599,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5508,10 +4616,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5529,10 +4633,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5592,10 +4692,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5718,10 +4814,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5736,10 +4828,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5772,10 +4860,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5790,10 +4874,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5808,10 +4888,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5826,10 +4902,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5844,10 +4916,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5865,10 +4933,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5886,10 +4950,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5907,10 +4967,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5928,10 +4984,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5949,10 +5001,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5970,10 +5018,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5991,10 +5035,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6012,10 +5052,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6033,10 +5069,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6054,10 +5086,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6075,10 +5103,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6096,10 +5120,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6117,10 +5137,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6138,10 +5154,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6159,10 +5171,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6180,10 +5188,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6201,10 +5205,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6219,10 +5219,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6240,10 +5236,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6261,10 +5253,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6282,10 +5270,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6303,10 +5287,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6324,10 +5304,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6345,10 +5321,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6366,10 +5338,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6387,10 +5355,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6408,10 +5372,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6429,10 +5389,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6447,10 +5403,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6465,10 +5417,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6483,10 +5431,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6501,10 +5445,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6522,10 +5462,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6540,10 +5476,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6624,10 +5556,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6645,10 +5573,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6666,10 +5590,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6687,10 +5607,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6708,10 +5624,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6729,10 +5641,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6750,10 +5658,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6792,10 +5696,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6834,10 +5734,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -6992,10 +5888,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7097,10 +5989,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7139,10 +6027,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7265,10 +6149,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7283,10 +6163,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7304,10 +6180,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7322,10 +6194,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7340,10 +6208,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7361,10 +6225,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7382,10 +6242,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7403,10 +6259,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7424,10 +6276,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7445,10 +6293,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7466,10 +6310,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7487,10 +6327,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7508,10 +6344,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
@@ -22,7 +22,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42,6 +42,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -59,6 +63,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -76,6 +84,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -93,6 +105,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -110,6 +126,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -127,6 +147,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -144,6 +168,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -162,7 +190,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -182,6 +210,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -199,6 +231,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -234,6 +270,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -251,6 +291,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -268,6 +312,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -285,6 +333,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -302,6 +354,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -319,6 +375,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -336,6 +396,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -354,7 +418,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -375,7 +439,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -396,7 +460,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -416,6 +480,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -434,7 +502,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -454,6 +522,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -472,7 +544,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -493,7 +565,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -513,6 +585,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -530,6 +606,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -547,6 +627,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -564,6 +648,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -581,6 +669,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -598,6 +690,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -615,6 +711,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -632,6 +732,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -650,7 +754,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -671,7 +775,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -691,6 +795,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -708,6 +816,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -725,6 +837,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -744,7 +860,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -760,6 +876,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -777,6 +897,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -795,7 +919,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -816,7 +940,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -837,7 +961,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -858,7 +982,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -879,7 +1003,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -899,6 +1023,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -914,7 +1042,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -930,6 +1058,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -947,6 +1079,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -964,6 +1100,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -981,6 +1121,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -998,6 +1142,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1012,6 +1160,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1029,6 +1181,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1046,6 +1202,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1063,6 +1223,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1080,6 +1244,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1097,6 +1265,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1111,6 +1283,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1125,6 +1301,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1139,6 +1319,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1153,6 +1337,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1167,6 +1355,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1181,6 +1373,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1195,6 +1391,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1209,6 +1409,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1223,6 +1427,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1237,6 +1445,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1251,6 +1463,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1265,6 +1481,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1282,6 +1502,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1299,6 +1523,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1316,6 +1544,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1333,6 +1565,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1347,6 +1583,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1361,6 +1601,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1375,6 +1619,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1389,6 +1637,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1403,6 +1655,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1417,6 +1673,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1431,6 +1691,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1445,6 +1709,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1459,6 +1727,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1473,6 +1745,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1487,6 +1763,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1501,6 +1781,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1515,6 +1799,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1529,6 +1817,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1543,6 +1835,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1557,6 +1853,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1574,6 +1874,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1591,6 +1895,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1608,6 +1916,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1625,6 +1937,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1639,6 +1955,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1653,6 +1973,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1667,6 +1991,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1681,6 +2009,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1695,6 +2027,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -1709,6 +2045,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -1723,6 +2063,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -1737,6 +2081,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -1751,6 +2099,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -1765,6 +2117,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -1779,6 +2135,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -1793,6 +2153,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -1810,6 +2174,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -1827,6 +2195,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -1845,7 +2217,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1865,6 +2237,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -1880,7 +2256,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1901,7 +2277,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1917,6 +2293,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -1934,6 +2314,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -1951,6 +2335,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -1968,6 +2356,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -1985,6 +2377,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2002,6 +2398,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2019,6 +2419,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2036,6 +2440,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2053,6 +2461,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2070,6 +2482,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2087,6 +2503,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2104,6 +2524,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2121,6 +2545,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2138,6 +2566,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2155,6 +2587,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2172,6 +2608,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2189,6 +2629,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2206,6 +2650,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2223,6 +2671,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2240,6 +2692,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2257,6 +2713,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2274,6 +2734,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2291,6 +2755,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2305,6 +2773,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2323,7 +2795,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2344,7 +2816,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2365,7 +2837,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2386,7 +2858,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2406,6 +2878,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2423,6 +2899,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2441,7 +2921,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2462,7 +2942,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2496,6 +2976,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2513,6 +2997,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -2531,7 +3019,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2552,7 +3040,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2572,6 +3060,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2587,7 +3079,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2607,6 +3099,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2624,6 +3120,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2641,6 +3141,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2658,6 +3162,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2675,6 +3183,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2692,6 +3204,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2709,6 +3225,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2726,6 +3246,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2743,6 +3267,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2760,6 +3288,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -2777,6 +3309,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -2794,6 +3330,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -2811,6 +3351,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -2828,6 +3372,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -2842,6 +3390,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -2856,6 +3408,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -2872,7 +3428,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2890,7 +3446,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2906,6 +3462,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -2925,7 +3485,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2941,6 +3501,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -2959,7 +3523,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2980,7 +3544,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3001,7 +3565,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3022,7 +3586,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3043,7 +3607,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3064,7 +3628,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3084,6 +3648,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3098,6 +3666,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3113,7 +3685,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3134,7 +3706,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3155,7 +3727,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3176,7 +3748,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3196,6 +3768,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3213,6 +3789,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3230,6 +3810,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3247,6 +3831,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3264,6 +3852,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3281,6 +3873,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3295,6 +3891,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3310,7 +3910,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3331,7 +3931,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3352,7 +3952,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3373,7 +3973,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3394,7 +3994,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3414,6 +4014,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3431,6 +4035,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3448,6 +4056,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3465,6 +4077,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3482,6 +4098,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3499,6 +4119,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3516,6 +4140,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3530,6 +4158,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3547,6 +4179,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3561,6 +4197,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3575,6 +4215,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3589,6 +4233,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3603,6 +4251,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3617,6 +4269,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3631,6 +4287,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3645,6 +4305,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3659,6 +4323,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3673,6 +4341,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3687,6 +4359,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3701,6 +4377,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3715,6 +4395,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3729,6 +4413,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3743,6 +4431,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3757,6 +4449,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -3771,6 +4467,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -3785,6 +4485,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -3799,6 +4503,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -3813,6 +4521,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -3827,6 +4539,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -3844,6 +4560,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -3858,6 +4578,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -3872,6 +4596,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -3886,6 +4614,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -3900,6 +4632,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -3914,6 +4650,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -3928,6 +4668,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -3942,6 +4686,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -3956,6 +4704,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -3970,6 +4722,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -3984,6 +4740,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -3998,6 +4758,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4015,6 +4779,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4032,6 +4800,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4049,6 +4821,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4066,6 +4842,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4083,6 +4863,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4100,6 +4884,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4117,6 +4905,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4134,6 +4926,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4151,6 +4947,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4168,6 +4968,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4185,6 +4989,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4202,6 +5010,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4219,6 +5031,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4236,6 +5052,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4250,6 +5070,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4264,6 +5088,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4281,6 +5109,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4298,6 +5130,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4315,6 +5151,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4332,6 +5172,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4349,6 +5193,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4366,6 +5214,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4383,6 +5235,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4400,6 +5256,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4417,6 +5277,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4434,6 +5298,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4451,6 +5319,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4468,6 +5340,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4485,6 +5361,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4502,6 +5382,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4519,6 +5403,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4537,7 +5425,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4558,7 +5446,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4579,7 +5467,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4599,6 +5487,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -4616,6 +5508,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4633,6 +5529,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4651,7 +5551,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4672,7 +5572,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4692,6 +5592,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4710,7 +5614,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4731,7 +5635,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4752,7 +5656,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4773,7 +5677,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4794,7 +5698,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4814,6 +5718,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -4828,6 +5736,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -4844,7 +5756,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4860,6 +5772,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -4874,6 +5790,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -4888,6 +5808,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -4902,6 +5826,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -4916,6 +5844,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -4933,6 +5865,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -4950,6 +5886,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -4967,6 +5907,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -4984,6 +5928,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5001,6 +5949,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5018,6 +5970,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5035,6 +5991,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5052,6 +6012,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5069,6 +6033,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5086,6 +6054,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5103,6 +6075,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5120,6 +6096,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5137,6 +6117,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5154,6 +6138,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5171,6 +6159,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5188,6 +6180,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5205,6 +6201,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5219,6 +6219,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5236,6 +6240,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5253,6 +6261,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5270,6 +6282,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5287,6 +6303,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5304,6 +6324,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5321,6 +6345,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5338,6 +6366,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5355,6 +6387,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5372,6 +6408,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5389,6 +6429,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5403,6 +6447,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5417,6 +6465,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5431,6 +6483,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5445,6 +6501,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5462,6 +6522,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5476,6 +6540,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5494,7 +6562,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5515,7 +6583,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5536,7 +6604,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5556,6 +6624,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5573,6 +6645,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5590,6 +6666,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5607,6 +6687,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5624,6 +6708,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5641,6 +6729,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5658,6 +6750,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5676,7 +6772,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5696,6 +6792,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5714,7 +6814,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5734,6 +6834,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -5752,7 +6856,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5773,7 +6877,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5794,7 +6898,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5834,7 +6938,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5851,7 +6955,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5872,7 +6976,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5888,6 +6992,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -5906,7 +7014,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5927,7 +7035,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5948,7 +7056,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5969,7 +7077,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5989,6 +7097,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6007,7 +7119,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6027,6 +7139,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6045,7 +7161,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6066,7 +7182,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6087,7 +7203,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6108,7 +7224,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6129,7 +7245,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6149,6 +7265,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6163,6 +7283,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6180,6 +7304,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6194,6 +7322,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6208,6 +7340,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6225,6 +7361,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6242,6 +7382,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6259,6 +7403,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6276,6 +7424,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6293,6 +7445,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6310,6 +7466,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6327,6 +7487,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6344,6 +7508,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
@@ -42,10 +42,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -63,10 +59,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -84,10 +76,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -105,10 +93,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -126,10 +110,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -147,10 +127,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -168,10 +144,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -210,10 +182,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -231,10 +199,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -270,10 +234,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -291,10 +251,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -312,10 +268,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -333,10 +285,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -354,10 +302,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -375,10 +319,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -396,10 +336,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -480,10 +416,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -522,10 +454,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -585,10 +513,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -606,10 +530,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -627,10 +547,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -648,10 +564,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -669,10 +581,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -690,10 +598,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -711,10 +615,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -732,10 +632,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -795,10 +691,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -816,10 +708,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -837,10 +725,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -876,10 +760,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -897,10 +777,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1023,10 +899,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1058,10 +930,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1079,10 +947,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1100,10 +964,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1121,10 +981,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1142,10 +998,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1160,10 +1012,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1181,10 +1029,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1202,10 +1046,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1223,10 +1063,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1244,10 +1080,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1265,10 +1097,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1283,10 +1111,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1301,10 +1125,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1319,10 +1139,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1337,10 +1153,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1355,10 +1167,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1373,10 +1181,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1391,10 +1195,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1409,10 +1209,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1427,10 +1223,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1445,10 +1237,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1463,10 +1251,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1481,10 +1265,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1502,10 +1282,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1523,10 +1299,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1544,10 +1316,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1565,10 +1333,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1583,10 +1347,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1601,10 +1361,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1619,10 +1375,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1637,10 +1389,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1655,10 +1403,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1673,10 +1417,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1691,10 +1431,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1709,10 +1445,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1727,10 +1459,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1745,10 +1473,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1763,10 +1487,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1781,10 +1501,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1799,10 +1515,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1817,10 +1529,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1835,10 +1543,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1853,10 +1557,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1874,10 +1574,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1895,10 +1591,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1916,10 +1608,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1937,10 +1625,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1955,10 +1639,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1973,10 +1653,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1991,10 +1667,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2009,10 +1681,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2027,10 +1695,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2045,10 +1709,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2063,10 +1723,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2081,10 +1737,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2099,10 +1751,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2117,10 +1765,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2135,10 +1779,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2153,10 +1793,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2174,10 +1810,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2195,10 +1827,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2237,10 +1865,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2293,10 +1917,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2314,10 +1934,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2335,10 +1951,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2356,10 +1968,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2377,10 +1985,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2398,10 +2002,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2419,10 +2019,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2440,10 +2036,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2461,10 +2053,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2482,10 +2070,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2503,10 +2087,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2524,10 +2104,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2545,10 +2121,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2566,10 +2138,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2587,10 +2155,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2608,10 +2172,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2629,10 +2189,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2650,10 +2206,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2671,10 +2223,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2692,10 +2240,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2713,10 +2257,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2734,10 +2274,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2755,10 +2291,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2773,10 +2305,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2878,10 +2406,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2899,10 +2423,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2976,10 +2496,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2997,10 +2513,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3060,10 +2572,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3099,10 +2607,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3120,10 +2624,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3141,10 +2641,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3162,10 +2658,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3183,10 +2675,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3204,10 +2692,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3225,10 +2709,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3246,10 +2726,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3267,10 +2743,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3288,10 +2760,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3309,10 +2777,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3330,10 +2794,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3351,10 +2811,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3372,10 +2828,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3390,10 +2842,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3408,10 +2856,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3462,10 +2906,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3501,10 +2941,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3648,10 +3084,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3666,10 +3098,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3768,10 +3196,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3789,10 +3213,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3810,10 +3230,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3831,10 +3247,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3852,10 +3264,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3873,10 +3281,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3891,10 +3295,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -4014,10 +3414,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4035,10 +3431,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4056,10 +3448,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4077,10 +3465,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4098,10 +3482,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4119,10 +3499,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4140,10 +3516,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4158,10 +3530,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4179,10 +3547,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4197,10 +3561,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4215,10 +3575,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4233,10 +3589,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4251,10 +3603,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4269,10 +3617,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4287,10 +3631,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4305,10 +3645,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4323,10 +3659,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4341,10 +3673,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4359,10 +3687,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4377,10 +3701,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4395,10 +3715,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4413,10 +3729,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4431,10 +3743,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4449,10 +3757,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4467,10 +3771,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4485,10 +3785,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4503,10 +3799,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4521,10 +3813,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4539,10 +3827,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4560,10 +3844,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4578,10 +3858,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4596,10 +3872,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4614,10 +3886,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4632,10 +3900,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4650,10 +3914,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4668,10 +3928,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4686,10 +3942,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4704,10 +3956,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4722,10 +3970,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4740,10 +3984,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4758,10 +3998,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4779,10 +4015,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4800,10 +4032,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4821,10 +4049,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4842,10 +4066,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4863,10 +4083,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4884,10 +4100,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4905,10 +4117,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4926,10 +4134,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4947,10 +4151,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4968,10 +4168,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4989,10 +4185,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5010,10 +4202,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5031,10 +4219,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5052,10 +4236,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5070,10 +4250,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5088,10 +4264,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5109,10 +4281,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5130,10 +4298,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5151,10 +4315,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5172,10 +4332,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5193,10 +4349,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5214,10 +4366,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5235,10 +4383,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5256,10 +4400,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5277,10 +4417,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5298,10 +4434,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5319,10 +4451,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5340,10 +4468,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5361,10 +4485,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5382,10 +4502,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5403,10 +4519,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5487,10 +4599,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5508,10 +4616,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5529,10 +4633,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5592,10 +4692,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5718,10 +4814,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5736,10 +4828,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5772,10 +4860,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5790,10 +4874,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5808,10 +4888,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5826,10 +4902,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5844,10 +4916,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5865,10 +4933,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5886,10 +4950,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5907,10 +4967,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5928,10 +4984,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5949,10 +5001,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5970,10 +5018,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5991,10 +5035,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6012,10 +5052,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6033,10 +5069,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6054,10 +5086,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6075,10 +5103,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6096,10 +5120,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6117,10 +5137,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6138,10 +5154,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6159,10 +5171,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6180,10 +5188,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6201,10 +5205,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6219,10 +5219,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6240,10 +5236,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6261,10 +5253,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6282,10 +5270,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6303,10 +5287,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6324,10 +5304,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6345,10 +5321,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6366,10 +5338,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6387,10 +5355,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6408,10 +5372,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6429,10 +5389,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6447,10 +5403,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6465,10 +5417,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6483,10 +5431,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6501,10 +5445,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6522,10 +5462,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6540,10 +5476,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6624,10 +5556,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6645,10 +5573,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6666,10 +5590,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6687,10 +5607,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6708,10 +5624,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6729,10 +5641,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6750,10 +5658,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6792,10 +5696,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6834,10 +5734,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -6992,10 +5888,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7097,10 +5989,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7139,10 +6027,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7265,10 +6149,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7283,10 +6163,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7304,10 +6180,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7322,10 +6194,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7340,10 +6208,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7361,10 +6225,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7382,10 +6242,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7403,10 +6259,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7424,10 +6276,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7445,10 +6293,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7466,10 +6310,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7487,10 +6327,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7508,10 +6344,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
@@ -42,10 +42,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -63,10 +59,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -84,10 +76,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -105,10 +93,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -126,10 +110,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -147,10 +127,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -168,10 +144,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -210,10 +182,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -231,10 +199,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -270,10 +234,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -291,10 +251,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -312,10 +268,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -333,10 +285,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -354,10 +302,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -375,10 +319,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -396,10 +336,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -480,10 +416,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -522,10 +454,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -585,10 +513,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -606,10 +530,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -627,10 +547,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -648,10 +564,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -669,10 +581,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -690,10 +598,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -711,10 +615,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -732,10 +632,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -795,10 +691,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -816,10 +708,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -837,10 +725,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -876,10 +760,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -897,10 +777,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1023,10 +899,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1058,10 +930,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1079,10 +947,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1100,10 +964,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1121,10 +981,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1142,10 +998,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1160,10 +1012,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1181,10 +1029,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1202,10 +1046,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1223,10 +1063,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1244,10 +1080,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1265,10 +1097,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1283,10 +1111,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1301,10 +1125,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1319,10 +1139,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1337,10 +1153,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1355,10 +1167,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1373,10 +1181,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1391,10 +1195,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1409,10 +1209,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1427,10 +1223,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1445,10 +1237,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1463,10 +1251,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1481,10 +1265,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1502,10 +1282,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1523,10 +1299,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1544,10 +1316,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1565,10 +1333,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1583,10 +1347,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1601,10 +1361,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1619,10 +1375,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1637,10 +1389,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1655,10 +1403,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1673,10 +1417,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1691,10 +1431,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1709,10 +1445,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1727,10 +1459,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1745,10 +1473,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1763,10 +1487,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1781,10 +1501,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1799,10 +1515,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1817,10 +1529,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1835,10 +1543,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1853,10 +1557,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1874,10 +1574,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1895,10 +1591,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1916,10 +1608,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1937,10 +1625,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1955,10 +1639,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1973,10 +1653,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1991,10 +1667,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2009,10 +1681,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2027,10 +1695,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2045,10 +1709,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2063,10 +1723,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2081,10 +1737,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2099,10 +1751,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2117,10 +1765,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2135,10 +1779,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2153,10 +1793,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2174,10 +1810,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2195,10 +1827,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2237,10 +1865,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2293,10 +1917,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2314,10 +1934,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2335,10 +1951,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2356,10 +1968,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2377,10 +1985,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2398,10 +2002,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2419,10 +2019,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2440,10 +2036,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2461,10 +2053,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2482,10 +2070,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2503,10 +2087,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2524,10 +2104,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2545,10 +2121,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2566,10 +2138,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2587,10 +2155,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2608,10 +2172,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2629,10 +2189,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2650,10 +2206,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2671,10 +2223,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2692,10 +2240,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2713,10 +2257,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2734,10 +2274,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2755,10 +2291,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2773,10 +2305,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2878,10 +2406,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2899,10 +2423,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2976,10 +2496,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2997,10 +2513,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3060,10 +2572,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3099,10 +2607,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3120,10 +2624,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3141,10 +2641,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3162,10 +2658,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3183,10 +2675,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3204,10 +2692,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3225,10 +2709,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3246,10 +2726,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3267,10 +2743,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3288,10 +2760,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3309,10 +2777,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3330,10 +2794,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3351,10 +2811,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3372,10 +2828,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3390,10 +2842,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3408,10 +2856,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3462,10 +2906,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3501,10 +2941,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3648,10 +3084,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3666,10 +3098,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3768,10 +3196,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3789,10 +3213,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3810,10 +3230,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3831,10 +3247,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3852,10 +3264,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3873,10 +3281,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3891,10 +3295,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -4014,10 +3414,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4035,10 +3431,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4056,10 +3448,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4077,10 +3465,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4098,10 +3482,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4119,10 +3499,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4140,10 +3516,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4158,10 +3530,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4179,10 +3547,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4197,10 +3561,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4215,10 +3575,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4233,10 +3589,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4251,10 +3603,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4269,10 +3617,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4287,10 +3631,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4305,10 +3645,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4323,10 +3659,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4341,10 +3673,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4359,10 +3687,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4377,10 +3701,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4395,10 +3715,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4413,10 +3729,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4431,10 +3743,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4449,10 +3757,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4467,10 +3771,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4485,10 +3785,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4503,10 +3799,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4521,10 +3813,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4539,10 +3827,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4560,10 +3844,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4578,10 +3858,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4596,10 +3872,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4614,10 +3886,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4632,10 +3900,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4650,10 +3914,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4668,10 +3928,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4686,10 +3942,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4704,10 +3956,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4722,10 +3970,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4740,10 +3984,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4758,10 +3998,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4779,10 +4015,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4800,10 +4032,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4821,10 +4049,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4842,10 +4066,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4863,10 +4083,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4884,10 +4100,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4905,10 +4117,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4926,10 +4134,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4947,10 +4151,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4968,10 +4168,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4989,10 +4185,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5010,10 +4202,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5031,10 +4219,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5052,10 +4236,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5070,10 +4250,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5088,10 +4264,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5109,10 +4281,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5130,10 +4298,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5151,10 +4315,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5172,10 +4332,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5193,10 +4349,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5214,10 +4366,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5235,10 +4383,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5256,10 +4400,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5277,10 +4417,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5298,10 +4434,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5319,10 +4451,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5340,10 +4468,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5361,10 +4485,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5382,10 +4502,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5403,10 +4519,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5487,10 +4599,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5508,10 +4616,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5529,10 +4633,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5592,10 +4692,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5718,10 +4814,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5736,10 +4828,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5772,10 +4860,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5790,10 +4874,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5808,10 +4888,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5826,10 +4902,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5844,10 +4916,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5865,10 +4933,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5886,10 +4950,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5907,10 +4967,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5928,10 +4984,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5949,10 +5001,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5970,10 +5018,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5991,10 +5035,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6012,10 +5052,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6033,10 +5069,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6054,10 +5086,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6075,10 +5103,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6096,10 +5120,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6117,10 +5137,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6138,10 +5154,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6159,10 +5171,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6180,10 +5188,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6201,10 +5205,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6219,10 +5219,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6240,10 +5236,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6261,10 +5253,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6282,10 +5270,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6303,10 +5287,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6324,10 +5304,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6345,10 +5321,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6366,10 +5338,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6387,10 +5355,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6408,10 +5372,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6429,10 +5389,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6447,10 +5403,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6465,10 +5417,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6483,10 +5431,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6501,10 +5445,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6522,10 +5462,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6540,10 +5476,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6624,10 +5556,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6645,10 +5573,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6666,10 +5590,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6687,10 +5607,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6708,10 +5624,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6729,10 +5641,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6750,10 +5658,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6792,10 +5696,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6834,10 +5734,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -6992,10 +5888,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7097,10 +5989,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7139,10 +6027,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7265,10 +6149,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7283,10 +6163,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7304,10 +6180,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7322,10 +6194,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7340,10 +6208,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7361,10 +6225,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7382,10 +6242,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7403,10 +6259,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7424,10 +6276,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7445,10 +6293,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7466,10 +6310,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7487,10 +6327,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7508,10 +6344,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
@@ -22,7 +22,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42,6 +42,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -59,6 +63,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -76,6 +84,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -93,6 +105,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -110,6 +126,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -127,6 +147,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -144,6 +168,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -162,7 +190,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -182,6 +210,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -199,6 +231,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -234,6 +270,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -251,6 +291,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -268,6 +312,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -285,6 +333,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -302,6 +354,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -319,6 +375,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -336,6 +396,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -354,7 +418,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -375,7 +439,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -396,7 +460,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -416,6 +480,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -434,7 +502,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -454,6 +522,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -472,7 +544,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -493,7 +565,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -513,6 +585,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -530,6 +606,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -547,6 +627,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -564,6 +648,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -581,6 +669,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -598,6 +690,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -615,6 +711,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -632,6 +732,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -650,7 +754,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -671,7 +775,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -691,6 +795,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -708,6 +816,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -725,6 +837,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -744,7 +860,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -760,6 +876,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -777,6 +897,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -795,7 +919,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -816,7 +940,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -837,7 +961,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -858,7 +982,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -879,7 +1003,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -899,6 +1023,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -914,7 +1042,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -930,6 +1058,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -947,6 +1079,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -964,6 +1100,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -981,6 +1121,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -998,6 +1142,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1012,6 +1160,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1029,6 +1181,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1046,6 +1202,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1063,6 +1223,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1080,6 +1244,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1097,6 +1265,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1111,6 +1283,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1125,6 +1301,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1139,6 +1319,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1153,6 +1337,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1167,6 +1355,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1181,6 +1373,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1195,6 +1391,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1209,6 +1409,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1223,6 +1427,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1237,6 +1445,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1251,6 +1463,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1265,6 +1481,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1282,6 +1502,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1299,6 +1523,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1316,6 +1544,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1333,6 +1565,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1347,6 +1583,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1361,6 +1601,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1375,6 +1619,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1389,6 +1637,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1403,6 +1655,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1417,6 +1673,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1431,6 +1691,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1445,6 +1709,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1459,6 +1727,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1473,6 +1745,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1487,6 +1763,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1501,6 +1781,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1515,6 +1799,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1529,6 +1817,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1543,6 +1835,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1557,6 +1853,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1574,6 +1874,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1591,6 +1895,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1608,6 +1916,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1625,6 +1937,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1639,6 +1955,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1653,6 +1973,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1667,6 +1991,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1681,6 +2009,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1695,6 +2027,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -1709,6 +2045,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -1723,6 +2063,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -1737,6 +2081,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -1751,6 +2099,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -1765,6 +2117,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -1779,6 +2135,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -1793,6 +2153,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -1810,6 +2174,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -1827,6 +2195,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -1845,7 +2217,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1865,6 +2237,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -1880,7 +2256,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1901,7 +2277,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1917,6 +2293,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -1934,6 +2314,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -1951,6 +2335,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -1968,6 +2356,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -1985,6 +2377,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2002,6 +2398,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2019,6 +2419,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2036,6 +2440,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2053,6 +2461,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2070,6 +2482,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2087,6 +2503,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2104,6 +2524,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2121,6 +2545,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2138,6 +2566,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2155,6 +2587,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2172,6 +2608,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2189,6 +2629,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2206,6 +2650,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2223,6 +2671,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2240,6 +2692,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2257,6 +2713,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2274,6 +2734,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2291,6 +2755,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2305,6 +2773,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2323,7 +2795,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2344,7 +2816,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2365,7 +2837,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2386,7 +2858,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2406,6 +2878,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2423,6 +2899,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2441,7 +2921,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2462,7 +2942,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2496,6 +2976,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2513,6 +2997,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -2531,7 +3019,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2552,7 +3040,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2572,6 +3060,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2587,7 +3079,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2607,6 +3099,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2624,6 +3120,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2641,6 +3141,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2658,6 +3162,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2675,6 +3183,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2692,6 +3204,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2709,6 +3225,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2726,6 +3246,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2743,6 +3267,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2760,6 +3288,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -2777,6 +3309,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -2794,6 +3330,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -2811,6 +3351,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -2828,6 +3372,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -2842,6 +3390,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -2856,6 +3408,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -2872,7 +3428,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2890,7 +3446,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2906,6 +3462,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -2925,7 +3485,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2941,6 +3501,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -2959,7 +3523,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2980,7 +3544,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3001,7 +3565,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3022,7 +3586,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3043,7 +3607,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3064,7 +3628,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3084,6 +3648,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3098,6 +3666,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3113,7 +3685,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3134,7 +3706,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3155,7 +3727,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3176,7 +3748,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3196,6 +3768,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3213,6 +3789,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3230,6 +3810,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3247,6 +3831,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3264,6 +3852,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3281,6 +3873,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3295,6 +3891,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3310,7 +3910,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3331,7 +3931,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3352,7 +3952,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3373,7 +3973,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3394,7 +3994,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3414,6 +4014,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3431,6 +4035,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3448,6 +4056,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3465,6 +4077,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3482,6 +4098,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3499,6 +4119,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3516,6 +4140,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3530,6 +4158,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3547,6 +4179,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3561,6 +4197,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3575,6 +4215,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3589,6 +4233,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3603,6 +4251,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3617,6 +4269,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3631,6 +4287,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3645,6 +4305,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3659,6 +4323,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3673,6 +4341,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3687,6 +4359,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3701,6 +4377,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3715,6 +4395,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3729,6 +4413,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3743,6 +4431,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3757,6 +4449,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -3771,6 +4467,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -3785,6 +4485,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -3799,6 +4503,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -3813,6 +4521,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -3827,6 +4539,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -3844,6 +4560,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -3858,6 +4578,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -3872,6 +4596,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -3886,6 +4614,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -3900,6 +4632,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -3914,6 +4650,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -3928,6 +4668,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -3942,6 +4686,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -3956,6 +4704,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -3970,6 +4722,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -3984,6 +4740,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -3998,6 +4758,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4015,6 +4779,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4032,6 +4800,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4049,6 +4821,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4066,6 +4842,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4083,6 +4863,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4100,6 +4884,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4117,6 +4905,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4134,6 +4926,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4151,6 +4947,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4168,6 +4968,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4185,6 +4989,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4202,6 +5010,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4219,6 +5031,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4236,6 +5052,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4250,6 +5070,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4264,6 +5088,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4281,6 +5109,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4298,6 +5130,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4315,6 +5151,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4332,6 +5172,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4349,6 +5193,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4366,6 +5214,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4383,6 +5235,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4400,6 +5256,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4417,6 +5277,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4434,6 +5298,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4451,6 +5319,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4468,6 +5340,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4485,6 +5361,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4502,6 +5382,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4519,6 +5403,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4537,7 +5425,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4558,7 +5446,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4579,7 +5467,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4599,6 +5487,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -4616,6 +5508,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4633,6 +5529,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4651,7 +5551,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4672,7 +5572,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4692,6 +5592,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4710,7 +5614,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4731,7 +5635,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4752,7 +5656,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4773,7 +5677,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4794,7 +5698,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4814,6 +5718,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -4828,6 +5736,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -4844,7 +5756,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4860,6 +5772,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -4874,6 +5790,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -4888,6 +5808,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -4902,6 +5826,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -4916,6 +5844,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -4933,6 +5865,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -4950,6 +5886,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -4967,6 +5907,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -4984,6 +5928,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5001,6 +5949,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5018,6 +5970,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5035,6 +5991,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5052,6 +6012,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5069,6 +6033,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5086,6 +6054,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5103,6 +6075,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5120,6 +6096,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5137,6 +6117,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5154,6 +6138,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5171,6 +6159,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5188,6 +6180,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5205,6 +6201,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5219,6 +6219,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5236,6 +6240,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5253,6 +6261,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5270,6 +6282,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5287,6 +6303,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5304,6 +6324,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5321,6 +6345,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5338,6 +6366,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5355,6 +6387,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5372,6 +6408,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5389,6 +6429,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5403,6 +6447,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5417,6 +6465,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5431,6 +6483,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5445,6 +6501,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5462,6 +6522,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5476,6 +6540,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5494,7 +6562,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5515,7 +6583,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5536,7 +6604,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5556,6 +6624,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5573,6 +6645,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5590,6 +6666,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5607,6 +6687,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5624,6 +6708,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5641,6 +6729,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5658,6 +6750,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5676,7 +6772,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5696,6 +6792,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5714,7 +6814,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5734,6 +6834,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -5752,7 +6856,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5773,7 +6877,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5794,7 +6898,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5834,7 +6938,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5851,7 +6955,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5872,7 +6976,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5888,6 +6992,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -5906,7 +7014,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5927,7 +7035,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5948,7 +7056,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5969,7 +7077,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5989,6 +7097,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6007,7 +7119,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6027,6 +7139,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6045,7 +7161,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6066,7 +7182,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6087,7 +7203,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6108,7 +7224,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6129,7 +7245,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6149,6 +7265,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6163,6 +7283,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6180,6 +7304,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6194,6 +7322,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6208,6 +7340,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6225,6 +7361,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6242,6 +7382,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6259,6 +7403,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6276,6 +7424,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6293,6 +7445,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6310,6 +7466,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6327,6 +7487,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6344,6 +7508,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
@@ -508,7 +508,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -528,6 +528,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -545,6 +549,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -562,6 +570,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -579,6 +591,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -596,6 +612,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -613,6 +633,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -630,6 +654,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -648,7 +676,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -668,6 +696,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -685,6 +717,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -720,6 +756,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -737,6 +777,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -754,6 +798,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -771,6 +819,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -788,6 +840,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -805,6 +861,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -822,6 +882,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -840,7 +904,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -861,7 +925,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -882,7 +946,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -902,6 +966,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -920,7 +988,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -940,6 +1008,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -958,7 +1030,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -979,7 +1051,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -999,6 +1071,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -1016,6 +1092,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -1033,6 +1113,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -1050,6 +1134,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -1067,6 +1155,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -1084,6 +1176,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -1101,6 +1197,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -1118,6 +1218,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -1136,7 +1240,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1157,7 +1261,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1177,6 +1281,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -1194,6 +1302,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -1211,6 +1323,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -1230,7 +1346,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1246,6 +1362,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -1263,6 +1383,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1281,7 +1405,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1302,7 +1426,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1323,7 +1447,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1344,7 +1468,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1365,7 +1489,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1385,6 +1509,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1400,7 +1528,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1416,6 +1544,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1433,6 +1565,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1450,6 +1586,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1467,6 +1607,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1484,6 +1628,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1498,6 +1646,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1515,6 +1667,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1532,6 +1688,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1549,6 +1709,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1566,6 +1730,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1583,6 +1751,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1597,6 +1769,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1611,6 +1787,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1625,6 +1805,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1639,6 +1823,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1653,6 +1841,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1667,6 +1859,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1681,6 +1877,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1695,6 +1895,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1709,6 +1913,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1723,6 +1931,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1737,6 +1949,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1751,6 +1967,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1768,6 +1988,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1785,6 +2009,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1802,6 +2030,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1819,6 +2051,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1833,6 +2069,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1847,6 +2087,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1861,6 +2105,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1875,6 +2123,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1889,6 +2141,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1903,6 +2159,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1917,6 +2177,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1931,6 +2195,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1945,6 +2213,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1959,6 +2231,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1973,6 +2249,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1987,6 +2267,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -2001,6 +2285,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -2015,6 +2303,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -2029,6 +2321,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -2043,6 +2339,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -2060,6 +2360,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -2077,6 +2381,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -2094,6 +2402,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -2111,6 +2423,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -2125,6 +2441,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -2139,6 +2459,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -2153,6 +2477,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2167,6 +2495,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2181,6 +2513,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2195,6 +2531,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2209,6 +2549,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2223,6 +2567,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2237,6 +2585,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2251,6 +2603,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2265,6 +2621,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2279,6 +2639,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2296,6 +2660,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2313,6 +2681,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2331,7 +2703,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2351,6 +2723,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2366,7 +2742,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2387,7 +2763,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2403,6 +2779,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2420,6 +2800,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2437,6 +2821,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2454,6 +2842,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2471,6 +2863,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2488,6 +2884,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2505,6 +2905,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2522,6 +2926,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2539,6 +2947,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2556,6 +2968,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2573,6 +2989,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2590,6 +3010,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2607,6 +3031,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2624,6 +3052,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2641,6 +3073,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2658,6 +3094,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2675,6 +3115,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2692,6 +3136,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2709,6 +3157,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2726,6 +3178,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2743,6 +3199,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2760,6 +3220,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2777,6 +3241,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2791,6 +3259,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2809,7 +3281,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2830,7 +3302,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2851,7 +3323,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2872,7 +3344,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2892,6 +3364,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2909,6 +3385,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2927,7 +3407,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2948,7 +3428,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2982,6 +3462,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2999,6 +3483,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3017,7 +3505,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3038,7 +3526,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3058,6 +3546,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3073,7 +3565,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3093,6 +3585,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3110,6 +3606,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3127,6 +3627,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3144,6 +3648,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3161,6 +3669,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3178,6 +3690,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3195,6 +3711,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3212,6 +3732,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3229,6 +3753,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3246,6 +3774,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3263,6 +3795,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3280,6 +3816,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3297,6 +3837,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3314,6 +3858,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3328,6 +3876,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3342,6 +3894,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3358,7 +3914,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3376,7 +3932,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3392,6 +3948,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3411,7 +3971,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3427,6 +3987,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3445,7 +4009,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3466,7 +4030,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3487,7 +4051,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3508,7 +4072,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3529,7 +4093,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3550,7 +4114,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3570,6 +4134,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3584,6 +4152,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3599,7 +4171,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3620,7 +4192,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3641,7 +4213,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3662,7 +4234,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3682,6 +4254,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3699,6 +4275,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3716,6 +4296,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3733,6 +4317,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3750,6 +4338,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3767,6 +4359,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3781,6 +4377,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3796,7 +4396,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3817,7 +4417,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3838,7 +4438,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3859,7 +4459,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3880,7 +4480,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3900,6 +4500,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3917,6 +4521,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3934,6 +4542,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3951,6 +4563,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3968,6 +4584,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3985,6 +4605,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4002,6 +4626,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4016,6 +4644,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4033,6 +4665,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4047,6 +4683,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4061,6 +4701,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4075,6 +4719,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4089,6 +4737,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4103,6 +4755,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4117,6 +4773,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4131,6 +4791,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4145,6 +4809,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4159,6 +4827,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4173,6 +4845,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4187,6 +4863,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4201,6 +4881,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4215,6 +4899,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4229,6 +4917,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4243,6 +4935,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4257,6 +4953,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4271,6 +4971,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4285,6 +4989,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4299,6 +5007,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4316,6 +5028,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4330,6 +5046,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4344,6 +5064,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4358,6 +5082,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4372,6 +5100,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4386,6 +5118,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4400,6 +5136,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4414,6 +5154,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4428,6 +5172,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4442,6 +5190,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4456,6 +5208,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4470,6 +5226,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4484,6 +5244,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4501,6 +5265,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4518,6 +5286,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4535,6 +5307,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4552,6 +5328,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4569,6 +5349,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4586,6 +5370,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4603,6 +5391,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4620,6 +5412,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4637,6 +5433,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4654,6 +5454,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4671,6 +5475,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4688,6 +5496,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4705,6 +5517,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4722,6 +5538,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4736,6 +5556,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4750,6 +5574,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4767,6 +5595,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4784,6 +5616,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4801,6 +5637,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4818,6 +5658,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4835,6 +5679,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4852,6 +5700,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4869,6 +5721,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4886,6 +5742,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4903,6 +5763,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4920,6 +5784,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4937,6 +5805,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4954,6 +5826,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4971,6 +5847,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4988,6 +5868,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5005,6 +5889,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5023,7 +5911,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5044,7 +5932,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5065,7 +5953,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5085,6 +5973,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5102,6 +5994,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5119,6 +6015,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5137,7 +6037,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5158,7 +6058,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5178,6 +6078,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5196,7 +6100,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5217,7 +6121,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5238,7 +6142,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5259,7 +6163,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5280,7 +6184,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5300,6 +6204,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5314,6 +6222,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5330,7 +6242,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5346,6 +6258,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5360,6 +6276,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5374,6 +6294,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5388,6 +6312,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5402,6 +6330,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5419,6 +6351,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5436,6 +6372,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5453,6 +6393,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5470,6 +6414,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5487,6 +6435,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5504,6 +6456,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5521,6 +6477,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5538,6 +6498,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5555,6 +6519,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5572,6 +6540,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5589,6 +6561,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5606,6 +6582,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5623,6 +6603,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5640,6 +6624,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5657,6 +6645,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5674,6 +6666,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5691,6 +6687,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5705,6 +6705,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5722,6 +6726,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5739,6 +6747,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5756,6 +6768,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5773,6 +6789,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5790,6 +6810,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5807,6 +6831,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5824,6 +6852,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5841,6 +6873,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5858,6 +6894,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5875,6 +6915,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5889,6 +6933,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5903,6 +6951,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5917,6 +6969,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5931,6 +6987,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5948,6 +7008,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5962,6 +7026,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5980,7 +7048,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6001,7 +7069,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6022,7 +7090,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6042,6 +7110,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6059,6 +7131,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6076,6 +7152,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6093,6 +7173,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6110,6 +7194,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6127,6 +7215,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6144,6 +7236,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6162,7 +7258,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6182,6 +7278,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6200,7 +7300,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6220,6 +7320,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -6238,7 +7342,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6259,7 +7363,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6280,7 +7384,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6320,7 +7424,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6337,7 +7441,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6358,7 +7462,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6374,6 +7478,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -6392,7 +7500,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6413,7 +7521,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6434,7 +7542,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6455,7 +7563,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6475,6 +7583,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6493,7 +7605,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6513,6 +7625,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6531,7 +7647,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6552,7 +7668,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6573,7 +7689,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6594,7 +7710,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6615,7 +7731,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6635,6 +7751,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6649,6 +7769,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6666,6 +7790,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6680,6 +7808,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6694,6 +7826,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6711,6 +7847,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6728,6 +7868,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6745,6 +7889,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6762,6 +7910,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6779,6 +7931,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6796,6 +7952,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6813,6 +7973,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6830,6 +7994,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
@@ -528,10 +528,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -549,10 +545,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -570,10 +562,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -591,10 +579,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -612,10 +596,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -633,10 +613,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -654,10 +630,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -696,10 +668,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -717,10 +685,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -756,10 +720,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -777,10 +737,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -798,10 +754,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -819,10 +771,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -840,10 +788,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -861,10 +805,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -882,10 +822,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -966,10 +902,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -1008,10 +940,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -1071,10 +999,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -1092,10 +1016,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -1113,10 +1033,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -1134,10 +1050,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -1155,10 +1067,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -1176,10 +1084,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -1197,10 +1101,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -1218,10 +1118,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -1281,10 +1177,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -1302,10 +1194,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -1323,10 +1211,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -1362,10 +1246,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -1383,10 +1263,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1509,10 +1385,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1544,10 +1416,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1565,10 +1433,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1586,10 +1450,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1607,10 +1467,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1628,10 +1484,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1646,10 +1498,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1667,10 +1515,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1688,10 +1532,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1709,10 +1549,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1730,10 +1566,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1751,10 +1583,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1769,10 +1597,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1787,10 +1611,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1805,10 +1625,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1823,10 +1639,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1841,10 +1653,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1859,10 +1667,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1877,10 +1681,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1895,10 +1695,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1913,10 +1709,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1931,10 +1723,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1949,10 +1737,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1967,10 +1751,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1988,10 +1768,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -2009,10 +1785,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -2030,10 +1802,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -2051,10 +1819,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -2069,10 +1833,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -2087,10 +1847,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -2105,10 +1861,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -2123,10 +1875,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -2141,10 +1889,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -2159,10 +1903,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -2177,10 +1917,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -2195,10 +1931,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -2213,10 +1945,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -2231,10 +1959,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -2249,10 +1973,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -2267,10 +1987,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -2285,10 +2001,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -2303,10 +2015,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -2321,10 +2029,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -2339,10 +2043,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -2360,10 +2060,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -2381,10 +2077,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -2402,10 +2094,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -2423,10 +2111,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -2441,10 +2125,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -2459,10 +2139,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -2477,10 +2153,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2495,10 +2167,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2513,10 +2181,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2531,10 +2195,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2549,10 +2209,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2567,10 +2223,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2585,10 +2237,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2603,10 +2251,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2621,10 +2265,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2639,10 +2279,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2660,10 +2296,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2681,10 +2313,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2723,10 +2351,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2779,10 +2403,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2800,10 +2420,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2821,10 +2437,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2842,10 +2454,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2863,10 +2471,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2884,10 +2488,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2905,10 +2505,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2926,10 +2522,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2947,10 +2539,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2968,10 +2556,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2989,10 +2573,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -3010,10 +2590,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -3031,10 +2607,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -3052,10 +2624,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -3073,10 +2641,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -3094,10 +2658,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -3115,10 +2675,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -3136,10 +2692,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -3157,10 +2709,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -3178,10 +2726,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -3199,10 +2743,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -3220,10 +2760,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -3241,10 +2777,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -3259,10 +2791,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -3364,10 +2892,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -3385,10 +2909,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -3462,10 +2982,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -3483,10 +2999,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3546,10 +3058,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3585,10 +3093,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3606,10 +3110,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3627,10 +3127,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3648,10 +3144,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3669,10 +3161,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3690,10 +3178,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3711,10 +3195,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3732,10 +3212,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3753,10 +3229,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3774,10 +3246,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3795,10 +3263,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3816,10 +3280,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3837,10 +3297,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3858,10 +3314,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3876,10 +3328,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3894,10 +3342,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3948,10 +3392,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3987,10 +3427,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -4134,10 +3570,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -4152,10 +3584,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -4254,10 +3682,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -4275,10 +3699,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -4296,10 +3716,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -4317,10 +3733,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -4338,10 +3750,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -4359,10 +3767,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -4377,10 +3781,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -4500,10 +3900,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4521,10 +3917,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4542,10 +3934,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4563,10 +3951,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4584,10 +3968,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4605,10 +3985,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4626,10 +4002,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4644,10 +4016,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4665,10 +4033,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4683,10 +4047,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4701,10 +4061,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4719,10 +4075,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4737,10 +4089,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4755,10 +4103,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4773,10 +4117,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4791,10 +4131,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4809,10 +4145,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4827,10 +4159,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4845,10 +4173,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4863,10 +4187,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4881,10 +4201,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4899,10 +4215,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4917,10 +4229,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4935,10 +4243,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4953,10 +4257,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4971,10 +4271,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4989,10 +4285,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -5007,10 +4299,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -5028,10 +4316,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -5046,10 +4330,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -5064,10 +4344,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -5082,10 +4358,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -5100,10 +4372,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -5118,10 +4386,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -5136,10 +4400,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -5154,10 +4414,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -5172,10 +4428,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -5190,10 +4442,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -5208,10 +4456,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -5226,10 +4470,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -5244,10 +4484,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -5265,10 +4501,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -5286,10 +4518,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -5307,10 +4535,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -5328,10 +4552,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -5349,10 +4569,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -5370,10 +4586,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -5391,10 +4603,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -5412,10 +4620,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -5433,10 +4637,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -5454,10 +4654,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -5475,10 +4671,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5496,10 +4688,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5517,10 +4705,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5538,10 +4722,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5556,10 +4736,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5574,10 +4750,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5595,10 +4767,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5616,10 +4784,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5637,10 +4801,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5658,10 +4818,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5679,10 +4835,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5700,10 +4852,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5721,10 +4869,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5742,10 +4886,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5763,10 +4903,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5784,10 +4920,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5805,10 +4937,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5826,10 +4954,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5847,10 +4971,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5868,10 +4988,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5889,10 +5005,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5973,10 +5085,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5994,10 +5102,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -6015,10 +5119,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -6078,10 +5178,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -6204,10 +5300,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -6222,10 +5314,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -6258,10 +5346,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -6276,10 +5360,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -6294,10 +5374,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -6312,10 +5388,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -6330,10 +5402,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -6351,10 +5419,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -6372,10 +5436,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -6393,10 +5453,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -6414,10 +5470,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -6435,10 +5487,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -6456,10 +5504,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -6477,10 +5521,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6498,10 +5538,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6519,10 +5555,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6540,10 +5572,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6561,10 +5589,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6582,10 +5606,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6603,10 +5623,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6624,10 +5640,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6645,10 +5657,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6666,10 +5674,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6687,10 +5691,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6705,10 +5705,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6726,10 +5722,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6747,10 +5739,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6768,10 +5756,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6789,10 +5773,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6810,10 +5790,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6831,10 +5807,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6852,10 +5824,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6873,10 +5841,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6894,10 +5858,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6915,10 +5875,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6933,10 +5889,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6951,10 +5903,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6969,10 +5917,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6987,10 +5931,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -7008,10 +5948,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -7026,10 +5962,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -7110,10 +6042,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -7131,10 +6059,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -7152,10 +6076,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -7173,10 +6093,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -7194,10 +6110,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -7215,10 +6127,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -7236,10 +6144,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -7278,10 +6182,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -7320,10 +6220,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -7478,10 +6374,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7583,10 +6475,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7625,10 +6513,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7751,10 +6635,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7769,10 +6649,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7790,10 +6666,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7808,10 +6680,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7826,10 +6694,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7847,10 +6711,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7868,10 +6728,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7889,10 +6745,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7910,10 +6762,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7931,10 +6779,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7952,10 +6796,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7973,10 +6813,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7994,10 +6830,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
@@ -508,7 +508,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -528,6 +528,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -545,6 +549,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -562,6 +570,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -579,6 +591,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -596,6 +612,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -613,6 +633,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -630,6 +654,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -648,7 +676,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -668,6 +696,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -685,6 +717,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -720,6 +756,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -737,6 +777,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -754,6 +798,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -771,6 +819,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -788,6 +840,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -805,6 +861,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -822,6 +882,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -840,7 +904,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -861,7 +925,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -882,7 +946,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -902,6 +966,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -920,7 +988,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -940,6 +1008,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -958,7 +1030,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -979,7 +1051,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -999,6 +1071,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -1016,6 +1092,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -1033,6 +1113,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -1050,6 +1134,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -1067,6 +1155,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -1084,6 +1176,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -1101,6 +1197,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -1118,6 +1218,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -1136,7 +1240,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1157,7 +1261,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1177,6 +1281,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -1194,6 +1302,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -1211,6 +1323,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -1230,7 +1346,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1246,6 +1362,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -1263,6 +1383,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1281,7 +1405,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1302,7 +1426,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1323,7 +1447,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1344,7 +1468,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1365,7 +1489,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1385,6 +1509,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1400,7 +1528,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1416,6 +1544,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1433,6 +1565,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1450,6 +1586,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1467,6 +1607,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1484,6 +1628,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1498,6 +1646,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1515,6 +1667,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1532,6 +1688,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1549,6 +1709,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1566,6 +1730,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1583,6 +1751,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1597,6 +1769,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1611,6 +1787,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1625,6 +1805,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1639,6 +1823,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1653,6 +1841,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1667,6 +1859,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1681,6 +1877,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1695,6 +1895,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1709,6 +1913,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1723,6 +1931,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1737,6 +1949,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1751,6 +1967,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1768,6 +1988,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1785,6 +2009,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1802,6 +2030,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1819,6 +2051,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1833,6 +2069,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1847,6 +2087,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1861,6 +2105,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1875,6 +2123,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1889,6 +2141,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1903,6 +2159,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1917,6 +2177,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1931,6 +2195,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1945,6 +2213,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1959,6 +2231,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1973,6 +2249,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1987,6 +2267,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -2001,6 +2285,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -2015,6 +2303,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -2029,6 +2321,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -2043,6 +2339,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -2060,6 +2360,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -2077,6 +2381,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -2094,6 +2402,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -2111,6 +2423,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -2125,6 +2441,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -2139,6 +2459,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -2153,6 +2477,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2167,6 +2495,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2181,6 +2513,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2195,6 +2531,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2209,6 +2549,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2223,6 +2567,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2237,6 +2585,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2251,6 +2603,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2265,6 +2621,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2279,6 +2639,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2296,6 +2660,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2313,6 +2681,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2331,7 +2703,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2351,6 +2723,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2366,7 +2742,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2387,7 +2763,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2403,6 +2779,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2420,6 +2800,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2437,6 +2821,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2454,6 +2842,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2471,6 +2863,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2488,6 +2884,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2505,6 +2905,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2522,6 +2926,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2539,6 +2947,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2556,6 +2968,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2573,6 +2989,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2590,6 +3010,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2607,6 +3031,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2624,6 +3052,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2641,6 +3073,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2658,6 +3094,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2675,6 +3115,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2692,6 +3136,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2709,6 +3157,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2726,6 +3178,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2743,6 +3199,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2760,6 +3220,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2777,6 +3241,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2791,6 +3259,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2809,7 +3281,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2830,7 +3302,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2851,7 +3323,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2872,7 +3344,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2892,6 +3364,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2909,6 +3385,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2927,7 +3407,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2948,7 +3428,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2982,6 +3462,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2999,6 +3483,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3017,7 +3505,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3038,7 +3526,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3058,6 +3546,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3073,7 +3565,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3093,6 +3585,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3110,6 +3606,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3127,6 +3627,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3144,6 +3648,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3161,6 +3669,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3178,6 +3690,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3195,6 +3711,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3212,6 +3732,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3229,6 +3753,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3246,6 +3774,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3263,6 +3795,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3280,6 +3816,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3297,6 +3837,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3314,6 +3858,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3328,6 +3876,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3342,6 +3894,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3358,7 +3914,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3376,7 +3932,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3392,6 +3948,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3411,7 +3971,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3427,6 +3987,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3445,7 +4009,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3466,7 +4030,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3487,7 +4051,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3508,7 +4072,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3529,7 +4093,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3550,7 +4114,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3570,6 +4134,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3584,6 +4152,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3599,7 +4171,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3620,7 +4192,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3641,7 +4213,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3662,7 +4234,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3682,6 +4254,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3699,6 +4275,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3716,6 +4296,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3733,6 +4317,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3750,6 +4338,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3767,6 +4359,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3781,6 +4377,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3796,7 +4396,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3817,7 +4417,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3838,7 +4438,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3859,7 +4459,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3880,7 +4480,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3900,6 +4500,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3917,6 +4521,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3934,6 +4542,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3951,6 +4563,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3968,6 +4584,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3985,6 +4605,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4002,6 +4626,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4016,6 +4644,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4033,6 +4665,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4047,6 +4683,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4061,6 +4701,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4075,6 +4719,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4089,6 +4737,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4103,6 +4755,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4117,6 +4773,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4131,6 +4791,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4145,6 +4809,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4159,6 +4827,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4173,6 +4845,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4187,6 +4863,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4201,6 +4881,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4215,6 +4899,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4229,6 +4917,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4243,6 +4935,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4257,6 +4953,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4271,6 +4971,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4285,6 +4989,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4299,6 +5007,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4316,6 +5028,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4330,6 +5046,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4344,6 +5064,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4358,6 +5082,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4372,6 +5100,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4386,6 +5118,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4400,6 +5136,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4414,6 +5154,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4428,6 +5172,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4442,6 +5190,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4456,6 +5208,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4470,6 +5226,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4484,6 +5244,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4501,6 +5265,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4518,6 +5286,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4535,6 +5307,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4552,6 +5328,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4569,6 +5349,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4586,6 +5370,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4603,6 +5391,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4620,6 +5412,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4637,6 +5433,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4654,6 +5454,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4671,6 +5475,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4688,6 +5496,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4705,6 +5517,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4722,6 +5538,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4736,6 +5556,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4750,6 +5574,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4767,6 +5595,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4784,6 +5616,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4801,6 +5637,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4818,6 +5658,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4835,6 +5679,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4852,6 +5700,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4869,6 +5721,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4886,6 +5742,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4903,6 +5763,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4920,6 +5784,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4937,6 +5805,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4954,6 +5826,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4971,6 +5847,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4988,6 +5868,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5005,6 +5889,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5023,7 +5911,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5044,7 +5932,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5065,7 +5953,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5085,6 +5973,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5102,6 +5994,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5119,6 +6015,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5137,7 +6037,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5158,7 +6058,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5178,6 +6078,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5196,7 +6100,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5217,7 +6121,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5238,7 +6142,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5259,7 +6163,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5280,7 +6184,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5300,6 +6204,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5314,6 +6222,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5330,7 +6242,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5346,6 +6258,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5360,6 +6276,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5374,6 +6294,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5388,6 +6312,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5402,6 +6330,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5419,6 +6351,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5436,6 +6372,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5453,6 +6393,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5470,6 +6414,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5487,6 +6435,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5504,6 +6456,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5521,6 +6477,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5538,6 +6498,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5555,6 +6519,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5572,6 +6540,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5589,6 +6561,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5606,6 +6582,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5623,6 +6603,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5640,6 +6624,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5657,6 +6645,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5674,6 +6666,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5691,6 +6687,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5705,6 +6705,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5722,6 +6726,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5739,6 +6747,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5756,6 +6768,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5773,6 +6789,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5790,6 +6810,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5807,6 +6831,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5824,6 +6852,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5841,6 +6873,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5858,6 +6894,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5875,6 +6915,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5889,6 +6933,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5903,6 +6951,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5917,6 +6969,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5931,6 +6987,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5948,6 +7008,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5962,6 +7026,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5980,7 +7048,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6001,7 +7069,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6022,7 +7090,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6042,6 +7110,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6059,6 +7131,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6076,6 +7152,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6093,6 +7173,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6110,6 +7194,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6127,6 +7215,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6144,6 +7236,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6162,7 +7258,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6182,6 +7278,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6200,7 +7300,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6220,6 +7320,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -6238,7 +7342,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6259,7 +7363,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6280,7 +7384,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6320,7 +7424,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6337,7 +7441,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6358,7 +7462,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6374,6 +7478,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -6392,7 +7500,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6413,7 +7521,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6434,7 +7542,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6455,7 +7563,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6475,6 +7583,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6493,7 +7605,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6513,6 +7625,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6531,7 +7647,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6552,7 +7668,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6573,7 +7689,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6594,7 +7710,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6615,7 +7731,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6635,6 +7751,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6649,6 +7769,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6666,6 +7790,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6680,6 +7808,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6694,6 +7826,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6711,6 +7847,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6728,6 +7868,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6745,6 +7889,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6762,6 +7910,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6779,6 +7931,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6796,6 +7952,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6813,6 +7973,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6830,6 +7994,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
@@ -528,10 +528,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -549,10 +545,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -570,10 +562,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -591,10 +579,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -612,10 +596,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -633,10 +613,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -654,10 +630,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -696,10 +668,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -717,10 +685,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -756,10 +720,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -777,10 +737,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -798,10 +754,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -819,10 +771,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -840,10 +788,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -861,10 +805,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -882,10 +822,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -966,10 +902,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -1008,10 +940,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -1071,10 +999,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -1092,10 +1016,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -1113,10 +1033,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -1134,10 +1050,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -1155,10 +1067,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -1176,10 +1084,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -1197,10 +1101,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -1218,10 +1118,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -1281,10 +1177,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -1302,10 +1194,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -1323,10 +1211,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -1362,10 +1246,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -1383,10 +1263,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1509,10 +1385,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1544,10 +1416,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1565,10 +1433,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1586,10 +1450,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1607,10 +1467,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1628,10 +1484,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1646,10 +1498,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1667,10 +1515,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1688,10 +1532,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1709,10 +1549,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1730,10 +1566,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1751,10 +1583,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1769,10 +1597,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1787,10 +1611,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1805,10 +1625,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1823,10 +1639,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1841,10 +1653,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1859,10 +1667,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1877,10 +1681,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1895,10 +1695,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1913,10 +1709,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1931,10 +1723,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1949,10 +1737,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1967,10 +1751,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1988,10 +1768,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -2009,10 +1785,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -2030,10 +1802,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -2051,10 +1819,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -2069,10 +1833,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -2087,10 +1847,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -2105,10 +1861,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -2123,10 +1875,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -2141,10 +1889,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -2159,10 +1903,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -2177,10 +1917,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -2195,10 +1931,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -2213,10 +1945,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -2231,10 +1959,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -2249,10 +1973,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -2267,10 +1987,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -2285,10 +2001,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -2303,10 +2015,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -2321,10 +2029,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -2339,10 +2043,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -2360,10 +2060,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -2381,10 +2077,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -2402,10 +2094,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -2423,10 +2111,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -2441,10 +2125,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -2459,10 +2139,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -2477,10 +2153,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2495,10 +2167,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2513,10 +2181,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2531,10 +2195,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2549,10 +2209,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2567,10 +2223,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2585,10 +2237,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2603,10 +2251,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2621,10 +2265,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2639,10 +2279,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2660,10 +2296,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2681,10 +2313,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2723,10 +2351,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2779,10 +2403,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2800,10 +2420,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2821,10 +2437,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2842,10 +2454,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2863,10 +2471,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2884,10 +2488,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2905,10 +2505,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2926,10 +2522,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2947,10 +2539,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2968,10 +2556,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2989,10 +2573,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -3010,10 +2590,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -3031,10 +2607,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -3052,10 +2624,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -3073,10 +2641,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -3094,10 +2658,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -3115,10 +2675,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -3136,10 +2692,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -3157,10 +2709,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -3178,10 +2726,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -3199,10 +2743,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -3220,10 +2760,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -3241,10 +2777,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -3259,10 +2791,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -3364,10 +2892,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -3385,10 +2909,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -3462,10 +2982,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -3483,10 +2999,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3546,10 +3058,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3585,10 +3093,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3606,10 +3110,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3627,10 +3127,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3648,10 +3144,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3669,10 +3161,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3690,10 +3178,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3711,10 +3195,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3732,10 +3212,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3753,10 +3229,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3774,10 +3246,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3795,10 +3263,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3816,10 +3280,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3837,10 +3297,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3858,10 +3314,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3876,10 +3328,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3894,10 +3342,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3948,10 +3392,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3987,10 +3427,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -4134,10 +3570,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -4152,10 +3584,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -4254,10 +3682,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -4275,10 +3699,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -4296,10 +3716,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -4317,10 +3733,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -4338,10 +3750,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -4359,10 +3767,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -4377,10 +3781,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -4500,10 +3900,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4521,10 +3917,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4542,10 +3934,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4563,10 +3951,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4584,10 +3968,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4605,10 +3985,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4626,10 +4002,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4644,10 +4016,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4665,10 +4033,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4683,10 +4047,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4701,10 +4061,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4719,10 +4075,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4737,10 +4089,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4755,10 +4103,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4773,10 +4117,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4791,10 +4131,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4809,10 +4145,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4827,10 +4159,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4845,10 +4173,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4863,10 +4187,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4881,10 +4201,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4899,10 +4215,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4917,10 +4229,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4935,10 +4243,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4953,10 +4257,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4971,10 +4271,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4989,10 +4285,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -5007,10 +4299,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -5028,10 +4316,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -5046,10 +4330,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -5064,10 +4344,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -5082,10 +4358,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -5100,10 +4372,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -5118,10 +4386,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -5136,10 +4400,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -5154,10 +4414,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -5172,10 +4428,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -5190,10 +4442,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -5208,10 +4456,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -5226,10 +4470,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -5244,10 +4484,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -5265,10 +4501,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -5286,10 +4518,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -5307,10 +4535,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -5328,10 +4552,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -5349,10 +4569,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -5370,10 +4586,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -5391,10 +4603,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -5412,10 +4620,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -5433,10 +4637,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -5454,10 +4654,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -5475,10 +4671,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5496,10 +4688,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5517,10 +4705,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5538,10 +4722,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5556,10 +4736,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5574,10 +4750,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5595,10 +4767,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5616,10 +4784,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5637,10 +4801,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5658,10 +4818,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5679,10 +4835,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5700,10 +4852,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5721,10 +4869,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5742,10 +4886,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5763,10 +4903,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5784,10 +4920,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5805,10 +4937,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5826,10 +4954,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5847,10 +4971,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5868,10 +4988,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5889,10 +5005,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5973,10 +5085,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5994,10 +5102,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -6015,10 +5119,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -6078,10 +5178,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -6204,10 +5300,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -6222,10 +5314,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -6258,10 +5346,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -6276,10 +5360,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -6294,10 +5374,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -6312,10 +5388,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -6330,10 +5402,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -6351,10 +5419,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -6372,10 +5436,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -6393,10 +5453,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -6414,10 +5470,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -6435,10 +5487,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -6456,10 +5504,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -6477,10 +5521,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6498,10 +5538,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6519,10 +5555,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6540,10 +5572,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6561,10 +5589,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6582,10 +5606,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6603,10 +5623,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6624,10 +5640,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6645,10 +5657,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6666,10 +5674,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6687,10 +5691,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6705,10 +5705,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6726,10 +5722,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6747,10 +5739,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6768,10 +5756,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6789,10 +5773,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6810,10 +5790,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6831,10 +5807,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6852,10 +5824,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6873,10 +5841,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6894,10 +5858,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6915,10 +5875,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6933,10 +5889,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6951,10 +5903,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6969,10 +5917,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6987,10 +5931,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -7008,10 +5948,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -7026,10 +5962,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -7110,10 +6042,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -7131,10 +6059,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -7152,10 +6076,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -7173,10 +6093,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -7194,10 +6110,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -7215,10 +6127,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -7236,10 +6144,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -7278,10 +6182,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -7320,10 +6220,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -7478,10 +6374,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7583,10 +6475,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7625,10 +6513,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7751,10 +6635,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7769,10 +6649,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7790,10 +6666,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7808,10 +6680,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7826,10 +6694,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7847,10 +6711,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7868,10 +6728,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7889,10 +6745,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7910,10 +6762,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7931,10 +6779,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7952,10 +6796,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7973,10 +6813,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7994,10 +6830,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
@@ -528,10 +528,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -549,10 +545,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -570,10 +562,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -591,10 +579,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -612,10 +596,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -633,10 +613,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -654,10 +630,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -696,10 +668,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -717,10 +685,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -756,10 +720,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -777,10 +737,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -798,10 +754,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -819,10 +771,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -840,10 +788,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -861,10 +805,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -882,10 +822,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -966,10 +902,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -1008,10 +940,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -1071,10 +999,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -1092,10 +1016,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -1113,10 +1033,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -1134,10 +1050,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -1155,10 +1067,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -1176,10 +1084,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -1197,10 +1101,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -1218,10 +1118,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -1281,10 +1177,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -1302,10 +1194,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -1323,10 +1211,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -1362,10 +1246,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -1383,10 +1263,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1509,10 +1385,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1544,10 +1416,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1565,10 +1433,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1586,10 +1450,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1607,10 +1467,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1628,10 +1484,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1646,10 +1498,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1667,10 +1515,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1688,10 +1532,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1709,10 +1549,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1730,10 +1566,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1751,10 +1583,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1769,10 +1597,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1787,10 +1611,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1805,10 +1625,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1823,10 +1639,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1841,10 +1653,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1859,10 +1667,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1877,10 +1681,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1895,10 +1695,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1913,10 +1709,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1931,10 +1723,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1949,10 +1737,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1967,10 +1751,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1988,10 +1768,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -2009,10 +1785,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -2030,10 +1802,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -2051,10 +1819,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -2069,10 +1833,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -2087,10 +1847,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -2105,10 +1861,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -2123,10 +1875,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -2141,10 +1889,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -2159,10 +1903,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -2177,10 +1917,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -2195,10 +1931,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -2213,10 +1945,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -2231,10 +1959,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -2249,10 +1973,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -2267,10 +1987,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -2285,10 +2001,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -2303,10 +2015,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -2321,10 +2029,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -2339,10 +2043,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -2360,10 +2060,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -2381,10 +2077,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -2402,10 +2094,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -2423,10 +2111,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -2441,10 +2125,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -2459,10 +2139,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -2477,10 +2153,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2495,10 +2167,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2513,10 +2181,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2531,10 +2195,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2549,10 +2209,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2567,10 +2223,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2585,10 +2237,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2603,10 +2251,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2621,10 +2265,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2639,10 +2279,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2660,10 +2296,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2681,10 +2313,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2723,10 +2351,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2779,10 +2403,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2800,10 +2420,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2821,10 +2437,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2842,10 +2454,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2863,10 +2471,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2884,10 +2488,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2905,10 +2505,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2926,10 +2522,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2947,10 +2539,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2968,10 +2556,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2989,10 +2573,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -3010,10 +2590,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -3031,10 +2607,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -3052,10 +2624,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -3073,10 +2641,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -3094,10 +2658,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -3115,10 +2675,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -3136,10 +2692,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -3157,10 +2709,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -3178,10 +2726,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -3199,10 +2743,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -3220,10 +2760,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -3241,10 +2777,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -3259,10 +2791,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -3364,10 +2892,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -3385,10 +2909,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -3462,10 +2982,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -3483,10 +2999,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3546,10 +3058,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3585,10 +3093,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3606,10 +3110,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3627,10 +3127,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3648,10 +3144,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3669,10 +3161,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3690,10 +3178,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3711,10 +3195,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3732,10 +3212,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3753,10 +3229,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3774,10 +3246,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3795,10 +3263,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3816,10 +3280,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3837,10 +3297,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3858,10 +3314,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3876,10 +3328,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3894,10 +3342,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3948,10 +3392,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3987,10 +3427,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -4134,10 +3570,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -4152,10 +3584,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -4254,10 +3682,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -4275,10 +3699,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -4296,10 +3716,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -4317,10 +3733,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -4338,10 +3750,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -4359,10 +3767,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -4377,10 +3781,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -4500,10 +3900,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4521,10 +3917,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4542,10 +3934,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4563,10 +3951,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4584,10 +3968,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4605,10 +3985,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4626,10 +4002,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4644,10 +4016,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4665,10 +4033,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4683,10 +4047,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4701,10 +4061,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4719,10 +4075,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4737,10 +4089,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4755,10 +4103,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4773,10 +4117,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4791,10 +4131,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4809,10 +4145,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4827,10 +4159,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4845,10 +4173,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4863,10 +4187,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4881,10 +4201,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4899,10 +4215,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4917,10 +4229,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4935,10 +4243,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4953,10 +4257,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4971,10 +4271,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4989,10 +4285,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -5007,10 +4299,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -5028,10 +4316,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -5046,10 +4330,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -5064,10 +4344,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -5082,10 +4358,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -5100,10 +4372,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -5118,10 +4386,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -5136,10 +4400,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -5154,10 +4414,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -5172,10 +4428,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -5190,10 +4442,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -5208,10 +4456,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -5226,10 +4470,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -5244,10 +4484,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -5265,10 +4501,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -5286,10 +4518,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -5307,10 +4535,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -5328,10 +4552,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -5349,10 +4569,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -5370,10 +4586,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -5391,10 +4603,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -5412,10 +4620,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -5433,10 +4637,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -5454,10 +4654,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -5475,10 +4671,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5496,10 +4688,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5517,10 +4705,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5538,10 +4722,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5556,10 +4736,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5574,10 +4750,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5595,10 +4767,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5616,10 +4784,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5637,10 +4801,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5658,10 +4818,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5679,10 +4835,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5700,10 +4852,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5721,10 +4869,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5742,10 +4886,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5763,10 +4903,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5784,10 +4920,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5805,10 +4937,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5826,10 +4954,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5847,10 +4971,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5868,10 +4988,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5889,10 +5005,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5973,10 +5085,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5994,10 +5102,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -6015,10 +5119,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -6078,10 +5178,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -6204,10 +5300,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -6222,10 +5314,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -6258,10 +5346,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -6276,10 +5360,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -6294,10 +5374,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -6312,10 +5388,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -6330,10 +5402,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -6351,10 +5419,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -6372,10 +5436,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -6393,10 +5453,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -6414,10 +5470,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -6435,10 +5487,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -6456,10 +5504,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -6477,10 +5521,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6498,10 +5538,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6519,10 +5555,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6540,10 +5572,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6561,10 +5589,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6582,10 +5606,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6603,10 +5623,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6624,10 +5640,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6645,10 +5657,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6666,10 +5674,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6687,10 +5691,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6705,10 +5705,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6726,10 +5722,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6747,10 +5739,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6768,10 +5756,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6789,10 +5773,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6810,10 +5790,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6831,10 +5807,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6852,10 +5824,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6873,10 +5841,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6894,10 +5858,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6915,10 +5875,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6933,10 +5889,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6951,10 +5903,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6969,10 +5917,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6987,10 +5931,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -7008,10 +5948,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -7026,10 +5962,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -7110,10 +6042,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -7131,10 +6059,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -7152,10 +6076,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -7173,10 +6093,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -7194,10 +6110,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -7215,10 +6127,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -7236,10 +6144,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -7278,10 +6182,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -7320,10 +6220,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -7478,10 +6374,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7583,10 +6475,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7625,10 +6513,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7751,10 +6635,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7769,10 +6649,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7790,10 +6666,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7808,10 +6680,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7826,10 +6694,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7847,10 +6711,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7868,10 +6728,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7889,10 +6745,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7910,10 +6762,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7931,10 +6779,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7952,10 +6796,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7973,10 +6813,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7994,10 +6830,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
@@ -508,7 +508,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -528,6 +528,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -545,6 +549,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -562,6 +570,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -579,6 +591,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -596,6 +612,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -613,6 +633,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -630,6 +654,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -648,7 +676,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -668,6 +696,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -685,6 +717,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -720,6 +756,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -737,6 +777,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -754,6 +798,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -771,6 +819,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -788,6 +840,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -805,6 +861,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -822,6 +882,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -840,7 +904,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -861,7 +925,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -882,7 +946,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -902,6 +966,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -920,7 +988,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -940,6 +1008,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -958,7 +1030,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -979,7 +1051,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -999,6 +1071,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -1016,6 +1092,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -1033,6 +1113,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -1050,6 +1134,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -1067,6 +1155,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -1084,6 +1176,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -1101,6 +1197,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -1118,6 +1218,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -1136,7 +1240,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1157,7 +1261,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1177,6 +1281,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -1194,6 +1302,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -1211,6 +1323,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -1230,7 +1346,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1246,6 +1362,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -1263,6 +1383,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1281,7 +1405,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1302,7 +1426,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1323,7 +1447,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1344,7 +1468,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1365,7 +1489,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1385,6 +1509,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1400,7 +1528,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1416,6 +1544,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1433,6 +1565,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1450,6 +1586,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1467,6 +1607,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1484,6 +1628,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1498,6 +1646,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1515,6 +1667,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1532,6 +1688,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1549,6 +1709,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1566,6 +1730,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1583,6 +1751,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1597,6 +1769,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1611,6 +1787,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1625,6 +1805,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1639,6 +1823,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1653,6 +1841,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1667,6 +1859,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1681,6 +1877,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1695,6 +1895,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1709,6 +1913,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1723,6 +1931,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1737,6 +1949,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1751,6 +1967,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1768,6 +1988,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1785,6 +2009,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1802,6 +2030,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1819,6 +2051,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1833,6 +2069,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1847,6 +2087,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1861,6 +2105,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1875,6 +2123,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1889,6 +2141,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1903,6 +2159,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1917,6 +2177,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1931,6 +2195,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1945,6 +2213,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1959,6 +2231,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1973,6 +2249,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1987,6 +2267,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -2001,6 +2285,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -2015,6 +2303,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -2029,6 +2321,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -2043,6 +2339,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -2060,6 +2360,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -2077,6 +2381,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -2094,6 +2402,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -2111,6 +2423,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -2125,6 +2441,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -2139,6 +2459,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -2153,6 +2477,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2167,6 +2495,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2181,6 +2513,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2195,6 +2531,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2209,6 +2549,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2223,6 +2567,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2237,6 +2585,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2251,6 +2603,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2265,6 +2621,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2279,6 +2639,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2296,6 +2660,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2313,6 +2681,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2331,7 +2703,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2351,6 +2723,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2366,7 +2742,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2387,7 +2763,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2403,6 +2779,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2420,6 +2800,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2437,6 +2821,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2454,6 +2842,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2471,6 +2863,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2488,6 +2884,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2505,6 +2905,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2522,6 +2926,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2539,6 +2947,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2556,6 +2968,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2573,6 +2989,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2590,6 +3010,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2607,6 +3031,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2624,6 +3052,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2641,6 +3073,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2658,6 +3094,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2675,6 +3115,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2692,6 +3136,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2709,6 +3157,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2726,6 +3178,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2743,6 +3199,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2760,6 +3220,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2777,6 +3241,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2791,6 +3259,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2809,7 +3281,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2830,7 +3302,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2851,7 +3323,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2872,7 +3344,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2892,6 +3364,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2909,6 +3385,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2927,7 +3407,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2948,7 +3428,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2982,6 +3462,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2999,6 +3483,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3017,7 +3505,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3038,7 +3526,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3058,6 +3546,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3073,7 +3565,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3093,6 +3585,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3110,6 +3606,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3127,6 +3627,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3144,6 +3648,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3161,6 +3669,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3178,6 +3690,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3195,6 +3711,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3212,6 +3732,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3229,6 +3753,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3246,6 +3774,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3263,6 +3795,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3280,6 +3816,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3297,6 +3837,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3314,6 +3858,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3328,6 +3876,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3342,6 +3894,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3358,7 +3914,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3376,7 +3932,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3392,6 +3948,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3411,7 +3971,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3427,6 +3987,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3445,7 +4009,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3466,7 +4030,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3487,7 +4051,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3508,7 +4072,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3529,7 +4093,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3550,7 +4114,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3570,6 +4134,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3584,6 +4152,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3599,7 +4171,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3620,7 +4192,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3641,7 +4213,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3662,7 +4234,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3682,6 +4254,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3699,6 +4275,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3716,6 +4296,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3733,6 +4317,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3750,6 +4338,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3767,6 +4359,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3781,6 +4377,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3796,7 +4396,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3817,7 +4417,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3838,7 +4438,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3859,7 +4459,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3880,7 +4480,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3900,6 +4500,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3917,6 +4521,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3934,6 +4542,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3951,6 +4563,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3968,6 +4584,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3985,6 +4605,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4002,6 +4626,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4016,6 +4644,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4033,6 +4665,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4047,6 +4683,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4061,6 +4701,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4075,6 +4719,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4089,6 +4737,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4103,6 +4755,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4117,6 +4773,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4131,6 +4791,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4145,6 +4809,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4159,6 +4827,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4173,6 +4845,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4187,6 +4863,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4201,6 +4881,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4215,6 +4899,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4229,6 +4917,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4243,6 +4935,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4257,6 +4953,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4271,6 +4971,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4285,6 +4989,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4299,6 +5007,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4316,6 +5028,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4330,6 +5046,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4344,6 +5064,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4358,6 +5082,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4372,6 +5100,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4386,6 +5118,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4400,6 +5136,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4414,6 +5154,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4428,6 +5172,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4442,6 +5190,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4456,6 +5208,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4470,6 +5226,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4484,6 +5244,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4501,6 +5265,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4518,6 +5286,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4535,6 +5307,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4552,6 +5328,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4569,6 +5349,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4586,6 +5370,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4603,6 +5391,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4620,6 +5412,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4637,6 +5433,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4654,6 +5454,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4671,6 +5475,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4688,6 +5496,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4705,6 +5517,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4722,6 +5538,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4736,6 +5556,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4750,6 +5574,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4767,6 +5595,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4784,6 +5616,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4801,6 +5637,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4818,6 +5658,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4835,6 +5679,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4852,6 +5700,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4869,6 +5721,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4886,6 +5742,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4903,6 +5763,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4920,6 +5784,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4937,6 +5805,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4954,6 +5826,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4971,6 +5847,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4988,6 +5868,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5005,6 +5889,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5023,7 +5911,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5044,7 +5932,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5065,7 +5953,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5085,6 +5973,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5102,6 +5994,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5119,6 +6015,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5137,7 +6037,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5158,7 +6058,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5178,6 +6078,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5196,7 +6100,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5217,7 +6121,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5238,7 +6142,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5259,7 +6163,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5280,7 +6184,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5300,6 +6204,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5314,6 +6222,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5330,7 +6242,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5346,6 +6258,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5360,6 +6276,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5374,6 +6294,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5388,6 +6312,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5402,6 +6330,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5419,6 +6351,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5436,6 +6372,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5453,6 +6393,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5470,6 +6414,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5487,6 +6435,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5504,6 +6456,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5521,6 +6477,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5538,6 +6498,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5555,6 +6519,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5572,6 +6540,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5589,6 +6561,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5606,6 +6582,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5623,6 +6603,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5640,6 +6624,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5657,6 +6645,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5674,6 +6666,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5691,6 +6687,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5705,6 +6705,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5722,6 +6726,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5739,6 +6747,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5756,6 +6768,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5773,6 +6789,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5790,6 +6810,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5807,6 +6831,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5824,6 +6852,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5841,6 +6873,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5858,6 +6894,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5875,6 +6915,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5889,6 +6933,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5903,6 +6951,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5917,6 +6969,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5931,6 +6987,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5948,6 +7008,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5962,6 +7026,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5980,7 +7048,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6001,7 +7069,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6022,7 +7090,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6042,6 +7110,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6059,6 +7131,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6076,6 +7152,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6093,6 +7173,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6110,6 +7194,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6127,6 +7215,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6144,6 +7236,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6162,7 +7258,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6182,6 +7278,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6200,7 +7300,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6220,6 +7320,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -6238,7 +7342,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6259,7 +7363,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6280,7 +7384,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6320,7 +7424,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6337,7 +7441,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6358,7 +7462,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6374,6 +7478,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -6392,7 +7500,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6413,7 +7521,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6434,7 +7542,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6455,7 +7563,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6475,6 +7583,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6493,7 +7605,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6513,6 +7625,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6531,7 +7647,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6552,7 +7668,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6573,7 +7689,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6594,7 +7710,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6615,7 +7731,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6635,6 +7751,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6649,6 +7769,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6666,6 +7790,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6680,6 +7808,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6694,6 +7826,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6711,6 +7847,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6728,6 +7868,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6745,6 +7889,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6762,6 +7910,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6779,6 +7931,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6796,6 +7952,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6813,6 +7973,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6830,6 +7994,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
@@ -528,10 +528,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -549,10 +545,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -570,10 +562,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -591,10 +579,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -612,10 +596,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -633,10 +613,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -654,10 +630,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -696,10 +668,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -717,10 +685,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -756,10 +720,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -777,10 +737,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -798,10 +754,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -819,10 +771,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -840,10 +788,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -861,10 +805,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -882,10 +822,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -966,10 +902,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -1008,10 +940,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -1071,10 +999,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -1092,10 +1016,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -1113,10 +1033,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -1134,10 +1050,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -1155,10 +1067,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -1176,10 +1084,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -1197,10 +1101,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -1218,10 +1118,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -1281,10 +1177,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -1302,10 +1194,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -1323,10 +1211,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -1362,10 +1246,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -1383,10 +1263,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1509,10 +1385,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1544,10 +1416,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1565,10 +1433,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1586,10 +1450,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1607,10 +1467,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1628,10 +1484,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1646,10 +1498,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1667,10 +1515,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1688,10 +1532,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1709,10 +1549,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1730,10 +1566,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1751,10 +1583,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1769,10 +1597,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1787,10 +1611,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1805,10 +1625,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1823,10 +1639,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1841,10 +1653,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1859,10 +1667,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1877,10 +1681,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1895,10 +1695,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1913,10 +1709,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1931,10 +1723,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1949,10 +1737,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1967,10 +1751,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1988,10 +1768,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -2009,10 +1785,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -2030,10 +1802,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -2051,10 +1819,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -2069,10 +1833,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -2087,10 +1847,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -2105,10 +1861,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -2123,10 +1875,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -2141,10 +1889,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -2159,10 +1903,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -2177,10 +1917,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -2195,10 +1931,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -2213,10 +1945,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -2231,10 +1959,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -2249,10 +1973,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -2267,10 +1987,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -2285,10 +2001,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -2303,10 +2015,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -2321,10 +2029,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -2339,10 +2043,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -2360,10 +2060,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -2381,10 +2077,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -2402,10 +2094,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -2423,10 +2111,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -2441,10 +2125,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -2459,10 +2139,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -2477,10 +2153,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2495,10 +2167,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2513,10 +2181,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2531,10 +2195,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2549,10 +2209,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2567,10 +2223,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2585,10 +2237,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2603,10 +2251,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2621,10 +2265,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2639,10 +2279,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2660,10 +2296,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2681,10 +2313,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2723,10 +2351,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2779,10 +2403,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2800,10 +2420,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2821,10 +2437,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2842,10 +2454,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2863,10 +2471,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2884,10 +2488,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2905,10 +2505,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2926,10 +2522,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2947,10 +2539,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2968,10 +2556,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2989,10 +2573,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -3010,10 +2590,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -3031,10 +2607,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -3052,10 +2624,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -3073,10 +2641,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -3094,10 +2658,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -3115,10 +2675,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -3136,10 +2692,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -3157,10 +2709,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -3178,10 +2726,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -3199,10 +2743,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -3220,10 +2760,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -3241,10 +2777,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -3259,10 +2791,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -3364,10 +2892,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -3385,10 +2909,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -3462,10 +2982,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -3483,10 +2999,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3546,10 +3058,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3585,10 +3093,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3606,10 +3110,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3627,10 +3127,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3648,10 +3144,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3669,10 +3161,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3690,10 +3178,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3711,10 +3195,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3732,10 +3212,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3753,10 +3229,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3774,10 +3246,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3795,10 +3263,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3816,10 +3280,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3837,10 +3297,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3858,10 +3314,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3876,10 +3328,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3894,10 +3342,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3948,10 +3392,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3987,10 +3427,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -4134,10 +3570,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -4152,10 +3584,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -4254,10 +3682,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -4275,10 +3699,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -4296,10 +3716,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -4317,10 +3733,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -4338,10 +3750,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -4359,10 +3767,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -4377,10 +3781,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -4500,10 +3900,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4521,10 +3917,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4542,10 +3934,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4563,10 +3951,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4584,10 +3968,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4605,10 +3985,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4626,10 +4002,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4644,10 +4016,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4665,10 +4033,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4683,10 +4047,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4701,10 +4061,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4719,10 +4075,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4737,10 +4089,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4755,10 +4103,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4773,10 +4117,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4791,10 +4131,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4809,10 +4145,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4827,10 +4159,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4845,10 +4173,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4863,10 +4187,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4881,10 +4201,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4899,10 +4215,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4917,10 +4229,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4935,10 +4243,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4953,10 +4257,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4971,10 +4271,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4989,10 +4285,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -5007,10 +4299,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -5028,10 +4316,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -5046,10 +4330,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -5064,10 +4344,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -5082,10 +4358,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -5100,10 +4372,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -5118,10 +4386,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -5136,10 +4400,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -5154,10 +4414,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -5172,10 +4428,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -5190,10 +4442,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -5208,10 +4456,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -5226,10 +4470,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -5244,10 +4484,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -5265,10 +4501,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -5286,10 +4518,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -5307,10 +4535,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -5328,10 +4552,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -5349,10 +4569,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -5370,10 +4586,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -5391,10 +4603,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -5412,10 +4620,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -5433,10 +4637,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -5454,10 +4654,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -5475,10 +4671,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5496,10 +4688,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5517,10 +4705,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5538,10 +4722,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5556,10 +4736,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5574,10 +4750,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5595,10 +4767,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5616,10 +4784,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5637,10 +4801,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5658,10 +4818,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5679,10 +4835,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5700,10 +4852,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5721,10 +4869,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5742,10 +4886,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5763,10 +4903,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5784,10 +4920,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5805,10 +4937,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5826,10 +4954,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5847,10 +4971,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5868,10 +4988,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5889,10 +5005,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5973,10 +5085,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5994,10 +5102,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -6015,10 +5119,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -6078,10 +5178,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -6204,10 +5300,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -6222,10 +5314,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -6258,10 +5346,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -6276,10 +5360,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -6294,10 +5374,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -6312,10 +5388,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -6330,10 +5402,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -6351,10 +5419,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -6372,10 +5436,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -6393,10 +5453,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -6414,10 +5470,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -6435,10 +5487,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -6456,10 +5504,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -6477,10 +5521,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6498,10 +5538,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6519,10 +5555,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6540,10 +5572,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6561,10 +5589,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6582,10 +5606,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6603,10 +5623,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6624,10 +5640,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6645,10 +5657,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6666,10 +5674,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6687,10 +5691,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6705,10 +5705,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6726,10 +5722,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6747,10 +5739,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6768,10 +5756,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6789,10 +5773,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6810,10 +5790,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6831,10 +5807,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6852,10 +5824,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6873,10 +5841,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6894,10 +5858,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6915,10 +5875,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6933,10 +5889,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6951,10 +5903,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6969,10 +5917,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6987,10 +5931,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -7008,10 +5948,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -7026,10 +5962,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -7110,10 +6042,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -7131,10 +6059,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -7152,10 +6076,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -7173,10 +6093,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -7194,10 +6110,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -7215,10 +6127,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -7236,10 +6144,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -7278,10 +6182,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -7320,10 +6220,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -7478,10 +6374,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7583,10 +6475,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7625,10 +6513,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7751,10 +6635,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7769,10 +6649,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7790,10 +6666,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7808,10 +6680,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7826,10 +6694,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7847,10 +6711,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7868,10 +6728,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7889,10 +6745,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7910,10 +6762,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7931,10 +6779,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7952,10 +6796,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7973,10 +6813,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7994,10 +6830,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
@@ -508,7 +508,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -528,6 +528,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -545,6 +549,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -562,6 +570,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -579,6 +591,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -596,6 +612,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -613,6 +633,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -630,6 +654,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -648,7 +676,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -668,6 +696,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -685,6 +717,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -720,6 +756,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -737,6 +777,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -754,6 +798,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -771,6 +819,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -788,6 +840,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -805,6 +861,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -822,6 +882,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -840,7 +904,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -861,7 +925,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -882,7 +946,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -902,6 +966,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -920,7 +988,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -940,6 +1008,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -958,7 +1030,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -979,7 +1051,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -999,6 +1071,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -1016,6 +1092,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -1033,6 +1113,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -1050,6 +1134,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -1067,6 +1155,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -1084,6 +1176,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -1101,6 +1197,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -1118,6 +1218,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -1136,7 +1240,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1157,7 +1261,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1177,6 +1281,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -1194,6 +1302,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -1211,6 +1323,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -1230,7 +1346,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1246,6 +1362,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -1263,6 +1383,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1281,7 +1405,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1302,7 +1426,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1323,7 +1447,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1344,7 +1468,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1365,7 +1489,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1385,6 +1509,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1400,7 +1528,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1416,6 +1544,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1433,6 +1565,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1450,6 +1586,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1467,6 +1607,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1484,6 +1628,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1498,6 +1646,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1515,6 +1667,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1532,6 +1688,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1549,6 +1709,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1566,6 +1730,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1583,6 +1751,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1597,6 +1769,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1611,6 +1787,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1625,6 +1805,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1639,6 +1823,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1653,6 +1841,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1667,6 +1859,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1681,6 +1877,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1695,6 +1895,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1709,6 +1913,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1723,6 +1931,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1737,6 +1949,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1751,6 +1967,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1768,6 +1988,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1785,6 +2009,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1802,6 +2030,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1819,6 +2051,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1833,6 +2069,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1847,6 +2087,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1861,6 +2105,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1875,6 +2123,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1889,6 +2141,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1903,6 +2159,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1917,6 +2177,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1931,6 +2195,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1945,6 +2213,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1959,6 +2231,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1973,6 +2249,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1987,6 +2267,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -2001,6 +2285,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -2015,6 +2303,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -2029,6 +2321,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -2043,6 +2339,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -2060,6 +2360,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -2077,6 +2381,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -2094,6 +2402,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -2111,6 +2423,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -2125,6 +2441,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -2139,6 +2459,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -2153,6 +2477,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2167,6 +2495,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2181,6 +2513,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2195,6 +2531,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2209,6 +2549,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2223,6 +2567,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2237,6 +2585,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2251,6 +2603,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2265,6 +2621,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2279,6 +2639,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2296,6 +2660,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2313,6 +2681,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2331,7 +2703,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2351,6 +2723,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2366,7 +2742,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2387,7 +2763,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2403,6 +2779,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2420,6 +2800,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2437,6 +2821,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2454,6 +2842,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2471,6 +2863,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2488,6 +2884,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2505,6 +2905,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2522,6 +2926,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2539,6 +2947,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2556,6 +2968,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2573,6 +2989,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2590,6 +3010,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2607,6 +3031,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2624,6 +3052,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2641,6 +3073,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2658,6 +3094,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2675,6 +3115,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2692,6 +3136,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2709,6 +3157,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2726,6 +3178,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2743,6 +3199,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2760,6 +3220,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2777,6 +3241,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2791,6 +3259,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2809,7 +3281,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2830,7 +3302,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2851,7 +3323,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2872,7 +3344,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2892,6 +3364,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2909,6 +3385,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2927,7 +3407,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2948,7 +3428,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2982,6 +3462,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2999,6 +3483,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3017,7 +3505,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3038,7 +3526,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3058,6 +3546,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3073,7 +3565,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3093,6 +3585,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3110,6 +3606,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3127,6 +3627,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3144,6 +3648,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3161,6 +3669,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3178,6 +3690,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3195,6 +3711,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3212,6 +3732,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3229,6 +3753,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3246,6 +3774,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3263,6 +3795,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3280,6 +3816,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3297,6 +3837,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3314,6 +3858,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3328,6 +3876,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3342,6 +3894,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3358,7 +3914,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3376,7 +3932,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3392,6 +3948,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3411,7 +3971,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3427,6 +3987,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3445,7 +4009,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3466,7 +4030,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3487,7 +4051,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3508,7 +4072,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3529,7 +4093,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3550,7 +4114,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3570,6 +4134,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3584,6 +4152,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3599,7 +4171,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3620,7 +4192,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3641,7 +4213,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3662,7 +4234,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3682,6 +4254,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3699,6 +4275,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3716,6 +4296,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3733,6 +4317,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3750,6 +4338,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3767,6 +4359,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3781,6 +4377,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3796,7 +4396,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3817,7 +4417,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3838,7 +4438,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3859,7 +4459,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3880,7 +4480,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3900,6 +4500,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3917,6 +4521,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3934,6 +4542,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3951,6 +4563,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3968,6 +4584,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3985,6 +4605,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4002,6 +4626,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4016,6 +4644,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4033,6 +4665,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4047,6 +4683,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4061,6 +4701,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4075,6 +4719,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4089,6 +4737,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4103,6 +4755,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4117,6 +4773,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4131,6 +4791,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4145,6 +4809,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4159,6 +4827,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4173,6 +4845,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4187,6 +4863,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4201,6 +4881,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4215,6 +4899,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4229,6 +4917,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4243,6 +4935,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4257,6 +4953,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4271,6 +4971,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4285,6 +4989,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4299,6 +5007,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4316,6 +5028,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4330,6 +5046,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4344,6 +5064,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4358,6 +5082,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4372,6 +5100,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4386,6 +5118,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4400,6 +5136,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4414,6 +5154,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4428,6 +5172,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4442,6 +5190,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4456,6 +5208,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4470,6 +5226,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4484,6 +5244,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4501,6 +5265,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4518,6 +5286,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4535,6 +5307,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4552,6 +5328,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4569,6 +5349,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4586,6 +5370,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4603,6 +5391,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4620,6 +5412,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4637,6 +5433,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4654,6 +5454,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4671,6 +5475,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4688,6 +5496,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4705,6 +5517,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4722,6 +5538,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4736,6 +5556,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4750,6 +5574,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4767,6 +5595,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4784,6 +5616,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4801,6 +5637,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4818,6 +5658,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4835,6 +5679,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4852,6 +5700,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4869,6 +5721,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4886,6 +5742,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4903,6 +5763,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4920,6 +5784,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4937,6 +5805,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4954,6 +5826,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4971,6 +5847,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4988,6 +5868,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5005,6 +5889,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5023,7 +5911,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5044,7 +5932,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5065,7 +5953,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5085,6 +5973,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5102,6 +5994,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5119,6 +6015,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5137,7 +6037,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5158,7 +6058,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5178,6 +6078,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5196,7 +6100,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5217,7 +6121,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5238,7 +6142,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5259,7 +6163,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5280,7 +6184,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5300,6 +6204,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5314,6 +6222,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5330,7 +6242,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5346,6 +6258,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5360,6 +6276,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5374,6 +6294,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5388,6 +6312,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5402,6 +6330,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5419,6 +6351,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5436,6 +6372,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5453,6 +6393,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5470,6 +6414,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5487,6 +6435,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5504,6 +6456,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5521,6 +6477,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5538,6 +6498,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5555,6 +6519,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5572,6 +6540,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5589,6 +6561,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5606,6 +6582,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5623,6 +6603,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5640,6 +6624,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5657,6 +6645,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5674,6 +6666,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5691,6 +6687,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5705,6 +6705,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5722,6 +6726,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5739,6 +6747,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5756,6 +6768,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5773,6 +6789,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5790,6 +6810,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5807,6 +6831,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5824,6 +6852,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5841,6 +6873,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5858,6 +6894,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5875,6 +6915,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5889,6 +6933,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5903,6 +6951,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5917,6 +6969,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5931,6 +6987,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5948,6 +7008,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5962,6 +7026,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5980,7 +7048,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6001,7 +7069,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6022,7 +7090,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6042,6 +7110,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6059,6 +7131,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6076,6 +7152,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6093,6 +7173,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6110,6 +7194,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6127,6 +7215,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6144,6 +7236,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6162,7 +7258,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6182,6 +7278,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6200,7 +7300,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6220,6 +7320,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -6238,7 +7342,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6259,7 +7363,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6280,7 +7384,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6320,7 +7424,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6337,7 +7441,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6358,7 +7462,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6374,6 +7478,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -6392,7 +7500,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6413,7 +7521,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6434,7 +7542,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6455,7 +7563,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6475,6 +7583,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6493,7 +7605,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6513,6 +7625,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6531,7 +7647,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6552,7 +7668,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6573,7 +7689,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6594,7 +7710,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6615,7 +7731,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6635,6 +7751,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6649,6 +7769,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6666,6 +7790,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6680,6 +7808,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6694,6 +7826,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6711,6 +7847,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6728,6 +7868,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6745,6 +7889,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6762,6 +7910,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6779,6 +7931,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6796,6 +7952,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6813,6 +7973,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6830,6 +7994,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
@@ -52,10 +52,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -73,10 +69,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -94,10 +86,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -115,10 +103,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -136,10 +120,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -157,10 +137,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -178,10 +154,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -220,10 +192,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -241,10 +209,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -280,10 +244,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -301,10 +261,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -322,10 +278,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -343,10 +295,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -364,10 +312,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -385,10 +329,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -406,10 +346,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -490,10 +426,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -532,10 +464,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -595,10 +523,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -616,10 +540,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -637,10 +557,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -658,10 +574,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -679,10 +591,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -700,10 +608,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -721,10 +625,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -742,10 +642,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -805,10 +701,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -826,10 +718,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -847,10 +735,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -886,10 +770,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -907,10 +787,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1033,10 +909,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1068,10 +940,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1089,10 +957,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1110,10 +974,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1131,10 +991,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1152,10 +1008,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1170,10 +1022,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1191,10 +1039,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1212,10 +1056,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1233,10 +1073,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1254,10 +1090,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1275,10 +1107,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1293,10 +1121,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1311,10 +1135,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1329,10 +1149,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1347,10 +1163,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1365,10 +1177,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1383,10 +1191,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1401,10 +1205,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1419,10 +1219,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1437,10 +1233,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1455,10 +1247,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1473,10 +1261,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1491,10 +1275,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1512,10 +1292,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1533,10 +1309,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1554,10 +1326,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1575,10 +1343,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1593,10 +1357,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1611,10 +1371,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1629,10 +1385,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1647,10 +1399,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1665,10 +1413,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1683,10 +1427,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1701,10 +1441,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1719,10 +1455,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1737,10 +1469,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1755,10 +1483,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1773,10 +1497,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1791,10 +1511,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1809,10 +1525,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1827,10 +1539,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1845,10 +1553,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1863,10 +1567,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1884,10 +1584,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1905,10 +1601,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1926,10 +1618,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1944,10 +1632,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1962,10 +1646,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1980,10 +1660,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1998,10 +1674,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2016,10 +1688,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2034,10 +1702,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2052,10 +1716,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2070,10 +1730,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2088,10 +1744,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2106,10 +1758,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2124,10 +1772,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2142,10 +1786,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2163,10 +1803,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2184,10 +1820,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2226,10 +1858,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2282,10 +1910,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2303,10 +1927,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2324,10 +1944,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2345,10 +1961,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2366,10 +1978,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2387,10 +1995,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2408,10 +2012,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2429,10 +2029,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2450,10 +2046,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2471,10 +2063,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2492,10 +2080,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2513,10 +2097,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2534,10 +2114,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2555,10 +2131,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2576,10 +2148,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2597,10 +2165,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2618,10 +2182,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2639,10 +2199,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2660,10 +2216,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2681,10 +2233,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2702,10 +2250,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2723,10 +2267,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2744,10 +2284,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2762,10 +2298,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2867,10 +2399,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2888,10 +2416,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2965,10 +2489,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2986,10 +2506,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3049,10 +2565,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3088,10 +2600,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3109,10 +2617,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3130,10 +2634,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3151,10 +2651,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3172,10 +2668,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3193,10 +2685,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3214,10 +2702,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3235,10 +2719,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3256,10 +2736,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3277,10 +2753,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3298,10 +2770,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3319,10 +2787,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3340,10 +2804,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3361,10 +2821,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3379,10 +2835,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3397,10 +2849,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3451,10 +2899,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3490,10 +2934,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3637,10 +3077,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3655,10 +3091,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3757,10 +3189,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3778,10 +3206,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3799,10 +3223,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3820,10 +3240,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3841,10 +3257,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3862,10 +3274,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3880,10 +3288,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -4003,10 +3407,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4024,10 +3424,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4045,10 +3441,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4066,10 +3458,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4087,10 +3475,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4108,10 +3492,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4129,10 +3509,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4147,10 +3523,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4168,10 +3540,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4186,10 +3554,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4204,10 +3568,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4222,10 +3582,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4240,10 +3596,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4258,10 +3610,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4276,10 +3624,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4294,10 +3638,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4312,10 +3652,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4330,10 +3666,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4348,10 +3680,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4366,10 +3694,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4384,10 +3708,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4402,10 +3722,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4420,10 +3736,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4438,10 +3750,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4456,10 +3764,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4474,10 +3778,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4492,10 +3792,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4510,10 +3806,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4528,10 +3820,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4549,10 +3837,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4567,10 +3851,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4585,10 +3865,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4603,10 +3879,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4621,10 +3893,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4639,10 +3907,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4657,10 +3921,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4675,10 +3935,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4693,10 +3949,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4711,10 +3963,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4729,10 +3977,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4747,10 +3991,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4765,10 +4005,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4786,10 +4022,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4807,10 +4039,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4828,10 +4056,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4849,10 +4073,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4870,10 +4090,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4891,10 +4107,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4912,10 +4124,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4933,10 +4141,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4954,10 +4158,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4975,10 +4175,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4996,10 +4192,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5017,10 +4209,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5038,10 +4226,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5059,10 +4243,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5077,10 +4257,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5095,10 +4271,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5116,10 +4288,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5137,10 +4305,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5158,10 +4322,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5179,10 +4339,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5200,10 +4356,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5221,10 +4373,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5242,10 +4390,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5263,10 +4407,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5284,10 +4424,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5305,10 +4441,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5326,10 +4458,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5347,10 +4475,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5368,10 +4492,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5389,10 +4509,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5410,10 +4526,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5494,10 +4606,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5515,10 +4623,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5536,10 +4640,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5599,10 +4699,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5725,10 +4821,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5743,10 +4835,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5779,10 +4867,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5797,10 +4881,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5815,10 +4895,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5833,10 +4909,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5851,10 +4923,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5872,10 +4940,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5893,10 +4957,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5914,10 +4974,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5935,10 +4991,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5956,10 +5008,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5977,10 +5025,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5998,10 +5042,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6019,10 +5059,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6040,10 +5076,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6061,10 +5093,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6082,10 +5110,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6103,10 +5127,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6124,10 +5144,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6145,10 +5161,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6166,10 +5178,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6187,10 +5195,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6208,10 +5212,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6226,10 +5226,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6247,10 +5243,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6268,10 +5260,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6289,10 +5277,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6310,10 +5294,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6331,10 +5311,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6352,10 +5328,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6373,10 +5345,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6394,10 +5362,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6415,10 +5379,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6436,10 +5396,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6454,10 +5410,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6472,10 +5424,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6490,10 +5438,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6508,10 +5452,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6529,10 +5469,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6547,10 +5483,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6631,10 +5563,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6652,10 +5580,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6673,10 +5597,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6694,10 +5614,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6715,10 +5631,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6736,10 +5648,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6757,10 +5665,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6799,10 +5703,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6841,10 +5741,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -6999,10 +5895,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7104,10 +5996,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7146,10 +6034,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7272,10 +6156,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7290,10 +6170,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7311,10 +6187,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7329,10 +6201,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7347,10 +6215,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7368,10 +6232,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7389,10 +6249,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7410,10 +6266,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7431,10 +6283,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7452,10 +6300,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7473,10 +6317,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7494,10 +6334,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7515,10 +6351,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
@@ -32,7 +32,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52,6 +52,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -69,6 +73,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -86,6 +94,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -103,6 +115,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -120,6 +136,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -137,6 +157,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -154,6 +178,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -172,7 +200,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -192,6 +220,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -209,6 +241,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -244,6 +280,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -261,6 +301,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -278,6 +322,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -295,6 +343,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -312,6 +364,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -329,6 +385,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -346,6 +406,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -364,7 +428,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -385,7 +449,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -406,7 +470,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -426,6 +490,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -444,7 +512,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -464,6 +532,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -482,7 +554,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -503,7 +575,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -523,6 +595,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -540,6 +616,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -557,6 +637,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -574,6 +658,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -591,6 +679,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -608,6 +700,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -625,6 +721,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -642,6 +742,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -660,7 +764,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -681,7 +785,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -701,6 +805,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -718,6 +826,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -735,6 +847,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -754,7 +870,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -770,6 +886,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -787,6 +907,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -805,7 +929,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -826,7 +950,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -847,7 +971,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -868,7 +992,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -889,7 +1013,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -909,6 +1033,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -924,7 +1052,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -940,6 +1068,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -957,6 +1089,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -974,6 +1110,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -991,6 +1131,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1008,6 +1152,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1022,6 +1170,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1039,6 +1191,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1056,6 +1212,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1073,6 +1233,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1090,6 +1254,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1107,6 +1275,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1121,6 +1293,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1135,6 +1311,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1149,6 +1329,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1163,6 +1347,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1177,6 +1365,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1191,6 +1383,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1205,6 +1401,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1219,6 +1419,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1233,6 +1437,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1247,6 +1455,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1261,6 +1473,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1275,6 +1491,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1292,6 +1512,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1309,6 +1533,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1326,6 +1554,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1343,6 +1575,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1357,6 +1593,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1371,6 +1611,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1385,6 +1629,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1399,6 +1647,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1413,6 +1665,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1427,6 +1683,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1441,6 +1701,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1455,6 +1719,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1469,6 +1737,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1483,6 +1755,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1497,6 +1773,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1511,6 +1791,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1525,6 +1809,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1539,6 +1827,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1553,6 +1845,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1567,6 +1863,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1584,6 +1884,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1601,6 +1905,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1618,6 +1926,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1632,6 +1944,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1646,6 +1962,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1660,6 +1980,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1674,6 +1998,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1688,6 +2016,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -1702,6 +2034,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -1716,6 +2052,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -1730,6 +2070,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -1744,6 +2088,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -1758,6 +2106,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -1772,6 +2124,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -1786,6 +2142,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -1803,6 +2163,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -1820,6 +2184,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -1838,7 +2206,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1858,6 +2226,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -1873,7 +2245,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1894,7 +2266,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1910,6 +2282,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -1927,6 +2303,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -1944,6 +2324,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -1961,6 +2345,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -1978,6 +2366,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -1995,6 +2387,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2012,6 +2408,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2029,6 +2429,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2046,6 +2450,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2063,6 +2471,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2080,6 +2492,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2097,6 +2513,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2114,6 +2534,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2131,6 +2555,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2148,6 +2576,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2165,6 +2597,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2182,6 +2618,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2199,6 +2639,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2216,6 +2660,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2233,6 +2681,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2250,6 +2702,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2267,6 +2723,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2284,6 +2744,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2298,6 +2762,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2316,7 +2784,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2337,7 +2805,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2358,7 +2826,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2379,7 +2847,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2399,6 +2867,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2416,6 +2888,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2434,7 +2910,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2455,7 +2931,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2489,6 +2965,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2506,6 +2986,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -2524,7 +3008,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2545,7 +3029,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2565,6 +3049,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2580,7 +3068,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2600,6 +3088,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2617,6 +3109,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2634,6 +3130,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2651,6 +3151,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2668,6 +3172,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2685,6 +3193,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2702,6 +3214,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2719,6 +3235,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2736,6 +3256,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2753,6 +3277,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -2770,6 +3298,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -2787,6 +3319,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -2804,6 +3340,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -2821,6 +3361,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -2835,6 +3379,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -2849,6 +3397,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -2865,7 +3417,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2883,7 +3435,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2899,6 +3451,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -2918,7 +3474,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2934,6 +3490,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -2952,7 +3512,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2973,7 +3533,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2994,7 +3554,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3015,7 +3575,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3036,7 +3596,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3057,7 +3617,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3077,6 +3637,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3091,6 +3655,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3106,7 +3674,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3127,7 +3695,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3148,7 +3716,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3169,7 +3737,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3189,6 +3757,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3206,6 +3778,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3223,6 +3799,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3240,6 +3820,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3257,6 +3841,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3274,6 +3862,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3288,6 +3880,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3303,7 +3899,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3324,7 +3920,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3345,7 +3941,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3366,7 +3962,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3387,7 +3983,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3407,6 +4003,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3424,6 +4024,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3441,6 +4045,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3458,6 +4066,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3475,6 +4087,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3492,6 +4108,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3509,6 +4129,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3523,6 +4147,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3540,6 +4168,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3554,6 +4186,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3568,6 +4204,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3582,6 +4222,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3596,6 +4240,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3610,6 +4258,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3624,6 +4276,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3638,6 +4294,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3652,6 +4312,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3666,6 +4330,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3680,6 +4348,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3694,6 +4366,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3708,6 +4384,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3722,6 +4402,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3736,6 +4420,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3750,6 +4438,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -3764,6 +4456,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -3778,6 +4474,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -3792,6 +4492,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -3806,6 +4510,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -3820,6 +4528,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -3837,6 +4549,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -3851,6 +4567,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -3865,6 +4585,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -3879,6 +4603,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -3893,6 +4621,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -3907,6 +4639,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -3921,6 +4657,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -3935,6 +4675,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -3949,6 +4693,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -3963,6 +4711,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -3977,6 +4729,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -3991,6 +4747,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4005,6 +4765,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4022,6 +4786,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4039,6 +4807,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4056,6 +4828,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4073,6 +4849,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4090,6 +4870,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4107,6 +4891,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4124,6 +4912,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4141,6 +4933,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4158,6 +4954,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4175,6 +4975,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4192,6 +4996,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4209,6 +5017,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4226,6 +5038,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4243,6 +5059,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4257,6 +5077,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4271,6 +5095,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4288,6 +5116,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4305,6 +5137,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4322,6 +5158,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4339,6 +5179,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4356,6 +5200,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4373,6 +5221,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4390,6 +5242,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4407,6 +5263,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4424,6 +5284,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4441,6 +5305,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4458,6 +5326,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4475,6 +5347,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4492,6 +5368,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4509,6 +5389,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4526,6 +5410,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4544,7 +5432,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4565,7 +5453,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4586,7 +5474,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4606,6 +5494,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -4623,6 +5515,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4640,6 +5536,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4658,7 +5558,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4679,7 +5579,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4699,6 +5599,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4717,7 +5621,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4738,7 +5642,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4759,7 +5663,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4780,7 +5684,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4801,7 +5705,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4821,6 +5725,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -4835,6 +5743,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -4851,7 +5763,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4867,6 +5779,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -4881,6 +5797,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -4895,6 +5815,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -4909,6 +5833,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -4923,6 +5851,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -4940,6 +5872,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -4957,6 +5893,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -4974,6 +5914,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -4991,6 +5935,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5008,6 +5956,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5025,6 +5977,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5042,6 +5998,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5059,6 +6019,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5076,6 +6040,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5093,6 +6061,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5110,6 +6082,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5127,6 +6103,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5144,6 +6124,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5161,6 +6145,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5178,6 +6166,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5195,6 +6187,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5212,6 +6208,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5226,6 +6226,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5243,6 +6247,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5260,6 +6268,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5277,6 +6289,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5294,6 +6310,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5311,6 +6331,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5328,6 +6352,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5345,6 +6373,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5362,6 +6394,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5379,6 +6415,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5396,6 +6436,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5410,6 +6454,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5424,6 +6472,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5438,6 +6490,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5452,6 +6508,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5469,6 +6529,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5483,6 +6547,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5501,7 +6569,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5522,7 +6590,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5543,7 +6611,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5563,6 +6631,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5580,6 +6652,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5597,6 +6673,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5614,6 +6694,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5631,6 +6715,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5648,6 +6736,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5665,6 +6757,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5683,7 +6779,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5703,6 +6799,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5721,7 +6821,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5741,6 +6841,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -5759,7 +6863,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5780,7 +6884,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5801,7 +6905,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5841,7 +6945,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5858,7 +6962,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5879,7 +6983,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5895,6 +6999,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -5913,7 +7021,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5934,7 +7042,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5955,7 +7063,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5976,7 +7084,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5996,6 +7104,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6014,7 +7126,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6034,6 +7146,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6052,7 +7168,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6073,7 +7189,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6094,7 +7210,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6115,7 +7231,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6136,7 +7252,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6156,6 +7272,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6170,6 +7290,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6187,6 +7311,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6201,6 +7329,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6215,6 +7347,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6232,6 +7368,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6249,6 +7389,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6266,6 +7410,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6283,6 +7431,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6300,6 +7452,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6317,6 +7473,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6334,6 +7494,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6351,6 +7515,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
@@ -32,7 +32,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52,6 +52,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -69,6 +73,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -86,6 +94,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -103,6 +115,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -120,6 +136,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -137,6 +157,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -154,6 +178,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -172,7 +200,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -192,6 +220,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -209,6 +241,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -244,6 +280,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -261,6 +301,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -278,6 +322,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -295,6 +343,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -312,6 +364,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -329,6 +385,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -346,6 +406,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -364,7 +428,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -385,7 +449,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -406,7 +470,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -426,6 +490,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -444,7 +512,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -464,6 +532,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -482,7 +554,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -503,7 +575,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -523,6 +595,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -540,6 +616,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -557,6 +637,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -574,6 +658,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -591,6 +679,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -608,6 +700,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -625,6 +721,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -642,6 +742,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -660,7 +764,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -681,7 +785,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -701,6 +805,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -718,6 +826,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -735,6 +847,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -754,7 +870,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -770,6 +886,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -787,6 +907,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -805,7 +929,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -826,7 +950,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -847,7 +971,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -868,7 +992,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -889,7 +1013,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -909,6 +1033,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -924,7 +1052,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -940,6 +1068,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -957,6 +1089,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -974,6 +1110,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -991,6 +1131,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1008,6 +1152,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1022,6 +1170,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1039,6 +1191,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1056,6 +1212,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1073,6 +1233,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1090,6 +1254,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1107,6 +1275,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1121,6 +1293,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1135,6 +1311,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1149,6 +1329,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1163,6 +1347,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1177,6 +1365,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1191,6 +1383,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1205,6 +1401,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1219,6 +1419,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1233,6 +1437,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1247,6 +1455,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1261,6 +1473,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1275,6 +1491,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1292,6 +1512,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1309,6 +1533,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1326,6 +1554,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1343,6 +1575,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1357,6 +1593,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1371,6 +1611,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1385,6 +1629,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1399,6 +1647,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1413,6 +1665,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1427,6 +1683,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1441,6 +1701,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1455,6 +1719,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1469,6 +1737,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1483,6 +1755,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1497,6 +1773,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1511,6 +1791,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1525,6 +1809,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1539,6 +1827,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1553,6 +1845,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1567,6 +1863,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1584,6 +1884,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1601,6 +1905,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1618,6 +1926,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1635,6 +1947,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1649,6 +1965,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1663,6 +1983,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1677,6 +2001,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1691,6 +2019,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1705,6 +2037,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -1719,6 +2055,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -1733,6 +2073,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -1747,6 +2091,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -1761,6 +2109,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -1775,6 +2127,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -1789,6 +2145,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -1803,6 +2163,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -1820,6 +2184,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -1838,7 +2206,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1858,6 +2226,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -1873,7 +2245,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1894,7 +2266,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1910,6 +2282,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -1927,6 +2303,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -1944,6 +2324,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -1961,6 +2345,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -1978,6 +2366,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -1995,6 +2387,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2012,6 +2408,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2029,6 +2429,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2046,6 +2450,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2063,6 +2471,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2080,6 +2492,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2097,6 +2513,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2114,6 +2534,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2131,6 +2555,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2148,6 +2576,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2165,6 +2597,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2182,6 +2618,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2199,6 +2639,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2216,6 +2660,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2233,6 +2681,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2250,6 +2702,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2267,6 +2723,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2284,6 +2744,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2298,6 +2762,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2316,7 +2784,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2337,7 +2805,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2358,7 +2826,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2379,7 +2847,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2399,6 +2867,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2416,6 +2888,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2434,7 +2910,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2455,7 +2931,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2489,6 +2965,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2506,6 +2986,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -2524,7 +3008,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2545,7 +3029,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2565,6 +3049,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2580,7 +3068,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2600,6 +3088,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2617,6 +3109,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2634,6 +3130,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2651,6 +3151,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2668,6 +3172,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2685,6 +3193,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2702,6 +3214,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2719,6 +3235,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2736,6 +3256,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2753,6 +3277,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -2770,6 +3298,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -2787,6 +3319,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -2804,6 +3340,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -2821,6 +3361,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -2835,6 +3379,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -2849,6 +3397,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -2865,7 +3417,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2883,7 +3435,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2899,6 +3451,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -2918,7 +3474,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2934,6 +3490,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -2952,7 +3512,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2973,7 +3533,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2994,7 +3554,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3015,7 +3575,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3036,7 +3596,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3057,7 +3617,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3077,6 +3637,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3091,6 +3655,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3106,7 +3674,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3127,7 +3695,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3148,7 +3716,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3169,7 +3737,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3189,6 +3757,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3206,6 +3778,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3223,6 +3799,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3240,6 +3820,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3257,6 +3841,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3274,6 +3862,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3288,6 +3880,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3303,7 +3899,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3324,7 +3920,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3345,7 +3941,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3366,7 +3962,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3387,7 +3983,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3407,6 +4003,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3424,6 +4024,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3441,6 +4045,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3458,6 +4066,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3475,6 +4087,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3492,6 +4108,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3509,6 +4129,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3523,6 +4147,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3540,6 +4168,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3554,6 +4186,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3568,6 +4204,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3582,6 +4222,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3596,6 +4240,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3610,6 +4258,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3624,6 +4276,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3638,6 +4294,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3652,6 +4312,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3666,6 +4330,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3680,6 +4348,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3694,6 +4366,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3708,6 +4384,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3722,6 +4402,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3736,6 +4420,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3750,6 +4438,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -3764,6 +4456,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -3778,6 +4474,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -3792,6 +4492,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -3806,6 +4510,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -3820,6 +4528,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -3837,6 +4549,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -3851,6 +4567,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -3865,6 +4585,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -3879,6 +4603,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -3893,6 +4621,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -3907,6 +4639,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -3921,6 +4657,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -3935,6 +4675,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -3949,6 +4693,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -3963,6 +4711,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -3977,6 +4729,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -3991,6 +4747,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4005,6 +4765,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4022,6 +4786,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4039,6 +4807,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4056,6 +4828,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4073,6 +4849,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4090,6 +4870,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4107,6 +4891,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4124,6 +4912,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4141,6 +4933,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4158,6 +4954,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4175,6 +4975,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4192,6 +4996,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4209,6 +5017,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4226,6 +5038,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4243,6 +5059,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4257,6 +5077,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4271,6 +5095,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4288,6 +5116,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4305,6 +5137,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4322,6 +5158,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4339,6 +5179,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4356,6 +5200,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4373,6 +5221,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4390,6 +5242,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4407,6 +5263,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4424,6 +5284,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4441,6 +5305,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4458,6 +5326,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4475,6 +5347,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4492,6 +5368,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4509,6 +5389,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4526,6 +5410,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4544,7 +5432,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4565,7 +5453,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4586,7 +5474,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4606,6 +5494,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -4623,6 +5515,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4640,6 +5536,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4658,7 +5558,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4679,7 +5579,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4699,6 +5599,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4717,7 +5621,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4738,7 +5642,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4759,7 +5663,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4780,7 +5684,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4801,7 +5705,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4821,6 +5725,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -4835,6 +5743,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -4851,7 +5763,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4867,6 +5779,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -4881,6 +5797,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -4895,6 +5815,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -4909,6 +5833,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -4923,6 +5851,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -4940,6 +5872,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -4957,6 +5893,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -4974,6 +5914,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -4991,6 +5935,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5008,6 +5956,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5025,6 +5977,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5042,6 +5998,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5059,6 +6019,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5076,6 +6040,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5093,6 +6061,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5110,6 +6082,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5127,6 +6103,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5144,6 +6124,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5161,6 +6145,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5178,6 +6166,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5195,6 +6187,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5212,6 +6208,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5226,6 +6226,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5243,6 +6247,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5260,6 +6268,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5277,6 +6289,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5294,6 +6310,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5311,6 +6331,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5328,6 +6352,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5345,6 +6373,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5362,6 +6394,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5379,6 +6415,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5396,6 +6436,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5410,6 +6454,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5424,6 +6472,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5438,6 +6490,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5452,6 +6508,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5469,6 +6529,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5483,6 +6547,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5501,7 +6569,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5522,7 +6590,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5543,7 +6611,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5563,6 +6631,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5580,6 +6652,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5597,6 +6673,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5614,6 +6694,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5631,6 +6715,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5648,6 +6736,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5665,6 +6757,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5683,7 +6779,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5703,6 +6799,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5721,7 +6821,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5741,6 +6841,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -5759,7 +6863,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5780,7 +6884,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5801,7 +6905,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5841,7 +6945,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5858,7 +6962,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5879,7 +6983,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5895,6 +6999,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -5913,7 +7021,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5948,7 +7056,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5969,7 +7077,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5990,7 +7098,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6010,6 +7118,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6028,7 +7140,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6048,6 +7160,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6066,7 +7182,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6087,7 +7203,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6108,7 +7224,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6129,7 +7245,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6150,7 +7266,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6170,6 +7286,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6184,6 +7304,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6201,6 +7325,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6215,6 +7343,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6229,6 +7361,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6246,6 +7382,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6263,6 +7403,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6280,6 +7424,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6297,6 +7445,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6314,6 +7466,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6331,6 +7487,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6348,6 +7508,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6365,6 +7529,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
@@ -52,10 +52,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -73,10 +69,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -94,10 +86,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -115,10 +103,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -136,10 +120,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -157,10 +137,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -178,10 +154,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -220,10 +192,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -241,10 +209,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -280,10 +244,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -301,10 +261,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -322,10 +278,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -343,10 +295,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -364,10 +312,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -385,10 +329,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -406,10 +346,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -490,10 +426,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -532,10 +464,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -595,10 +523,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -616,10 +540,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -637,10 +557,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -658,10 +574,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -679,10 +591,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -700,10 +608,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -721,10 +625,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -742,10 +642,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -805,10 +701,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -826,10 +718,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -847,10 +735,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -886,10 +770,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -907,10 +787,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1033,10 +909,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1068,10 +940,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1089,10 +957,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1110,10 +974,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1131,10 +991,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1152,10 +1008,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1170,10 +1022,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1191,10 +1039,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1212,10 +1056,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1233,10 +1073,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1254,10 +1090,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1275,10 +1107,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1293,10 +1121,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1311,10 +1135,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1329,10 +1149,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1347,10 +1163,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1365,10 +1177,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1383,10 +1191,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1401,10 +1205,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1419,10 +1219,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1437,10 +1233,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1455,10 +1247,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1473,10 +1261,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1491,10 +1275,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1512,10 +1292,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1533,10 +1309,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1554,10 +1326,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1575,10 +1343,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1593,10 +1357,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1611,10 +1371,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1629,10 +1385,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1647,10 +1399,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1665,10 +1413,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1683,10 +1427,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1701,10 +1441,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1719,10 +1455,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1737,10 +1469,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1755,10 +1483,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1773,10 +1497,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1791,10 +1511,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1809,10 +1525,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1827,10 +1539,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1845,10 +1553,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1863,10 +1567,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1884,10 +1584,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1905,10 +1601,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1926,10 +1618,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1947,10 +1635,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1965,10 +1649,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1983,10 +1663,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -2001,10 +1677,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2019,10 +1691,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2037,10 +1705,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2055,10 +1719,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2073,10 +1733,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2091,10 +1747,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2109,10 +1761,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2127,10 +1775,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2145,10 +1789,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2163,10 +1803,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2184,10 +1820,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2226,10 +1858,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2282,10 +1910,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2303,10 +1927,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2324,10 +1944,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2345,10 +1961,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2366,10 +1978,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2387,10 +1995,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2408,10 +2012,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2429,10 +2029,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2450,10 +2046,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2471,10 +2063,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2492,10 +2080,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2513,10 +2097,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2534,10 +2114,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2555,10 +2131,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2576,10 +2148,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2597,10 +2165,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2618,10 +2182,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2639,10 +2199,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2660,10 +2216,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2681,10 +2233,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2702,10 +2250,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2723,10 +2267,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2744,10 +2284,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2762,10 +2298,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2867,10 +2399,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2888,10 +2416,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2965,10 +2489,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2986,10 +2506,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3049,10 +2565,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3088,10 +2600,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3109,10 +2617,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3130,10 +2634,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3151,10 +2651,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3172,10 +2668,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3193,10 +2685,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3214,10 +2702,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3235,10 +2719,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3256,10 +2736,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3277,10 +2753,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3298,10 +2770,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3319,10 +2787,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3340,10 +2804,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3361,10 +2821,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3379,10 +2835,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3397,10 +2849,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3451,10 +2899,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3490,10 +2934,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3637,10 +3077,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3655,10 +3091,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3757,10 +3189,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3778,10 +3206,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3799,10 +3223,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3820,10 +3240,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3841,10 +3257,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3862,10 +3274,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3880,10 +3288,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -4003,10 +3407,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4024,10 +3424,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4045,10 +3441,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4066,10 +3458,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4087,10 +3475,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4108,10 +3492,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4129,10 +3509,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4147,10 +3523,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4168,10 +3540,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4186,10 +3554,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4204,10 +3568,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4222,10 +3582,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4240,10 +3596,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4258,10 +3610,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4276,10 +3624,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4294,10 +3638,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4312,10 +3652,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4330,10 +3666,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4348,10 +3680,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4366,10 +3694,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4384,10 +3708,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4402,10 +3722,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4420,10 +3736,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4438,10 +3750,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4456,10 +3764,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4474,10 +3778,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4492,10 +3792,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4510,10 +3806,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4528,10 +3820,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4549,10 +3837,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4567,10 +3851,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4585,10 +3865,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4603,10 +3879,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4621,10 +3893,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4639,10 +3907,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4657,10 +3921,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4675,10 +3935,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4693,10 +3949,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4711,10 +3963,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4729,10 +3977,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4747,10 +3991,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4765,10 +4005,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4786,10 +4022,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4807,10 +4039,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4828,10 +4056,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4849,10 +4073,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4870,10 +4090,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4891,10 +4107,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4912,10 +4124,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4933,10 +4141,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4954,10 +4158,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4975,10 +4175,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4996,10 +4192,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5017,10 +4209,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5038,10 +4226,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5059,10 +4243,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5077,10 +4257,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5095,10 +4271,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5116,10 +4288,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5137,10 +4305,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5158,10 +4322,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5179,10 +4339,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5200,10 +4356,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5221,10 +4373,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5242,10 +4390,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5263,10 +4407,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5284,10 +4424,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5305,10 +4441,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5326,10 +4458,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5347,10 +4475,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5368,10 +4492,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5389,10 +4509,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5410,10 +4526,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5494,10 +4606,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5515,10 +4623,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5536,10 +4640,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5599,10 +4699,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5725,10 +4821,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5743,10 +4835,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5779,10 +4867,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5797,10 +4881,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5815,10 +4895,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5833,10 +4909,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5851,10 +4923,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5872,10 +4940,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5893,10 +4957,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5914,10 +4974,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5935,10 +4991,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5956,10 +5008,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5977,10 +5025,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5998,10 +5042,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6019,10 +5059,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6040,10 +5076,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6061,10 +5093,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6082,10 +5110,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6103,10 +5127,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6124,10 +5144,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6145,10 +5161,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6166,10 +5178,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6187,10 +5195,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6208,10 +5212,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6226,10 +5226,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6247,10 +5243,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6268,10 +5260,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6289,10 +5277,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6310,10 +5294,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6331,10 +5311,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6352,10 +5328,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6373,10 +5345,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6394,10 +5362,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6415,10 +5379,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6436,10 +5396,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6454,10 +5410,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6472,10 +5424,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6490,10 +5438,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6508,10 +5452,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6529,10 +5469,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6547,10 +5483,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6631,10 +5563,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6652,10 +5580,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6673,10 +5597,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6694,10 +5614,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6715,10 +5631,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6736,10 +5648,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6757,10 +5665,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6799,10 +5703,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6841,10 +5741,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -6999,10 +5895,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7118,10 +6010,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7160,10 +6048,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7286,10 +6170,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7304,10 +6184,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7325,10 +6201,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7343,10 +6215,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7361,10 +6229,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7382,10 +6246,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7403,10 +6263,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7424,10 +6280,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7445,10 +6297,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7466,10 +6314,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7487,10 +6331,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7508,10 +6348,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7529,10 +6365,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
@@ -32,7 +32,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52,6 +52,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -69,6 +73,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -86,6 +94,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -103,6 +115,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -120,6 +136,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -137,6 +157,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -154,6 +178,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -172,7 +200,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -192,6 +220,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -209,6 +241,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -244,6 +280,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -261,6 +301,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -278,6 +322,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -295,6 +343,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -312,6 +364,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -329,6 +385,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -346,6 +406,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -364,7 +428,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -385,7 +449,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -406,7 +470,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -426,6 +490,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -444,7 +512,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -464,6 +532,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -482,7 +554,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -503,7 +575,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -523,6 +595,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -540,6 +616,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -557,6 +637,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -574,6 +658,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -591,6 +679,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -608,6 +700,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -625,6 +721,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -642,6 +742,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -660,7 +764,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -681,7 +785,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -701,6 +805,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -718,6 +826,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -735,6 +847,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -754,7 +870,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -770,6 +886,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -787,6 +907,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -805,7 +929,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -826,7 +950,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -847,7 +971,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -868,7 +992,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -889,7 +1013,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -909,6 +1033,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -924,7 +1052,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -940,6 +1068,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -957,6 +1089,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -974,6 +1110,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -991,6 +1131,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1008,6 +1152,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1022,6 +1170,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1039,6 +1191,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1056,6 +1212,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1073,6 +1233,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1090,6 +1254,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1107,6 +1275,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1121,6 +1293,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1135,6 +1311,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1149,6 +1329,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1163,6 +1347,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1177,6 +1365,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1191,6 +1383,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1205,6 +1401,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1219,6 +1419,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1233,6 +1437,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1247,6 +1455,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1261,6 +1473,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1275,6 +1491,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1292,6 +1512,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1309,6 +1533,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1326,6 +1554,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1343,6 +1575,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1357,6 +1593,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1371,6 +1611,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1385,6 +1629,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1399,6 +1647,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1413,6 +1665,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1427,6 +1683,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1441,6 +1701,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1455,6 +1719,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1469,6 +1737,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1483,6 +1755,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1497,6 +1773,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1511,6 +1791,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1525,6 +1809,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1539,6 +1827,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1553,6 +1845,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1567,6 +1863,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1584,6 +1884,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1601,6 +1905,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1618,6 +1926,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1635,6 +1947,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1649,6 +1965,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1663,6 +1983,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1677,6 +2001,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1691,6 +2019,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1705,6 +2037,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -1719,6 +2055,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -1733,6 +2073,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -1747,6 +2091,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -1761,6 +2109,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -1775,6 +2127,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -1789,6 +2145,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -1803,6 +2163,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -1820,6 +2184,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -1838,7 +2206,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1858,6 +2226,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -1873,7 +2245,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1894,7 +2266,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1910,6 +2282,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -1927,6 +2303,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -1944,6 +2324,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -1961,6 +2345,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -1978,6 +2366,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -1995,6 +2387,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2012,6 +2408,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2029,6 +2429,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2046,6 +2450,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2063,6 +2471,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2080,6 +2492,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2097,6 +2513,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2114,6 +2534,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2131,6 +2555,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2148,6 +2576,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2165,6 +2597,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2182,6 +2618,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2199,6 +2639,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2216,6 +2660,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2233,6 +2681,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2250,6 +2702,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2267,6 +2723,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2284,6 +2744,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2298,6 +2762,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2316,7 +2784,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2337,7 +2805,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2358,7 +2826,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2379,7 +2847,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2399,6 +2867,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2416,6 +2888,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2434,7 +2910,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2455,7 +2931,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2489,6 +2965,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2506,6 +2986,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -2524,7 +3008,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2545,7 +3029,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2565,6 +3049,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2580,7 +3068,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2600,6 +3088,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2617,6 +3109,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2634,6 +3130,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2651,6 +3151,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2668,6 +3172,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2685,6 +3193,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2702,6 +3214,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2719,6 +3235,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2736,6 +3256,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2753,6 +3277,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -2770,6 +3298,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -2787,6 +3319,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -2804,6 +3340,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -2821,6 +3361,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -2835,6 +3379,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -2849,6 +3397,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -2865,7 +3417,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2883,7 +3435,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2899,6 +3451,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -2918,7 +3474,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2934,6 +3490,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -2952,7 +3512,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2973,7 +3533,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2994,7 +3554,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3015,7 +3575,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3036,7 +3596,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3057,7 +3617,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3077,6 +3637,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3091,6 +3655,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3106,7 +3674,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3127,7 +3695,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3148,7 +3716,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3169,7 +3737,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3189,6 +3757,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3206,6 +3778,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3223,6 +3799,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3240,6 +3820,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3257,6 +3841,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3274,6 +3862,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3288,6 +3880,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3303,7 +3899,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3324,7 +3920,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3345,7 +3941,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3366,7 +3962,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3387,7 +3983,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3407,6 +4003,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3424,6 +4024,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3441,6 +4045,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3458,6 +4066,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3475,6 +4087,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3492,6 +4108,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3509,6 +4129,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3523,6 +4147,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3540,6 +4168,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3554,6 +4186,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3568,6 +4204,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3582,6 +4222,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3596,6 +4240,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3610,6 +4258,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3624,6 +4276,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3638,6 +4294,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3652,6 +4312,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3666,6 +4330,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3680,6 +4348,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3694,6 +4366,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3708,6 +4384,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3722,6 +4402,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3736,6 +4420,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3750,6 +4438,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -3764,6 +4456,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -3778,6 +4474,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -3792,6 +4492,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -3806,6 +4510,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -3820,6 +4528,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -3837,6 +4549,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -3851,6 +4567,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -3865,6 +4585,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -3879,6 +4603,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -3893,6 +4621,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -3907,6 +4639,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -3921,6 +4657,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -3935,6 +4675,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -3949,6 +4693,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -3963,6 +4711,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -3977,6 +4729,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -3991,6 +4747,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4005,6 +4765,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4022,6 +4786,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4039,6 +4807,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4056,6 +4828,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4073,6 +4849,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4090,6 +4870,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4107,6 +4891,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4124,6 +4912,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4141,6 +4933,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4158,6 +4954,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4175,6 +4975,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4192,6 +4996,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4209,6 +5017,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4226,6 +5038,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4243,6 +5059,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4257,6 +5077,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4271,6 +5095,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4288,6 +5116,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4305,6 +5137,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4322,6 +5158,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4339,6 +5179,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4356,6 +5200,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4373,6 +5221,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4390,6 +5242,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4407,6 +5263,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4424,6 +5284,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4441,6 +5305,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4458,6 +5326,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4475,6 +5347,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4492,6 +5368,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4509,6 +5389,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4526,6 +5410,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4544,7 +5432,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4565,7 +5453,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4586,7 +5474,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4606,6 +5494,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -4623,6 +5515,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4640,6 +5536,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4658,7 +5558,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4679,7 +5579,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4699,6 +5599,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4717,7 +5621,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4738,7 +5642,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4759,7 +5663,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4780,7 +5684,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4801,7 +5705,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4821,6 +5725,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -4835,6 +5743,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -4851,7 +5763,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4867,6 +5779,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -4881,6 +5797,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -4895,6 +5815,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -4909,6 +5833,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -4923,6 +5851,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -4940,6 +5872,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -4957,6 +5893,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -4974,6 +5914,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -4991,6 +5935,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5008,6 +5956,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5025,6 +5977,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5042,6 +5998,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5059,6 +6019,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5076,6 +6040,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5093,6 +6061,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5110,6 +6082,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5127,6 +6103,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5144,6 +6124,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5161,6 +6145,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5178,6 +6166,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5195,6 +6187,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5212,6 +6208,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5226,6 +6226,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5243,6 +6247,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5260,6 +6268,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5277,6 +6289,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5294,6 +6310,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5311,6 +6331,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5328,6 +6352,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5345,6 +6373,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5362,6 +6394,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5379,6 +6415,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5396,6 +6436,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5410,6 +6454,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5424,6 +6472,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5438,6 +6490,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5452,6 +6508,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5469,6 +6529,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5483,6 +6547,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5501,7 +6569,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5522,7 +6590,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5543,7 +6611,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5563,6 +6631,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5580,6 +6652,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5597,6 +6673,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5614,6 +6694,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5631,6 +6715,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5648,6 +6736,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5665,6 +6757,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5683,7 +6779,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5703,6 +6799,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5721,7 +6821,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5741,6 +6841,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -5759,7 +6863,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5780,7 +6884,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5801,7 +6905,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5841,7 +6945,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5858,7 +6962,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5879,7 +6983,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5895,6 +6999,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -5913,7 +7021,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5948,7 +7056,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5969,7 +7077,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5990,7 +7098,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6010,6 +7118,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6028,7 +7140,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6048,6 +7160,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6066,7 +7182,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6087,7 +7203,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6108,7 +7224,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6129,7 +7245,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6150,7 +7266,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6170,6 +7286,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6184,6 +7304,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6201,6 +7325,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6215,6 +7343,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6229,6 +7361,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6246,6 +7382,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6263,6 +7403,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6280,6 +7424,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6297,6 +7445,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6314,6 +7466,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6331,6 +7487,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6348,6 +7508,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6365,6 +7529,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
@@ -52,10 +52,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -73,10 +69,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -94,10 +86,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -115,10 +103,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -136,10 +120,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -157,10 +137,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -178,10 +154,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -220,10 +192,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -241,10 +209,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -280,10 +244,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -301,10 +261,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -322,10 +278,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -343,10 +295,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -364,10 +312,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -385,10 +329,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -406,10 +346,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -490,10 +426,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -532,10 +464,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -595,10 +523,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -616,10 +540,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -637,10 +557,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -658,10 +574,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -679,10 +591,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -700,10 +608,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -721,10 +625,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -742,10 +642,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -805,10 +701,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -826,10 +718,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -847,10 +735,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -886,10 +770,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -907,10 +787,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1033,10 +909,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1068,10 +940,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1089,10 +957,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1110,10 +974,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1131,10 +991,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1152,10 +1008,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1170,10 +1022,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1191,10 +1039,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1212,10 +1056,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1233,10 +1073,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1254,10 +1090,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1275,10 +1107,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1293,10 +1121,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1311,10 +1135,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1329,10 +1149,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1347,10 +1163,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1365,10 +1177,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1383,10 +1191,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1401,10 +1205,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1419,10 +1219,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1437,10 +1233,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1455,10 +1247,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1473,10 +1261,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1491,10 +1275,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1512,10 +1292,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1533,10 +1309,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1554,10 +1326,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1575,10 +1343,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1593,10 +1357,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1611,10 +1371,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1629,10 +1385,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1647,10 +1399,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1665,10 +1413,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1683,10 +1427,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1701,10 +1441,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1719,10 +1455,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1737,10 +1469,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1755,10 +1483,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1773,10 +1497,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1791,10 +1511,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1809,10 +1525,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1827,10 +1539,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1845,10 +1553,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1863,10 +1567,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1884,10 +1584,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1905,10 +1601,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1926,10 +1618,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1947,10 +1635,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1965,10 +1649,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1983,10 +1663,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -2001,10 +1677,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2019,10 +1691,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2037,10 +1705,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2055,10 +1719,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2073,10 +1733,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2091,10 +1747,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2109,10 +1761,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2127,10 +1775,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2145,10 +1789,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2163,10 +1803,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2184,10 +1820,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2226,10 +1858,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2282,10 +1910,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2303,10 +1927,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2324,10 +1944,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2345,10 +1961,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2366,10 +1978,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2387,10 +1995,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2408,10 +2012,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2429,10 +2029,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2450,10 +2046,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2471,10 +2063,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2492,10 +2080,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2513,10 +2097,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2534,10 +2114,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2555,10 +2131,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2576,10 +2148,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2597,10 +2165,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2618,10 +2182,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2639,10 +2199,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2660,10 +2216,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2681,10 +2233,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2702,10 +2250,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2723,10 +2267,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2744,10 +2284,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2762,10 +2298,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2867,10 +2399,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2888,10 +2416,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2965,10 +2489,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2986,10 +2506,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3049,10 +2565,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3088,10 +2600,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3109,10 +2617,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3130,10 +2634,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3151,10 +2651,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3172,10 +2668,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3193,10 +2685,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3214,10 +2702,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3235,10 +2719,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3256,10 +2736,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3277,10 +2753,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3298,10 +2770,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3319,10 +2787,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3340,10 +2804,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3361,10 +2821,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3379,10 +2835,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3397,10 +2849,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3451,10 +2899,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3490,10 +2934,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3637,10 +3077,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3655,10 +3091,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3757,10 +3189,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3778,10 +3206,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3799,10 +3223,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3820,10 +3240,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3841,10 +3257,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3862,10 +3274,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3880,10 +3288,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -4003,10 +3407,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4024,10 +3424,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4045,10 +3441,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4066,10 +3458,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4087,10 +3475,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4108,10 +3492,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4129,10 +3509,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4147,10 +3523,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4168,10 +3540,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4186,10 +3554,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4204,10 +3568,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4222,10 +3582,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4240,10 +3596,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4258,10 +3610,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4276,10 +3624,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4294,10 +3638,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4312,10 +3652,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4330,10 +3666,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4348,10 +3680,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4366,10 +3694,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4384,10 +3708,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4402,10 +3722,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4420,10 +3736,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4438,10 +3750,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4456,10 +3764,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4474,10 +3778,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4492,10 +3792,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4510,10 +3806,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4528,10 +3820,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4549,10 +3837,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4567,10 +3851,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4585,10 +3865,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4603,10 +3879,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4621,10 +3893,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4639,10 +3907,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4657,10 +3921,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4675,10 +3935,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4693,10 +3949,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4711,10 +3963,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4729,10 +3977,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4747,10 +3991,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4765,10 +4005,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4786,10 +4022,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4807,10 +4039,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4828,10 +4056,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4849,10 +4073,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4870,10 +4090,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4891,10 +4107,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4912,10 +4124,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4933,10 +4141,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4954,10 +4158,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4975,10 +4175,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4996,10 +4192,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5017,10 +4209,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5038,10 +4226,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5059,10 +4243,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5077,10 +4257,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5095,10 +4271,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5116,10 +4288,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5137,10 +4305,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5158,10 +4322,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5179,10 +4339,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5200,10 +4356,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5221,10 +4373,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5242,10 +4390,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5263,10 +4407,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5284,10 +4424,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5305,10 +4441,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5326,10 +4458,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5347,10 +4475,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5368,10 +4492,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5389,10 +4509,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5410,10 +4526,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5494,10 +4606,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5515,10 +4623,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5536,10 +4640,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5599,10 +4699,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5725,10 +4821,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5743,10 +4835,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5779,10 +4867,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5797,10 +4881,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5815,10 +4895,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5833,10 +4909,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5851,10 +4923,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5872,10 +4940,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5893,10 +4957,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5914,10 +4974,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5935,10 +4991,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5956,10 +5008,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5977,10 +5025,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5998,10 +5042,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6019,10 +5059,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6040,10 +5076,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6061,10 +5093,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6082,10 +5110,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6103,10 +5127,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6124,10 +5144,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6145,10 +5161,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6166,10 +5178,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6187,10 +5195,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6208,10 +5212,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6226,10 +5226,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6247,10 +5243,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6268,10 +5260,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6289,10 +5277,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6310,10 +5294,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6331,10 +5311,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6352,10 +5328,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6373,10 +5345,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6394,10 +5362,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6415,10 +5379,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6436,10 +5396,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6454,10 +5410,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6472,10 +5424,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6490,10 +5438,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6508,10 +5452,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6529,10 +5469,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6547,10 +5483,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6631,10 +5563,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6652,10 +5580,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6673,10 +5597,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6694,10 +5614,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6715,10 +5631,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6736,10 +5648,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6757,10 +5665,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6799,10 +5703,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6841,10 +5741,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -6999,10 +5895,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7118,10 +6010,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7160,10 +6048,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7286,10 +6170,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7304,10 +6184,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7325,10 +6201,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7343,10 +6215,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7361,10 +6229,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7382,10 +6246,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7403,10 +6263,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7424,10 +6280,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7445,10 +6297,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7466,10 +6314,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7487,10 +6331,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7508,10 +6348,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7529,10 +6365,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
@@ -32,7 +32,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -52,6 +52,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -69,6 +73,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -86,6 +94,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -103,6 +115,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -120,6 +136,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -137,6 +157,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -154,6 +178,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -172,7 +200,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -192,6 +220,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -209,6 +241,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -244,6 +280,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -261,6 +301,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -278,6 +322,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -295,6 +343,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -312,6 +364,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -329,6 +385,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -346,6 +406,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -364,7 +428,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -385,7 +449,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -406,7 +470,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -426,6 +490,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -444,7 +512,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -464,6 +532,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -482,7 +554,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -503,7 +575,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -523,6 +595,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -540,6 +616,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -557,6 +637,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -574,6 +658,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -591,6 +679,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -608,6 +700,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -625,6 +721,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -642,6 +742,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -660,7 +764,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -681,7 +785,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -701,6 +805,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -718,6 +826,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -735,6 +847,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -754,7 +870,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -770,6 +886,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -787,6 +907,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -805,7 +929,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -826,7 +950,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -847,7 +971,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -868,7 +992,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -889,7 +1013,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -909,6 +1033,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -924,7 +1052,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -940,6 +1068,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -957,6 +1089,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -974,6 +1110,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -991,6 +1131,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1008,6 +1152,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1022,6 +1170,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1039,6 +1191,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1056,6 +1212,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1073,6 +1233,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1090,6 +1254,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1107,6 +1275,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1121,6 +1293,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1135,6 +1311,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1149,6 +1329,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1163,6 +1347,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1177,6 +1365,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1191,6 +1383,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1205,6 +1401,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1219,6 +1419,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1233,6 +1437,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1247,6 +1455,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1261,6 +1473,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1275,6 +1491,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1292,6 +1512,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1309,6 +1533,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1326,6 +1554,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1343,6 +1575,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1357,6 +1593,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1371,6 +1611,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1385,6 +1629,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1399,6 +1647,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1413,6 +1665,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1427,6 +1683,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1441,6 +1701,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1455,6 +1719,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1469,6 +1737,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1483,6 +1755,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1497,6 +1773,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1511,6 +1791,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1525,6 +1809,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1539,6 +1827,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1553,6 +1845,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1567,6 +1863,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1584,6 +1884,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1601,6 +1905,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1618,6 +1926,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1635,6 +1947,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1649,6 +1965,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1663,6 +1983,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1677,6 +2001,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1691,6 +2019,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1705,6 +2037,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -1719,6 +2055,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -1733,6 +2073,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -1747,6 +2091,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -1761,6 +2109,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -1775,6 +2127,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -1789,6 +2145,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -1803,6 +2163,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -1820,6 +2184,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -1838,7 +2206,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1858,6 +2226,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -1873,7 +2245,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1894,7 +2266,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1910,6 +2282,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -1927,6 +2303,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -1944,6 +2324,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -1961,6 +2345,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -1978,6 +2366,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -1995,6 +2387,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2012,6 +2408,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2029,6 +2429,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2046,6 +2450,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2063,6 +2471,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2080,6 +2492,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2097,6 +2513,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2114,6 +2534,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2131,6 +2555,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2148,6 +2576,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2165,6 +2597,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2182,6 +2618,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2199,6 +2639,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2216,6 +2660,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2233,6 +2681,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2250,6 +2702,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2267,6 +2723,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2284,6 +2744,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2298,6 +2762,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2316,7 +2784,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2337,7 +2805,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2358,7 +2826,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2379,7 +2847,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2399,6 +2867,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2416,6 +2888,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2434,7 +2910,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2455,7 +2931,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2489,6 +2965,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2506,6 +2986,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -2524,7 +3008,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2545,7 +3029,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2565,6 +3049,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2580,7 +3068,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2600,6 +3088,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2617,6 +3109,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2634,6 +3130,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2651,6 +3151,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2668,6 +3172,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2685,6 +3193,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2702,6 +3214,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2719,6 +3235,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2736,6 +3256,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2753,6 +3277,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -2770,6 +3298,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -2787,6 +3319,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -2804,6 +3340,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -2821,6 +3361,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -2835,6 +3379,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -2849,6 +3397,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -2865,7 +3417,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2883,7 +3435,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2899,6 +3451,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -2918,7 +3474,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2934,6 +3490,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -2952,7 +3512,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2973,7 +3533,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2994,7 +3554,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3015,7 +3575,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3036,7 +3596,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3057,7 +3617,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3077,6 +3637,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3091,6 +3655,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3106,7 +3674,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3127,7 +3695,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3148,7 +3716,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3169,7 +3737,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3189,6 +3757,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3206,6 +3778,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3223,6 +3799,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3240,6 +3820,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3257,6 +3841,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3274,6 +3862,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3288,6 +3880,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3303,7 +3899,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3324,7 +3920,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3345,7 +3941,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3366,7 +3962,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3387,7 +3983,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3407,6 +4003,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3424,6 +4024,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3441,6 +4045,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3458,6 +4066,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3475,6 +4087,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3492,6 +4108,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3509,6 +4129,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3523,6 +4147,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3540,6 +4168,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3554,6 +4186,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3568,6 +4204,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3582,6 +4222,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3596,6 +4240,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3610,6 +4258,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3624,6 +4276,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3638,6 +4294,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3652,6 +4312,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3666,6 +4330,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3680,6 +4348,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3694,6 +4366,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3708,6 +4384,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3722,6 +4402,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3736,6 +4420,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3750,6 +4438,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -3764,6 +4456,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -3778,6 +4474,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -3792,6 +4492,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -3806,6 +4510,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -3820,6 +4528,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -3837,6 +4549,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -3851,6 +4567,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -3865,6 +4585,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -3879,6 +4603,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -3893,6 +4621,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -3907,6 +4639,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -3921,6 +4657,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -3935,6 +4675,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -3949,6 +4693,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -3963,6 +4711,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -3977,6 +4729,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -3991,6 +4747,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4005,6 +4765,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4022,6 +4786,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4039,6 +4807,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4056,6 +4828,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4073,6 +4849,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4090,6 +4870,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4107,6 +4891,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4124,6 +4912,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4141,6 +4933,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4158,6 +4954,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4175,6 +4975,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4192,6 +4996,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4209,6 +5017,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4226,6 +5038,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4243,6 +5059,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4257,6 +5077,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4271,6 +5095,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4288,6 +5116,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4305,6 +5137,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4322,6 +5158,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4339,6 +5179,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4356,6 +5200,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4373,6 +5221,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4390,6 +5242,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4407,6 +5263,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4424,6 +5284,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4441,6 +5305,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4458,6 +5326,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4475,6 +5347,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4492,6 +5368,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4509,6 +5389,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4526,6 +5410,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4544,7 +5432,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4565,7 +5453,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4586,7 +5474,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4606,6 +5494,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -4623,6 +5515,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4640,6 +5536,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4658,7 +5558,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4679,7 +5579,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4699,6 +5599,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4717,7 +5621,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4738,7 +5642,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4759,7 +5663,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4780,7 +5684,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4801,7 +5705,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4821,6 +5725,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -4835,6 +5743,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -4851,7 +5763,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4867,6 +5779,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -4881,6 +5797,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -4895,6 +5815,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -4909,6 +5833,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -4923,6 +5851,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -4940,6 +5872,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -4957,6 +5893,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -4974,6 +5914,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -4991,6 +5935,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5008,6 +5956,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5025,6 +5977,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5042,6 +5998,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5059,6 +6019,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5076,6 +6040,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5093,6 +6061,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5110,6 +6082,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5127,6 +6103,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5144,6 +6124,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5161,6 +6145,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5178,6 +6166,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5195,6 +6187,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5212,6 +6208,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5226,6 +6226,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5243,6 +6247,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5260,6 +6268,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5277,6 +6289,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5294,6 +6310,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5311,6 +6331,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5328,6 +6352,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5345,6 +6373,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5362,6 +6394,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5379,6 +6415,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5396,6 +6436,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5410,6 +6454,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5424,6 +6472,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5438,6 +6490,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5452,6 +6508,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5469,6 +6529,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5483,6 +6547,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5501,7 +6569,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5522,7 +6590,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5543,7 +6611,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5563,6 +6631,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5580,6 +6652,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5597,6 +6673,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5614,6 +6694,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5631,6 +6715,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5648,6 +6736,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5665,6 +6757,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5683,7 +6779,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5703,6 +6799,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5721,7 +6821,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5741,6 +6841,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -5759,7 +6863,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5780,7 +6884,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5801,7 +6905,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5841,7 +6945,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5858,7 +6962,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5879,7 +6983,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5895,6 +6999,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -5913,7 +7021,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5934,7 +7042,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5955,7 +7063,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5976,7 +7084,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5996,6 +7104,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6014,7 +7126,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6034,6 +7146,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6052,7 +7168,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6073,7 +7189,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6094,7 +7210,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6115,7 +7231,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6136,7 +7252,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6156,6 +7272,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6170,6 +7290,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6187,6 +7311,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6201,6 +7329,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6215,6 +7347,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6232,6 +7368,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6249,6 +7389,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6266,6 +7410,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6283,6 +7431,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6300,6 +7452,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6317,6 +7473,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6334,6 +7494,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6351,6 +7515,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
@@ -52,10 +52,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -73,10 +69,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -94,10 +86,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -115,10 +103,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -136,10 +120,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -157,10 +137,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -178,10 +154,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -220,10 +192,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -241,10 +209,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -280,10 +244,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -301,10 +261,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -322,10 +278,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -343,10 +295,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -364,10 +312,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -385,10 +329,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -406,10 +346,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -490,10 +426,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -532,10 +464,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -595,10 +523,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -616,10 +540,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -637,10 +557,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -658,10 +574,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -679,10 +591,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -700,10 +608,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -721,10 +625,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -742,10 +642,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -805,10 +701,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -826,10 +718,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -847,10 +735,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -886,10 +770,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -907,10 +787,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1033,10 +909,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1068,10 +940,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1089,10 +957,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1110,10 +974,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1131,10 +991,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1152,10 +1008,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1170,10 +1022,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1191,10 +1039,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1212,10 +1056,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1233,10 +1073,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1254,10 +1090,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1275,10 +1107,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1293,10 +1121,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1311,10 +1135,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1329,10 +1149,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1347,10 +1163,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1365,10 +1177,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1383,10 +1191,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1401,10 +1205,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1419,10 +1219,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1437,10 +1233,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1455,10 +1247,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1473,10 +1261,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1491,10 +1275,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1512,10 +1292,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1533,10 +1309,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1554,10 +1326,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1575,10 +1343,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1593,10 +1357,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1611,10 +1371,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1629,10 +1385,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1647,10 +1399,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1665,10 +1413,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1683,10 +1427,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1701,10 +1441,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1719,10 +1455,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1737,10 +1469,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1755,10 +1483,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1773,10 +1497,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1791,10 +1511,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1809,10 +1525,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1827,10 +1539,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1845,10 +1553,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1863,10 +1567,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1884,10 +1584,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1905,10 +1601,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1926,10 +1618,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1947,10 +1635,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1965,10 +1649,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1983,10 +1663,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -2001,10 +1677,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2019,10 +1691,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2037,10 +1705,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2055,10 +1719,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2073,10 +1733,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2091,10 +1747,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2109,10 +1761,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2127,10 +1775,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2145,10 +1789,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2163,10 +1803,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2184,10 +1820,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2226,10 +1858,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2282,10 +1910,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2303,10 +1927,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2324,10 +1944,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2345,10 +1961,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2366,10 +1978,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2387,10 +1995,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2408,10 +2012,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2429,10 +2029,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2450,10 +2046,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2471,10 +2063,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2492,10 +2080,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2513,10 +2097,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2534,10 +2114,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2555,10 +2131,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2576,10 +2148,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2597,10 +2165,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2618,10 +2182,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2639,10 +2199,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2660,10 +2216,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2681,10 +2233,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2702,10 +2250,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2723,10 +2267,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2744,10 +2284,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2762,10 +2298,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2867,10 +2399,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2888,10 +2416,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2965,10 +2489,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2986,10 +2506,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3049,10 +2565,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3088,10 +2600,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3109,10 +2617,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3130,10 +2634,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3151,10 +2651,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3172,10 +2668,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3193,10 +2685,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3214,10 +2702,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3235,10 +2719,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3256,10 +2736,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3277,10 +2753,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3298,10 +2770,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3319,10 +2787,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3340,10 +2804,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3361,10 +2821,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3379,10 +2835,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3397,10 +2849,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3451,10 +2899,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3490,10 +2934,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3637,10 +3077,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3655,10 +3091,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3757,10 +3189,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3778,10 +3206,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3799,10 +3223,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3820,10 +3240,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3841,10 +3257,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3862,10 +3274,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3880,10 +3288,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -4003,10 +3407,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4024,10 +3424,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4045,10 +3441,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4066,10 +3458,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4087,10 +3475,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4108,10 +3492,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4129,10 +3509,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4147,10 +3523,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4168,10 +3540,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4186,10 +3554,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4204,10 +3568,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4222,10 +3582,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4240,10 +3596,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4258,10 +3610,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4276,10 +3624,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4294,10 +3638,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4312,10 +3652,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4330,10 +3666,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4348,10 +3680,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4366,10 +3694,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4384,10 +3708,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4402,10 +3722,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4420,10 +3736,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4438,10 +3750,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4456,10 +3764,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4474,10 +3778,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4492,10 +3792,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4510,10 +3806,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4528,10 +3820,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4549,10 +3837,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4567,10 +3851,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4585,10 +3865,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4603,10 +3879,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4621,10 +3893,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4639,10 +3907,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4657,10 +3921,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4675,10 +3935,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4693,10 +3949,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4711,10 +3963,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4729,10 +3977,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4747,10 +3991,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4765,10 +4005,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4786,10 +4022,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4807,10 +4039,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4828,10 +4056,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4849,10 +4073,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4870,10 +4090,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4891,10 +4107,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4912,10 +4124,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4933,10 +4141,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4954,10 +4158,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4975,10 +4175,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4996,10 +4192,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5017,10 +4209,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5038,10 +4226,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5059,10 +4243,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5077,10 +4257,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5095,10 +4271,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5116,10 +4288,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5137,10 +4305,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5158,10 +4322,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5179,10 +4339,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5200,10 +4356,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5221,10 +4373,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5242,10 +4390,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5263,10 +4407,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5284,10 +4424,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5305,10 +4441,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5326,10 +4458,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5347,10 +4475,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5368,10 +4492,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5389,10 +4509,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5410,10 +4526,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5494,10 +4606,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5515,10 +4623,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5536,10 +4640,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5599,10 +4699,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5725,10 +4821,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5743,10 +4835,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5779,10 +4867,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5797,10 +4881,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5815,10 +4895,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5833,10 +4909,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5851,10 +4923,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5872,10 +4940,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5893,10 +4957,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5914,10 +4974,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5935,10 +4991,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5956,10 +5008,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5977,10 +5025,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5998,10 +5042,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6019,10 +5059,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6040,10 +5076,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6061,10 +5093,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6082,10 +5110,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6103,10 +5127,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6124,10 +5144,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6145,10 +5161,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6166,10 +5178,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6187,10 +5195,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6208,10 +5212,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6226,10 +5226,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6247,10 +5243,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6268,10 +5260,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6289,10 +5277,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6310,10 +5294,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6331,10 +5311,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6352,10 +5328,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6373,10 +5345,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6394,10 +5362,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6415,10 +5379,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6436,10 +5396,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6454,10 +5410,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6472,10 +5424,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6490,10 +5438,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6508,10 +5452,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6529,10 +5469,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6547,10 +5483,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6631,10 +5563,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6652,10 +5580,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6673,10 +5597,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6694,10 +5614,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6715,10 +5631,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6736,10 +5648,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6757,10 +5665,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6799,10 +5703,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6841,10 +5741,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -6999,10 +5895,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7104,10 +5996,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7146,10 +6034,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7272,10 +6156,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7290,10 +6170,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7311,10 +6187,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7329,10 +6201,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7347,10 +6215,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7368,10 +6232,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7389,10 +6249,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7410,10 +6266,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7431,10 +6283,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7452,10 +6300,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7473,10 +6317,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7494,10 +6334,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7515,10 +6351,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptTopLevel.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptTopLevel.json
@@ -91,7 +91,7 @@
     "detail": "Nested resource with defaults",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  properties: {\n    \n  }\n}\n```"
+      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  properties: {\n    \n  }\n}\n```  \n"
     },
     "deprecated": false,
     "preselect": true,
@@ -121,7 +121,7 @@
     "detail": "Nested resource without defaults",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  \n}\n```"
+      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  \n}\n```  \n"
     },
     "deprecated": false,
     "preselect": true,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/discriminatorProperty.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/discriminatorProperty.json
@@ -37,7 +37,7 @@
     "detail": "Nested resource with defaults",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  properties: {\n    \n  }\n}\n```"
+      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  properties: {\n    \n  }\n}\n```  \n"
     },
     "deprecated": false,
     "preselect": true,
@@ -67,7 +67,7 @@
     "detail": "Nested resource without defaults",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  \n}\n```"
+      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  \n}\n```  \n"
     },
     "deprecated": false,
     "preselect": true,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
@@ -22,7 +22,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42,6 +42,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -59,6 +63,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -76,6 +84,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -93,6 +105,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -110,6 +126,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -127,6 +147,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -144,6 +168,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -162,7 +190,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -182,6 +210,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -199,6 +231,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -234,6 +270,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -251,6 +291,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -268,6 +312,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -285,6 +333,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -302,6 +354,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -319,6 +375,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -336,6 +396,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -354,7 +418,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -375,7 +439,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -396,7 +460,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -416,6 +480,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -434,7 +502,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -454,6 +522,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -472,7 +544,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -493,7 +565,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -513,6 +585,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -530,6 +606,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -547,6 +627,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -564,6 +648,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -581,6 +669,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -598,6 +690,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -615,6 +711,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -632,6 +732,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -650,7 +754,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -671,7 +775,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -691,6 +795,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -708,6 +816,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -725,6 +837,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -744,7 +860,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -760,6 +876,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -777,6 +897,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -795,7 +919,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -816,7 +940,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -837,7 +961,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -858,7 +982,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -879,7 +1003,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -899,6 +1023,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -914,7 +1042,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -930,6 +1058,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -947,6 +1079,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -964,6 +1100,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -981,6 +1121,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -998,6 +1142,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1012,6 +1160,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1029,6 +1181,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1046,6 +1202,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1063,6 +1223,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1080,6 +1244,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1097,6 +1265,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1111,6 +1283,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1125,6 +1301,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1139,6 +1319,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1153,6 +1337,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1167,6 +1355,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1181,6 +1373,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1195,6 +1391,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1209,6 +1409,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1223,6 +1427,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1237,6 +1445,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1251,6 +1463,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1265,6 +1481,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1282,6 +1502,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1299,6 +1523,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1316,6 +1544,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1333,6 +1565,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1347,6 +1583,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1361,6 +1601,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1375,6 +1619,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1389,6 +1637,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1403,6 +1655,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1417,6 +1673,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1431,6 +1691,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1445,6 +1709,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1459,6 +1727,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1473,6 +1745,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1487,6 +1763,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1501,6 +1781,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1515,6 +1799,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1529,6 +1817,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1543,6 +1835,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1557,6 +1853,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1574,6 +1874,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1591,6 +1895,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1608,6 +1916,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1625,6 +1937,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1639,6 +1955,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1653,6 +1973,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1667,6 +1991,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1681,6 +2009,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1695,6 +2027,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -1709,6 +2045,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -1723,6 +2063,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -1737,6 +2081,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -1751,6 +2099,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -1765,6 +2117,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -1779,6 +2135,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -1796,6 +2156,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -1813,6 +2177,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -1831,7 +2199,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1851,6 +2219,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -1866,7 +2238,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1887,7 +2259,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1903,6 +2275,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -1920,6 +2296,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -1937,6 +2317,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -1954,6 +2338,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -1971,6 +2359,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -1988,6 +2380,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2005,6 +2401,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2022,6 +2422,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2039,6 +2443,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2056,6 +2464,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2073,6 +2485,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2090,6 +2506,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2107,6 +2527,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2124,6 +2548,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2141,6 +2569,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2158,6 +2590,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2175,6 +2611,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2192,6 +2632,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2209,6 +2653,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2226,6 +2674,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2243,6 +2695,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2260,6 +2716,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2277,6 +2737,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2291,6 +2755,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2309,7 +2777,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2330,7 +2798,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2351,7 +2819,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2372,7 +2840,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2392,6 +2860,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2409,6 +2881,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2427,7 +2903,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2448,7 +2924,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2482,6 +2958,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2499,6 +2979,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -2517,7 +3001,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2538,7 +3022,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2558,6 +3042,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2573,7 +3061,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2593,6 +3081,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2610,6 +3102,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2627,6 +3123,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2644,6 +3144,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2661,6 +3165,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2678,6 +3186,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2695,6 +3207,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2712,6 +3228,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2729,6 +3249,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2746,6 +3270,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -2763,6 +3291,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -2780,6 +3312,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -2797,6 +3333,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -2814,6 +3354,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -2828,6 +3372,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -2842,6 +3390,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -2858,7 +3410,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2876,7 +3428,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2892,6 +3444,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -2911,7 +3467,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2927,6 +3483,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -2945,7 +3505,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2966,7 +3526,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2987,7 +3547,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3008,7 +3568,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3029,7 +3589,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3050,7 +3610,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3070,6 +3630,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3084,6 +3648,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3099,7 +3667,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3120,7 +3688,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3141,7 +3709,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3162,7 +3730,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3182,6 +3750,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3199,6 +3771,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3216,6 +3792,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3233,6 +3813,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3250,6 +3834,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3267,6 +3855,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3281,6 +3873,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3296,7 +3892,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3317,7 +3913,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3338,7 +3934,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3359,7 +3955,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3380,7 +3976,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3400,6 +3996,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3417,6 +4017,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3434,6 +4038,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3451,6 +4059,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3468,6 +4080,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3485,6 +4101,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3502,6 +4122,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3516,6 +4140,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3533,6 +4161,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3547,6 +4179,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3561,6 +4197,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3575,6 +4215,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3589,6 +4233,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3603,6 +4251,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3617,6 +4269,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3631,6 +4287,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3645,6 +4305,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3659,6 +4323,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3673,6 +4341,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3687,6 +4359,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3701,6 +4377,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3715,6 +4395,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3729,6 +4413,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3743,6 +4431,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -3757,6 +4449,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -3771,6 +4467,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -3785,6 +4485,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -3799,6 +4503,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -3813,6 +4521,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -3830,6 +4542,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -3844,6 +4560,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -3858,6 +4578,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -3872,6 +4596,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -3886,6 +4614,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -3900,6 +4632,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -3914,6 +4650,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -3928,6 +4668,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -3942,6 +4686,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -3956,6 +4704,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -3970,6 +4722,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -3984,6 +4740,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -3998,6 +4758,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4015,6 +4779,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4032,6 +4800,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4049,6 +4821,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4066,6 +4842,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4083,6 +4863,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4100,6 +4884,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4117,6 +4905,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4134,6 +4926,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4151,6 +4947,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4168,6 +4968,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4185,6 +4989,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4202,6 +5010,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4219,6 +5031,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4236,6 +5052,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4250,6 +5070,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4264,6 +5088,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4281,6 +5109,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4298,6 +5130,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4315,6 +5151,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4332,6 +5172,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4349,6 +5193,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4366,6 +5214,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4383,6 +5235,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4400,6 +5256,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4417,6 +5277,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4434,6 +5298,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4451,6 +5319,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4468,6 +5340,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4485,6 +5361,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4502,6 +5382,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4519,6 +5403,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4537,7 +5425,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4558,7 +5446,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4579,7 +5467,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4599,6 +5487,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -4616,6 +5508,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4633,6 +5529,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4651,7 +5551,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4672,7 +5572,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4692,6 +5592,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4710,7 +5614,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4731,7 +5635,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4752,7 +5656,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4773,7 +5677,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4794,7 +5698,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4814,6 +5718,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -4828,6 +5736,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -4844,7 +5756,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4860,6 +5772,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -4874,6 +5790,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -4888,6 +5808,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -4902,6 +5826,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -4916,6 +5844,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -4933,6 +5865,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -4950,6 +5886,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -4967,6 +5907,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -4984,6 +5928,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5001,6 +5949,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5018,6 +5970,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5035,6 +5991,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5052,6 +6012,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5069,6 +6033,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5086,6 +6054,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5103,6 +6075,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5120,6 +6096,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5137,6 +6117,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5154,6 +6138,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5171,6 +6159,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5188,6 +6180,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5205,6 +6201,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5219,6 +6219,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5236,6 +6240,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5253,6 +6261,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5270,6 +6282,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5287,6 +6303,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5304,6 +6324,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5321,6 +6345,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5338,6 +6366,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5355,6 +6387,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5372,6 +6408,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5389,6 +6429,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5403,6 +6447,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5417,6 +6465,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5431,6 +6483,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5445,6 +6501,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5462,6 +6522,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5476,6 +6540,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5494,7 +6562,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5515,7 +6583,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5536,7 +6604,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5556,6 +6624,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5573,6 +6645,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5590,6 +6666,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5607,6 +6687,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5624,6 +6708,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5641,6 +6729,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5658,6 +6750,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5676,7 +6772,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5696,6 +6792,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5714,7 +6814,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5734,6 +6834,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -5752,7 +6856,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5773,7 +6877,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5794,7 +6898,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5834,7 +6938,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5851,7 +6955,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5872,7 +6976,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5888,6 +6992,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -5906,7 +7014,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5927,7 +7035,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5948,7 +7056,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5969,7 +7077,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5989,6 +7097,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6007,7 +7119,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6027,6 +7139,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6045,7 +7161,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6066,7 +7182,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6087,7 +7203,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6108,7 +7224,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6129,7 +7245,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6149,6 +7265,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6163,6 +7283,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6180,6 +7304,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6194,6 +7322,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6208,6 +7340,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6225,6 +7361,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6242,6 +7382,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6259,6 +7403,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6276,6 +7424,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6293,6 +7445,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6310,6 +7466,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6327,6 +7487,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6344,6 +7508,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
@@ -42,10 +42,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -63,10 +59,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -84,10 +76,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -105,10 +93,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -126,10 +110,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -147,10 +127,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -168,10 +144,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -210,10 +182,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -231,10 +199,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -270,10 +234,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -291,10 +251,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -312,10 +268,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -333,10 +285,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -354,10 +302,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -375,10 +319,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -396,10 +336,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -480,10 +416,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -522,10 +454,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -585,10 +513,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -606,10 +530,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -627,10 +547,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -648,10 +564,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -669,10 +581,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -690,10 +598,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -711,10 +615,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -732,10 +632,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -795,10 +691,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -816,10 +708,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -837,10 +725,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -876,10 +760,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -897,10 +777,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1023,10 +899,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1058,10 +930,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1079,10 +947,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1100,10 +964,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1121,10 +981,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1142,10 +998,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1160,10 +1012,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1181,10 +1029,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1202,10 +1046,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1223,10 +1063,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1244,10 +1080,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1265,10 +1097,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1283,10 +1111,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1301,10 +1125,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1319,10 +1139,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1337,10 +1153,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1355,10 +1167,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1373,10 +1181,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1391,10 +1195,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1409,10 +1209,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1427,10 +1223,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1445,10 +1237,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1463,10 +1251,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1481,10 +1265,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1502,10 +1282,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1523,10 +1299,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1544,10 +1316,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1565,10 +1333,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1583,10 +1347,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1601,10 +1361,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1619,10 +1375,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1637,10 +1389,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1655,10 +1403,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1673,10 +1417,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1691,10 +1431,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1709,10 +1445,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1727,10 +1459,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1745,10 +1473,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1763,10 +1487,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1781,10 +1501,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1799,10 +1515,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1817,10 +1529,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1835,10 +1543,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1853,10 +1557,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1874,10 +1574,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1895,10 +1591,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1916,10 +1608,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1937,10 +1625,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1955,10 +1639,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1973,10 +1653,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1991,10 +1667,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2009,10 +1681,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2027,10 +1695,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2045,10 +1709,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2063,10 +1723,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2081,10 +1737,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2099,10 +1751,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2117,10 +1765,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2135,10 +1779,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2156,10 +1796,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2177,10 +1813,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2219,10 +1851,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2275,10 +1903,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2296,10 +1920,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2317,10 +1937,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2338,10 +1954,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2359,10 +1971,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2380,10 +1988,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2401,10 +2005,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2422,10 +2022,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2443,10 +2039,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2464,10 +2056,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2485,10 +2073,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2506,10 +2090,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2527,10 +2107,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2548,10 +2124,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2569,10 +2141,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2590,10 +2158,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2611,10 +2175,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2632,10 +2192,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2653,10 +2209,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2674,10 +2226,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2695,10 +2243,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2716,10 +2260,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2737,10 +2277,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2755,10 +2291,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2860,10 +2392,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2881,10 +2409,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2958,10 +2482,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2979,10 +2499,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3042,10 +2558,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3081,10 +2593,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3102,10 +2610,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3123,10 +2627,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3144,10 +2644,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3165,10 +2661,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3186,10 +2678,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3207,10 +2695,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3228,10 +2712,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3249,10 +2729,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3270,10 +2746,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3291,10 +2763,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3312,10 +2780,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3333,10 +2797,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3354,10 +2814,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3372,10 +2828,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3390,10 +2842,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3444,10 +2892,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3483,10 +2927,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3630,10 +3070,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3648,10 +3084,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3750,10 +3182,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3771,10 +3199,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3792,10 +3216,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3813,10 +3233,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3834,10 +3250,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3855,10 +3267,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3873,10 +3281,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3996,10 +3400,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4017,10 +3417,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4038,10 +3434,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4059,10 +3451,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4080,10 +3468,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4101,10 +3485,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4122,10 +3502,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4140,10 +3516,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4161,10 +3533,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4179,10 +3547,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4197,10 +3561,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4215,10 +3575,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4233,10 +3589,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4251,10 +3603,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4269,10 +3617,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4287,10 +3631,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4305,10 +3645,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4323,10 +3659,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4341,10 +3673,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4359,10 +3687,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4377,10 +3701,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4395,10 +3715,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4413,10 +3729,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4431,10 +3743,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4449,10 +3757,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4467,10 +3771,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4485,10 +3785,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4503,10 +3799,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4521,10 +3813,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4542,10 +3830,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4560,10 +3844,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4578,10 +3858,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4596,10 +3872,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4614,10 +3886,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4632,10 +3900,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4650,10 +3914,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4668,10 +3928,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4686,10 +3942,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4704,10 +3956,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4722,10 +3970,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4740,10 +3984,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4758,10 +3998,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4779,10 +4015,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4800,10 +4032,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4821,10 +4049,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4842,10 +4066,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4863,10 +4083,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4884,10 +4100,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4905,10 +4117,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4926,10 +4134,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4947,10 +4151,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4968,10 +4168,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4989,10 +4185,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5010,10 +4202,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5031,10 +4219,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5052,10 +4236,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5070,10 +4250,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5088,10 +4264,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5109,10 +4281,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5130,10 +4298,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5151,10 +4315,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5172,10 +4332,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5193,10 +4349,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5214,10 +4366,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5235,10 +4383,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5256,10 +4400,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5277,10 +4417,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5298,10 +4434,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5319,10 +4451,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5340,10 +4468,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5361,10 +4485,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5382,10 +4502,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5403,10 +4519,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5487,10 +4599,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5508,10 +4616,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5529,10 +4633,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5592,10 +4692,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5718,10 +4814,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5736,10 +4828,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5772,10 +4860,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5790,10 +4874,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5808,10 +4888,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5826,10 +4902,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5844,10 +4916,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5865,10 +4933,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5886,10 +4950,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5907,10 +4967,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5928,10 +4984,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5949,10 +5001,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5970,10 +5018,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5991,10 +5035,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6012,10 +5052,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6033,10 +5069,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6054,10 +5086,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6075,10 +5103,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6096,10 +5120,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6117,10 +5137,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6138,10 +5154,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6159,10 +5171,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6180,10 +5188,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6201,10 +5205,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6219,10 +5219,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6240,10 +5236,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6261,10 +5253,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6282,10 +5270,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6303,10 +5287,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6324,10 +5304,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6345,10 +5321,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6366,10 +5338,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6387,10 +5355,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6408,10 +5372,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6429,10 +5389,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6447,10 +5403,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6465,10 +5417,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6483,10 +5431,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6501,10 +5445,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6522,10 +5462,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6540,10 +5476,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6624,10 +5556,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6645,10 +5573,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6666,10 +5590,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6687,10 +5607,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6708,10 +5624,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6729,10 +5641,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6750,10 +5658,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6792,10 +5696,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6834,10 +5734,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -6992,10 +5888,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7097,10 +5989,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7139,10 +6027,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7265,10 +6149,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7283,10 +6163,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7304,10 +6180,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7322,10 +6194,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7340,10 +6208,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7361,10 +6225,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7382,10 +6242,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7403,10 +6259,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7424,10 +6276,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7445,10 +6293,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7466,10 +6310,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7487,10 +6327,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7508,10 +6344,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
@@ -22,7 +22,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42,6 +42,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -59,6 +63,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -76,6 +84,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -93,6 +105,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -110,6 +126,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -127,6 +147,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -144,6 +168,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -162,7 +190,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -182,6 +210,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -199,6 +231,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -234,6 +270,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -251,6 +291,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -268,6 +312,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -285,6 +333,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -302,6 +354,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -319,6 +375,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -336,6 +396,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -354,7 +418,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -375,7 +439,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -396,7 +460,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -416,6 +480,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -434,7 +502,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -454,6 +522,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -472,7 +544,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -493,7 +565,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -513,6 +585,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -530,6 +606,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -547,6 +627,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -564,6 +648,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -581,6 +669,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -598,6 +690,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -615,6 +711,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -632,6 +732,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -650,7 +754,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -671,7 +775,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -691,6 +795,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -708,6 +816,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -725,6 +837,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -744,7 +860,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -760,6 +876,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -777,6 +897,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -795,7 +919,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -816,7 +940,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -837,7 +961,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -858,7 +982,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -879,7 +1003,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -899,6 +1023,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -914,7 +1042,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -930,6 +1058,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -947,6 +1079,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -964,6 +1100,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -981,6 +1121,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -998,6 +1142,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1012,6 +1160,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1029,6 +1181,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1046,6 +1202,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1063,6 +1223,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1080,6 +1244,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1097,6 +1265,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1111,6 +1283,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1125,6 +1301,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1139,6 +1319,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1153,6 +1337,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1167,6 +1355,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1181,6 +1373,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1195,6 +1391,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1209,6 +1409,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1223,6 +1427,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1237,6 +1445,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1251,6 +1463,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1265,6 +1481,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1282,6 +1502,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1299,6 +1523,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1316,6 +1544,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1333,6 +1565,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1347,6 +1583,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1361,6 +1601,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1375,6 +1619,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1389,6 +1637,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1403,6 +1655,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1417,6 +1673,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1431,6 +1691,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1445,6 +1709,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1459,6 +1727,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1473,6 +1745,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1487,6 +1763,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1501,6 +1781,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1515,6 +1799,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1529,6 +1817,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1543,6 +1835,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1557,6 +1853,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1574,6 +1874,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1591,6 +1895,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1608,6 +1916,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1625,6 +1937,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1639,6 +1955,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1653,6 +1973,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1667,6 +1991,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1681,6 +2009,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1695,6 +2027,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -1709,6 +2045,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -1723,6 +2063,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -1737,6 +2081,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -1751,6 +2099,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -1765,6 +2117,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -1779,6 +2135,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -1796,6 +2156,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -1813,6 +2177,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -1831,7 +2199,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1851,6 +2219,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -1866,7 +2238,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1887,7 +2259,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1903,6 +2275,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -1920,6 +2296,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -1937,6 +2317,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -1954,6 +2338,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -1971,6 +2359,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -1988,6 +2380,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2005,6 +2401,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2022,6 +2422,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2039,6 +2443,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2056,6 +2464,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2073,6 +2485,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2090,6 +2506,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2107,6 +2527,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2124,6 +2548,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2141,6 +2569,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2158,6 +2590,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2175,6 +2611,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2192,6 +2632,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2209,6 +2653,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2226,6 +2674,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2243,6 +2695,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2260,6 +2716,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2277,6 +2737,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2291,6 +2755,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2309,7 +2777,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2330,7 +2798,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2351,7 +2819,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2372,7 +2840,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2392,6 +2860,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2409,6 +2881,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2427,7 +2903,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2448,7 +2924,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2482,6 +2958,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2499,6 +2979,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -2517,7 +3001,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2538,7 +3022,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2558,6 +3042,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2573,7 +3061,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2593,6 +3081,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2610,6 +3102,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2627,6 +3123,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2644,6 +3144,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2661,6 +3165,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2678,6 +3186,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2695,6 +3207,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2712,6 +3228,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2729,6 +3249,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2746,6 +3270,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -2763,6 +3291,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -2780,6 +3312,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -2797,6 +3333,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -2814,6 +3354,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -2828,6 +3372,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -2842,6 +3390,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -2858,7 +3410,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2876,7 +3428,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2892,6 +3444,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -2911,7 +3467,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2927,6 +3483,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -2945,7 +3505,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2966,7 +3526,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2987,7 +3547,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3008,7 +3568,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3029,7 +3589,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3050,7 +3610,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3070,6 +3630,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3084,6 +3648,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3099,7 +3667,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3120,7 +3688,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3141,7 +3709,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3162,7 +3730,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3182,6 +3750,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3199,6 +3771,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3216,6 +3792,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3233,6 +3813,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3250,6 +3834,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3267,6 +3855,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3281,6 +3873,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3296,7 +3892,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3317,7 +3913,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3338,7 +3934,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3359,7 +3955,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3380,7 +3976,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3400,6 +3996,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3417,6 +4017,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3434,6 +4038,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3451,6 +4059,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3468,6 +4080,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3485,6 +4101,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3502,6 +4122,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3516,6 +4140,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3533,6 +4161,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3547,6 +4179,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3561,6 +4197,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3575,6 +4215,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3589,6 +4233,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3603,6 +4251,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3617,6 +4269,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3631,6 +4287,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3645,6 +4305,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3659,6 +4323,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3673,6 +4341,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3687,6 +4359,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3701,6 +4377,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3715,6 +4395,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3729,6 +4413,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3743,6 +4431,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -3757,6 +4449,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -3771,6 +4467,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -3785,6 +4485,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -3799,6 +4503,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -3813,6 +4521,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -3830,6 +4542,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -3844,6 +4560,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -3858,6 +4578,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -3872,6 +4596,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -3886,6 +4614,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -3900,6 +4632,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -3914,6 +4650,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -3928,6 +4668,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -3942,6 +4686,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -3956,6 +4704,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -3970,6 +4722,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -3984,6 +4740,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -3998,6 +4758,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4015,6 +4779,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4032,6 +4800,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4049,6 +4821,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4066,6 +4842,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4083,6 +4863,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4100,6 +4884,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4117,6 +4905,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4134,6 +4926,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4151,6 +4947,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4168,6 +4968,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4185,6 +4989,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4202,6 +5010,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4219,6 +5031,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4236,6 +5052,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4250,6 +5070,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4264,6 +5088,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4281,6 +5109,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4298,6 +5130,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4315,6 +5151,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4332,6 +5172,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4349,6 +5193,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4366,6 +5214,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4383,6 +5235,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4400,6 +5256,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4417,6 +5277,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4434,6 +5298,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4451,6 +5319,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4468,6 +5340,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4485,6 +5361,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4502,6 +5382,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4519,6 +5403,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4537,7 +5425,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4558,7 +5446,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4579,7 +5467,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4599,6 +5487,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -4616,6 +5508,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4633,6 +5529,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4651,7 +5551,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4672,7 +5572,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4692,6 +5592,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4710,7 +5614,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4731,7 +5635,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4752,7 +5656,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4773,7 +5677,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4794,7 +5698,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4814,6 +5718,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -4828,6 +5736,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -4844,7 +5756,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4860,6 +5772,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -4874,6 +5790,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -4888,6 +5808,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -4902,6 +5826,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -4916,6 +5844,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -4933,6 +5865,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -4950,6 +5886,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -4967,6 +5907,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -4984,6 +5928,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5001,6 +5949,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5018,6 +5970,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5035,6 +5991,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5052,6 +6012,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5069,6 +6033,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5086,6 +6054,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5103,6 +6075,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5120,6 +6096,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5137,6 +6117,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5154,6 +6138,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5171,6 +6159,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5188,6 +6180,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5205,6 +6201,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5219,6 +6219,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5236,6 +6240,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5253,6 +6261,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5270,6 +6282,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5287,6 +6303,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5304,6 +6324,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5321,6 +6345,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5338,6 +6366,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5355,6 +6387,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5372,6 +6408,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5389,6 +6429,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5403,6 +6447,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5417,6 +6465,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5431,6 +6483,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5445,6 +6501,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5462,6 +6522,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5476,6 +6540,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5494,7 +6562,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5515,7 +6583,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5536,7 +6604,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5556,6 +6624,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5573,6 +6645,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5590,6 +6666,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5607,6 +6687,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5624,6 +6708,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5641,6 +6729,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5658,6 +6750,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5676,7 +6772,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5696,6 +6792,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5714,7 +6814,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5734,6 +6834,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -5752,7 +6856,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5773,7 +6877,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5794,7 +6898,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5834,7 +6938,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5851,7 +6955,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5872,7 +6976,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5888,6 +6992,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -5906,7 +7014,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5927,7 +7035,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5948,7 +7056,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5969,7 +7077,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5989,6 +7097,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6007,7 +7119,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6027,6 +7139,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6045,7 +7161,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6066,7 +7182,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6087,7 +7203,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6108,7 +7224,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6129,7 +7245,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6149,6 +7265,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6163,6 +7283,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6180,6 +7304,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6194,6 +7322,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6208,6 +7340,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6225,6 +7361,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6242,6 +7382,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6259,6 +7403,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6276,6 +7424,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6293,6 +7445,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6310,6 +7466,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6327,6 +7487,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6344,6 +7508,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
@@ -42,10 +42,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -63,10 +59,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -84,10 +76,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -105,10 +93,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -126,10 +110,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -147,10 +127,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -168,10 +144,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -210,10 +182,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -231,10 +199,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -270,10 +234,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -291,10 +251,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -312,10 +268,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -333,10 +285,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -354,10 +302,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -375,10 +319,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -396,10 +336,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -480,10 +416,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -522,10 +454,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -585,10 +513,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -606,10 +530,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -627,10 +547,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -648,10 +564,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -669,10 +581,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -690,10 +598,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -711,10 +615,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -732,10 +632,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -795,10 +691,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -816,10 +708,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -837,10 +725,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -876,10 +760,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -897,10 +777,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1023,10 +899,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1058,10 +930,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1079,10 +947,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1100,10 +964,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1121,10 +981,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1142,10 +998,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1160,10 +1012,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1181,10 +1029,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1202,10 +1046,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1223,10 +1063,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1244,10 +1080,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1265,10 +1097,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1283,10 +1111,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1301,10 +1125,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1319,10 +1139,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1337,10 +1153,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1355,10 +1167,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1373,10 +1181,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1391,10 +1195,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1409,10 +1209,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1427,10 +1223,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1445,10 +1237,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1463,10 +1251,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1481,10 +1265,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1502,10 +1282,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1523,10 +1299,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1544,10 +1316,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1565,10 +1333,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1583,10 +1347,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1601,10 +1361,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1619,10 +1375,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1637,10 +1389,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1655,10 +1403,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1673,10 +1417,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1691,10 +1431,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1709,10 +1445,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1727,10 +1459,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1745,10 +1473,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1763,10 +1487,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1781,10 +1501,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1799,10 +1515,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1817,10 +1529,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1835,10 +1543,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1853,10 +1557,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1874,10 +1574,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1895,10 +1591,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1916,10 +1608,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1937,10 +1625,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1955,10 +1639,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1973,10 +1653,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1991,10 +1667,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2009,10 +1681,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2027,10 +1695,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2045,10 +1709,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2063,10 +1723,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2081,10 +1737,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2099,10 +1751,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2117,10 +1765,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2135,10 +1779,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2156,10 +1796,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2177,10 +1813,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2219,10 +1851,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2275,10 +1903,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2296,10 +1920,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2317,10 +1937,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2338,10 +1954,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2359,10 +1971,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2380,10 +1988,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2401,10 +2005,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2422,10 +2022,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2443,10 +2039,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2464,10 +2056,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2485,10 +2073,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2506,10 +2090,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2527,10 +2107,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2548,10 +2124,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2569,10 +2141,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2590,10 +2158,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2611,10 +2175,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2632,10 +2192,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2653,10 +2209,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2674,10 +2226,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2695,10 +2243,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2716,10 +2260,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2737,10 +2277,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2755,10 +2291,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2860,10 +2392,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2881,10 +2409,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2958,10 +2482,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2979,10 +2499,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3042,10 +2558,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3081,10 +2593,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3102,10 +2610,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3123,10 +2627,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3144,10 +2644,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3165,10 +2661,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3186,10 +2678,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3207,10 +2695,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3228,10 +2712,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3249,10 +2729,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3270,10 +2746,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3291,10 +2763,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3312,10 +2780,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3333,10 +2797,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3354,10 +2814,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3372,10 +2828,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3390,10 +2842,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3444,10 +2892,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3483,10 +2927,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3630,10 +3070,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3648,10 +3084,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3750,10 +3182,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3771,10 +3199,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3792,10 +3216,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3813,10 +3233,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3834,10 +3250,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3855,10 +3267,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3873,10 +3281,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3996,10 +3400,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4017,10 +3417,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4038,10 +3434,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4059,10 +3451,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4080,10 +3468,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4101,10 +3485,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4122,10 +3502,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4140,10 +3516,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4161,10 +3533,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4179,10 +3547,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4197,10 +3561,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4215,10 +3575,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4233,10 +3589,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4251,10 +3603,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4269,10 +3617,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4287,10 +3631,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4305,10 +3645,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4323,10 +3659,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4341,10 +3673,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4359,10 +3687,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4377,10 +3701,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4395,10 +3715,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4413,10 +3729,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4431,10 +3743,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4449,10 +3757,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4467,10 +3771,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4485,10 +3785,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4503,10 +3799,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4521,10 +3813,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4542,10 +3830,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4560,10 +3844,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4578,10 +3858,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4596,10 +3872,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4614,10 +3886,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4632,10 +3900,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4650,10 +3914,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4668,10 +3928,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4686,10 +3942,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4704,10 +3956,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4722,10 +3970,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4740,10 +3984,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4758,10 +3998,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4779,10 +4015,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4800,10 +4032,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4821,10 +4049,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4842,10 +4066,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4863,10 +4083,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4884,10 +4100,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4905,10 +4117,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4926,10 +4134,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4947,10 +4151,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4968,10 +4168,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4989,10 +4185,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5010,10 +4202,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5031,10 +4219,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5052,10 +4236,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5070,10 +4250,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5088,10 +4264,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5109,10 +4281,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5130,10 +4298,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5151,10 +4315,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5172,10 +4332,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5193,10 +4349,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5214,10 +4366,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5235,10 +4383,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5256,10 +4400,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5277,10 +4417,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5298,10 +4434,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5319,10 +4451,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5340,10 +4468,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5361,10 +4485,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5382,10 +4502,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5403,10 +4519,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5487,10 +4599,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5508,10 +4616,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5529,10 +4633,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5592,10 +4692,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5718,10 +4814,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5736,10 +4828,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5772,10 +4860,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5790,10 +4874,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5808,10 +4888,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5826,10 +4902,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5844,10 +4916,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5865,10 +4933,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5886,10 +4950,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5907,10 +4967,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5928,10 +4984,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5949,10 +5001,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5970,10 +5018,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5991,10 +5035,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6012,10 +5052,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6033,10 +5069,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6054,10 +5086,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6075,10 +5103,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6096,10 +5120,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6117,10 +5137,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6138,10 +5154,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6159,10 +5171,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6180,10 +5188,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6201,10 +5205,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6219,10 +5219,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6240,10 +5236,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6261,10 +5253,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6282,10 +5270,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6303,10 +5287,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6324,10 +5304,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6345,10 +5321,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6366,10 +5338,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6387,10 +5355,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6408,10 +5372,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6429,10 +5389,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6447,10 +5403,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6465,10 +5417,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6483,10 +5431,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6501,10 +5445,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6522,10 +5462,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6540,10 +5476,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6624,10 +5556,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6645,10 +5573,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6666,10 +5590,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6687,10 +5607,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6708,10 +5624,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6729,10 +5641,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6750,10 +5658,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6792,10 +5696,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6834,10 +5734,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -6992,10 +5888,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7097,10 +5989,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7139,10 +6027,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7265,10 +6149,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7283,10 +6163,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7304,10 +6180,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7322,10 +6194,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7340,10 +6208,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7361,10 +6225,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7382,10 +6242,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7403,10 +6259,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7424,10 +6276,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7445,10 +6293,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7466,10 +6310,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7487,10 +6327,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7508,10 +6344,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
@@ -22,7 +22,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42,6 +42,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -59,6 +63,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -76,6 +84,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -93,6 +105,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -110,6 +126,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -127,6 +147,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -144,6 +168,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -162,7 +190,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -182,6 +210,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -199,6 +231,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -234,6 +270,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -251,6 +291,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -268,6 +312,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -285,6 +333,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -302,6 +354,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -319,6 +375,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -336,6 +396,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -354,7 +418,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -375,7 +439,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -396,7 +460,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -416,6 +480,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -434,7 +502,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -454,6 +522,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -472,7 +544,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -493,7 +565,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -513,6 +585,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -530,6 +606,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -547,6 +627,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -564,6 +648,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -581,6 +669,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -598,6 +690,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -615,6 +711,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -632,6 +732,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -650,7 +754,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -671,7 +775,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -691,6 +795,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -708,6 +816,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -725,6 +837,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -744,7 +860,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -760,6 +876,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -777,6 +897,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -795,7 +919,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -816,7 +940,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -837,7 +961,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -858,7 +982,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -879,7 +1003,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -899,6 +1023,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -914,7 +1042,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -930,6 +1058,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -947,6 +1079,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -964,6 +1100,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -981,6 +1121,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -998,6 +1142,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1012,6 +1160,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1029,6 +1181,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1046,6 +1202,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1063,6 +1223,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1080,6 +1244,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1097,6 +1265,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1111,6 +1283,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1125,6 +1301,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1139,6 +1319,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1153,6 +1337,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1167,6 +1355,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1181,6 +1373,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1195,6 +1391,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1209,6 +1409,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1223,6 +1427,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1237,6 +1445,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1251,6 +1463,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1265,6 +1481,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1282,6 +1502,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1299,6 +1523,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1316,6 +1544,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1333,6 +1565,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1347,6 +1583,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1361,6 +1601,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1375,6 +1619,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1389,6 +1637,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1403,6 +1655,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1417,6 +1673,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1431,6 +1691,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1445,6 +1709,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1459,6 +1727,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1473,6 +1745,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1487,6 +1763,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1501,6 +1781,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1515,6 +1799,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1529,6 +1817,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1543,6 +1835,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1557,6 +1853,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1574,6 +1874,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1591,6 +1895,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1608,6 +1916,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1625,6 +1937,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1639,6 +1955,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1653,6 +1973,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1667,6 +1991,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1681,6 +2009,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1695,6 +2027,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -1709,6 +2045,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -1723,6 +2063,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -1737,6 +2081,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -1751,6 +2099,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -1765,6 +2117,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -1779,6 +2135,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -1796,6 +2156,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -1813,6 +2177,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -1831,7 +2199,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1851,6 +2219,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -1866,7 +2238,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1887,7 +2259,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1903,6 +2275,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -1920,6 +2296,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -1937,6 +2317,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -1954,6 +2338,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -1971,6 +2359,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -1988,6 +2380,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2005,6 +2401,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2022,6 +2422,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2039,6 +2443,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2056,6 +2464,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2073,6 +2485,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2090,6 +2506,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2107,6 +2527,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2124,6 +2548,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2141,6 +2569,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2158,6 +2590,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2175,6 +2611,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2192,6 +2632,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2209,6 +2653,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2226,6 +2674,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2243,6 +2695,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2260,6 +2716,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2277,6 +2737,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2291,6 +2755,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2309,7 +2777,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2330,7 +2798,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2351,7 +2819,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2372,7 +2840,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2392,6 +2860,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2409,6 +2881,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2427,7 +2903,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2448,7 +2924,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2482,6 +2958,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2499,6 +2979,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -2517,7 +3001,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2538,7 +3022,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2558,6 +3042,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2573,7 +3061,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2593,6 +3081,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2610,6 +3102,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2627,6 +3123,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2644,6 +3144,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2661,6 +3165,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2678,6 +3186,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2695,6 +3207,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2712,6 +3228,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2729,6 +3249,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2746,6 +3270,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -2763,6 +3291,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -2780,6 +3312,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -2797,6 +3333,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -2814,6 +3354,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -2828,6 +3372,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -2842,6 +3390,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -2858,7 +3410,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2876,7 +3428,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2892,6 +3444,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -2911,7 +3467,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2927,6 +3483,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -2945,7 +3505,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2966,7 +3526,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2987,7 +3547,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3008,7 +3568,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3029,7 +3589,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3050,7 +3610,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3070,6 +3630,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3084,6 +3648,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3099,7 +3667,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3120,7 +3688,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3141,7 +3709,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3162,7 +3730,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3182,6 +3750,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3199,6 +3771,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3216,6 +3792,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3233,6 +3813,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3250,6 +3834,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3267,6 +3855,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3281,6 +3873,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3296,7 +3892,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3317,7 +3913,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3338,7 +3934,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3359,7 +3955,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3380,7 +3976,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3400,6 +3996,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3417,6 +4017,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3434,6 +4038,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3451,6 +4059,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3468,6 +4080,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3485,6 +4101,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3502,6 +4122,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3516,6 +4140,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3533,6 +4161,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3547,6 +4179,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3561,6 +4197,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3575,6 +4215,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3589,6 +4233,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3603,6 +4251,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3617,6 +4269,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3631,6 +4287,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3645,6 +4305,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3659,6 +4323,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3673,6 +4341,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3687,6 +4359,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3701,6 +4377,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3715,6 +4395,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3729,6 +4413,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3743,6 +4431,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -3757,6 +4449,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -3771,6 +4467,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -3785,6 +4485,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -3799,6 +4503,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -3813,6 +4521,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -3830,6 +4542,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -3844,6 +4560,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -3858,6 +4578,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -3872,6 +4596,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -3886,6 +4614,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -3900,6 +4632,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -3914,6 +4650,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -3928,6 +4668,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -3942,6 +4686,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -3956,6 +4704,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -3970,6 +4722,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -3984,6 +4740,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -3998,6 +4758,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4015,6 +4779,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4032,6 +4800,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4049,6 +4821,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4066,6 +4842,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4083,6 +4863,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4100,6 +4884,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4117,6 +4905,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4134,6 +4926,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4151,6 +4947,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4168,6 +4968,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4185,6 +4989,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4202,6 +5010,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4219,6 +5031,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4236,6 +5052,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4250,6 +5070,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4264,6 +5088,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4281,6 +5109,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4298,6 +5130,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4315,6 +5151,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4332,6 +5172,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4349,6 +5193,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4366,6 +5214,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4383,6 +5235,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4400,6 +5256,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4417,6 +5277,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4434,6 +5298,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4451,6 +5319,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4468,6 +5340,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4485,6 +5361,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4502,6 +5382,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4519,6 +5403,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4537,7 +5425,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4558,7 +5446,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4579,7 +5467,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4599,6 +5487,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -4616,6 +5508,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4633,6 +5529,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4651,7 +5551,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4672,7 +5572,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4692,6 +5592,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4710,7 +5614,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4731,7 +5635,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4752,7 +5656,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4773,7 +5677,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4794,7 +5698,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4814,6 +5718,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -4828,6 +5736,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -4844,7 +5756,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4860,6 +5772,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -4874,6 +5790,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -4888,6 +5808,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -4902,6 +5826,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -4916,6 +5844,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -4933,6 +5865,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -4950,6 +5886,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -4967,6 +5907,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -4984,6 +5928,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5001,6 +5949,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5018,6 +5970,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5035,6 +5991,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5052,6 +6012,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5069,6 +6033,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5086,6 +6054,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5103,6 +6075,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5120,6 +6096,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5137,6 +6117,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5154,6 +6138,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5171,6 +6159,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5188,6 +6180,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5205,6 +6201,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5219,6 +6219,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5236,6 +6240,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5253,6 +6261,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5270,6 +6282,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5287,6 +6303,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5304,6 +6324,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5321,6 +6345,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5338,6 +6366,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5355,6 +6387,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5372,6 +6408,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5389,6 +6429,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5403,6 +6447,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5417,6 +6465,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5431,6 +6483,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5445,6 +6501,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5462,6 +6522,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5476,6 +6540,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5494,7 +6562,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5515,7 +6583,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5536,7 +6604,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5556,6 +6624,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5573,6 +6645,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5590,6 +6666,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5607,6 +6687,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5624,6 +6708,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5641,6 +6729,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5658,6 +6750,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5676,7 +6772,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5696,6 +6792,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5714,7 +6814,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5734,6 +6834,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -5752,7 +6856,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5773,7 +6877,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5794,7 +6898,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5834,7 +6938,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5851,7 +6955,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5872,7 +6976,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5888,6 +6992,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -5906,7 +7014,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5927,7 +7035,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5948,7 +7056,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5969,7 +7077,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5989,6 +7097,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6007,7 +7119,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6027,6 +7139,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6045,7 +7161,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6066,7 +7182,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6087,7 +7203,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6108,7 +7224,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6129,7 +7245,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6149,6 +7265,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6163,6 +7283,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6180,6 +7304,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6194,6 +7322,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6208,6 +7340,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6225,6 +7361,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6242,6 +7382,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6259,6 +7403,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6276,6 +7424,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6293,6 +7445,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6310,6 +7466,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6327,6 +7487,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6344,6 +7508,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
@@ -42,10 +42,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -63,10 +59,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -84,10 +76,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -105,10 +93,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -126,10 +110,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -147,10 +127,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -168,10 +144,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -210,10 +182,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -231,10 +199,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -270,10 +234,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -291,10 +251,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -312,10 +268,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -333,10 +285,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -354,10 +302,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -375,10 +319,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -396,10 +336,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -480,10 +416,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -522,10 +454,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -585,10 +513,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -606,10 +530,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -627,10 +547,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -648,10 +564,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -669,10 +581,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -690,10 +598,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -711,10 +615,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -732,10 +632,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -795,10 +691,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -816,10 +708,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -837,10 +725,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -876,10 +760,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -897,10 +777,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1023,10 +899,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1058,10 +930,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1079,10 +947,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1100,10 +964,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1121,10 +981,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1142,10 +998,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1160,10 +1012,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1181,10 +1029,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1202,10 +1046,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1223,10 +1063,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1244,10 +1080,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1265,10 +1097,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1283,10 +1111,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1301,10 +1125,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1319,10 +1139,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1337,10 +1153,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1355,10 +1167,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1373,10 +1181,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1391,10 +1195,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1409,10 +1209,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1427,10 +1223,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1445,10 +1237,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1463,10 +1251,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1481,10 +1265,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1502,10 +1282,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1523,10 +1299,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1544,10 +1316,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1565,10 +1333,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1583,10 +1347,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1601,10 +1361,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1619,10 +1375,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1637,10 +1389,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1655,10 +1403,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1673,10 +1417,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1691,10 +1431,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1709,10 +1445,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1727,10 +1459,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1745,10 +1473,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1763,10 +1487,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1781,10 +1501,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1799,10 +1515,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1817,10 +1529,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1835,10 +1543,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1853,10 +1557,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1874,10 +1574,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1895,10 +1591,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1916,10 +1608,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1937,10 +1625,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1955,10 +1639,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1973,10 +1653,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1991,10 +1667,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2009,10 +1681,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2027,10 +1695,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2045,10 +1709,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2063,10 +1723,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2081,10 +1737,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2099,10 +1751,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2117,10 +1765,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2135,10 +1779,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2156,10 +1796,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2177,10 +1813,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2219,10 +1851,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2275,10 +1903,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2296,10 +1920,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2317,10 +1937,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2338,10 +1954,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2359,10 +1971,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2380,10 +1988,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2401,10 +2005,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2422,10 +2022,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2443,10 +2039,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2464,10 +2056,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2485,10 +2073,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2506,10 +2090,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2527,10 +2107,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2548,10 +2124,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2569,10 +2141,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2590,10 +2158,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2611,10 +2175,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2632,10 +2192,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2653,10 +2209,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2674,10 +2226,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2695,10 +2243,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2716,10 +2260,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2737,10 +2277,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2755,10 +2291,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2860,10 +2392,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2881,10 +2409,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2958,10 +2482,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2979,10 +2499,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3042,10 +2558,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3081,10 +2593,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3102,10 +2610,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3123,10 +2627,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3144,10 +2644,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3165,10 +2661,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3186,10 +2678,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3207,10 +2695,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3228,10 +2712,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3249,10 +2729,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3270,10 +2746,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3291,10 +2763,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3312,10 +2780,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3333,10 +2797,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3354,10 +2814,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3372,10 +2828,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3390,10 +2842,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3444,10 +2892,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3483,10 +2927,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3630,10 +3070,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3648,10 +3084,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3750,10 +3182,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3771,10 +3199,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3792,10 +3216,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3813,10 +3233,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3834,10 +3250,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3855,10 +3267,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3873,10 +3281,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3996,10 +3400,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4017,10 +3417,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4038,10 +3434,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4059,10 +3451,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4080,10 +3468,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4101,10 +3485,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4122,10 +3502,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4140,10 +3516,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4161,10 +3533,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4179,10 +3547,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4197,10 +3561,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4215,10 +3575,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4233,10 +3589,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4251,10 +3603,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4269,10 +3617,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4287,10 +3631,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4305,10 +3645,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4323,10 +3659,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4341,10 +3673,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4359,10 +3687,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4377,10 +3701,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4395,10 +3715,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4413,10 +3729,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4431,10 +3743,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4449,10 +3757,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4467,10 +3771,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4485,10 +3785,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4503,10 +3799,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4521,10 +3813,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4542,10 +3830,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4560,10 +3844,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4578,10 +3858,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4596,10 +3872,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4614,10 +3886,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4632,10 +3900,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4650,10 +3914,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4668,10 +3928,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4686,10 +3942,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4704,10 +3956,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4722,10 +3970,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4740,10 +3984,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4758,10 +3998,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4779,10 +4015,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4800,10 +4032,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4821,10 +4049,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4842,10 +4066,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4863,10 +4083,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4884,10 +4100,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4905,10 +4117,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4926,10 +4134,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4947,10 +4151,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4968,10 +4168,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4989,10 +4185,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5010,10 +4202,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5031,10 +4219,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5052,10 +4236,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5070,10 +4250,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5088,10 +4264,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5109,10 +4281,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5130,10 +4298,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5151,10 +4315,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5172,10 +4332,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5193,10 +4349,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5214,10 +4366,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5235,10 +4383,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5256,10 +4400,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5277,10 +4417,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5298,10 +4434,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5319,10 +4451,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5340,10 +4468,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5361,10 +4485,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5382,10 +4502,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5403,10 +4519,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5487,10 +4599,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5508,10 +4616,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5529,10 +4633,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5592,10 +4692,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5718,10 +4814,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5736,10 +4828,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5772,10 +4860,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5790,10 +4874,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5808,10 +4888,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5826,10 +4902,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5844,10 +4916,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5865,10 +4933,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5886,10 +4950,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5907,10 +4967,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5928,10 +4984,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5949,10 +5001,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5970,10 +5018,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5991,10 +5035,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6012,10 +5052,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6033,10 +5069,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6054,10 +5086,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6075,10 +5103,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6096,10 +5120,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6117,10 +5137,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6138,10 +5154,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6159,10 +5171,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6180,10 +5188,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6201,10 +5205,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6219,10 +5219,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6240,10 +5236,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6261,10 +5253,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6282,10 +5270,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6303,10 +5287,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6324,10 +5304,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6345,10 +5321,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6366,10 +5338,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6387,10 +5355,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6408,10 +5372,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6429,10 +5389,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6447,10 +5403,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6465,10 +5417,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6483,10 +5431,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6501,10 +5445,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6522,10 +5462,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6540,10 +5476,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6624,10 +5556,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6645,10 +5573,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6666,10 +5590,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6687,10 +5607,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6708,10 +5624,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6729,10 +5641,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6750,10 +5658,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6792,10 +5696,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6834,10 +5734,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -6992,10 +5888,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7097,10 +5989,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7139,10 +6027,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7265,10 +6149,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7283,10 +6163,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7304,10 +6180,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7322,10 +6194,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7340,10 +6208,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7361,10 +6225,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7382,10 +6242,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7403,10 +6259,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7424,10 +6276,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7445,10 +6293,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7466,10 +6310,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7487,10 +6327,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7508,10 +6344,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
@@ -22,7 +22,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -42,6 +42,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -59,6 +63,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -76,6 +84,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -93,6 +105,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -110,6 +126,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -127,6 +147,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -144,6 +168,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -162,7 +190,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -182,6 +210,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -199,6 +231,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -234,6 +270,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -251,6 +291,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -268,6 +312,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -285,6 +333,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -302,6 +354,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -319,6 +375,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -336,6 +396,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -354,7 +418,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -375,7 +439,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -396,7 +460,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -416,6 +480,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -434,7 +502,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -454,6 +522,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -472,7 +544,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -493,7 +565,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -513,6 +585,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -530,6 +606,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -547,6 +627,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -564,6 +648,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -581,6 +669,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -598,6 +690,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -615,6 +711,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -632,6 +732,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -650,7 +754,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -671,7 +775,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -691,6 +795,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -708,6 +816,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -725,6 +837,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -744,7 +860,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -760,6 +876,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -777,6 +897,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -795,7 +919,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -816,7 +940,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -837,7 +961,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -858,7 +982,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -879,7 +1003,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -899,6 +1023,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -914,7 +1042,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -930,6 +1058,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -947,6 +1079,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -964,6 +1100,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -981,6 +1121,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -998,6 +1142,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1012,6 +1160,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1029,6 +1181,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1046,6 +1202,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1063,6 +1223,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1080,6 +1244,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1097,6 +1265,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1111,6 +1283,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1125,6 +1301,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1139,6 +1319,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1153,6 +1337,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1167,6 +1355,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1181,6 +1373,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1195,6 +1391,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1209,6 +1409,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1223,6 +1427,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1237,6 +1445,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1251,6 +1463,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1265,6 +1481,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1282,6 +1502,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1299,6 +1523,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1316,6 +1544,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1333,6 +1565,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1347,6 +1583,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1361,6 +1601,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1375,6 +1619,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1389,6 +1637,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1403,6 +1655,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1417,6 +1673,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1431,6 +1691,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1445,6 +1709,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1459,6 +1727,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1473,6 +1745,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1487,6 +1763,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1501,6 +1781,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1515,6 +1799,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1529,6 +1817,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1543,6 +1835,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1557,6 +1853,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1574,6 +1874,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1591,6 +1895,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1608,6 +1916,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1625,6 +1937,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1639,6 +1955,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1653,6 +1973,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1667,6 +1991,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1681,6 +2009,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1695,6 +2027,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -1709,6 +2045,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -1723,6 +2063,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -1737,6 +2081,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -1751,6 +2099,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -1765,6 +2117,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -1779,6 +2135,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -1796,6 +2156,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -1813,6 +2177,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -1831,7 +2199,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1851,6 +2219,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -1866,7 +2238,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1887,7 +2259,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1903,6 +2275,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -1920,6 +2296,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -1937,6 +2317,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -1954,6 +2338,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -1971,6 +2359,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -1988,6 +2380,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2005,6 +2401,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2022,6 +2422,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2039,6 +2443,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2056,6 +2464,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2073,6 +2485,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2090,6 +2506,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2107,6 +2527,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2124,6 +2548,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2141,6 +2569,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2158,6 +2590,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2175,6 +2611,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2192,6 +2632,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2209,6 +2653,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2226,6 +2674,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2243,6 +2695,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2260,6 +2716,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2277,6 +2737,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2291,6 +2755,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2309,7 +2777,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2330,7 +2798,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2351,7 +2819,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2372,7 +2840,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2392,6 +2860,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2409,6 +2881,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2427,7 +2903,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2448,7 +2924,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2482,6 +2958,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2499,6 +2979,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -2517,7 +3001,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2538,7 +3022,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2558,6 +3042,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2573,7 +3061,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2593,6 +3081,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2610,6 +3102,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2627,6 +3123,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2644,6 +3144,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2661,6 +3165,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2678,6 +3186,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2695,6 +3207,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2712,6 +3228,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2729,6 +3249,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2746,6 +3270,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -2763,6 +3291,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -2780,6 +3312,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -2797,6 +3333,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -2814,6 +3354,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -2828,6 +3372,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -2842,6 +3390,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -2858,7 +3410,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2876,7 +3428,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2892,6 +3444,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -2911,7 +3467,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2927,6 +3483,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -2945,7 +3505,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2966,7 +3526,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2987,7 +3547,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3008,7 +3568,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3029,7 +3589,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3050,7 +3610,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3070,6 +3630,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3084,6 +3648,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3099,7 +3667,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3120,7 +3688,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3141,7 +3709,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3162,7 +3730,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3182,6 +3750,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3199,6 +3771,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3216,6 +3792,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3233,6 +3813,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3250,6 +3834,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3267,6 +3855,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3281,6 +3873,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3296,7 +3892,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3317,7 +3913,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3338,7 +3934,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3359,7 +3955,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3380,7 +3976,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3400,6 +3996,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3417,6 +4017,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3434,6 +4038,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3451,6 +4059,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3468,6 +4080,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3485,6 +4101,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3502,6 +4122,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3516,6 +4140,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3533,6 +4161,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3547,6 +4179,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3561,6 +4197,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3575,6 +4215,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3589,6 +4233,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3603,6 +4251,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3617,6 +4269,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3631,6 +4287,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3645,6 +4305,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3659,6 +4323,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3673,6 +4341,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3687,6 +4359,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3701,6 +4377,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3715,6 +4395,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3729,6 +4413,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3743,6 +4431,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -3757,6 +4449,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -3771,6 +4467,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -3785,6 +4485,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -3799,6 +4503,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -3813,6 +4521,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -3830,6 +4542,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -3844,6 +4560,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -3858,6 +4578,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -3872,6 +4596,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -3886,6 +4614,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -3900,6 +4632,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -3914,6 +4650,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -3928,6 +4668,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -3942,6 +4686,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -3956,6 +4704,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -3970,6 +4722,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -3984,6 +4740,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -3998,6 +4758,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4015,6 +4779,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4032,6 +4800,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4049,6 +4821,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4066,6 +4842,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4083,6 +4863,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4100,6 +4884,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4117,6 +4905,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4134,6 +4926,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4151,6 +4947,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4168,6 +4968,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4185,6 +4989,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4202,6 +5010,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4219,6 +5031,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4236,6 +5052,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4250,6 +5070,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4264,6 +5088,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4281,6 +5109,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4298,6 +5130,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4315,6 +5151,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4332,6 +5172,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4349,6 +5193,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4366,6 +5214,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4383,6 +5235,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4400,6 +5256,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4417,6 +5277,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4434,6 +5298,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4451,6 +5319,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4468,6 +5340,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4485,6 +5361,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4502,6 +5382,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4519,6 +5403,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4537,7 +5425,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4558,7 +5446,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4579,7 +5467,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4599,6 +5487,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -4616,6 +5508,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4633,6 +5529,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4651,7 +5551,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4672,7 +5572,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4692,6 +5592,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4710,7 +5614,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4731,7 +5635,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4752,7 +5656,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4773,7 +5677,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4794,7 +5698,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4814,6 +5718,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -4828,6 +5736,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -4844,7 +5756,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4860,6 +5772,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -4874,6 +5790,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -4888,6 +5808,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -4902,6 +5826,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -4916,6 +5844,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -4933,6 +5865,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -4950,6 +5886,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -4967,6 +5907,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -4984,6 +5928,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5001,6 +5949,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5018,6 +5970,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5035,6 +5991,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5052,6 +6012,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5069,6 +6033,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5086,6 +6054,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5103,6 +6075,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5120,6 +6096,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5137,6 +6117,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5154,6 +6138,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5171,6 +6159,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5188,6 +6180,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5205,6 +6201,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5219,6 +6219,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5236,6 +6240,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5253,6 +6261,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5270,6 +6282,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5287,6 +6303,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5304,6 +6324,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5321,6 +6345,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5338,6 +6366,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5355,6 +6387,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5372,6 +6408,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5389,6 +6429,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5403,6 +6447,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5417,6 +6465,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5431,6 +6483,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5445,6 +6501,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5462,6 +6522,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5476,6 +6540,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5494,7 +6562,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5515,7 +6583,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5536,7 +6604,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5556,6 +6624,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5573,6 +6645,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5590,6 +6666,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5607,6 +6687,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5624,6 +6708,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5641,6 +6729,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5658,6 +6750,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5676,7 +6772,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5696,6 +6792,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5714,7 +6814,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5734,6 +6834,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -5752,7 +6856,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5773,7 +6877,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5794,7 +6898,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5834,7 +6938,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5851,7 +6955,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5872,7 +6976,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5888,6 +6992,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -5906,7 +7014,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5927,7 +7035,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5948,7 +7056,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5969,7 +7077,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5989,6 +7097,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6007,7 +7119,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6027,6 +7139,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6045,7 +7161,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6066,7 +7182,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6087,7 +7203,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6108,7 +7224,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6129,7 +7245,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6149,6 +7265,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6163,6 +7283,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6180,6 +7304,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6194,6 +7322,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6208,6 +7340,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6225,6 +7361,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6242,6 +7382,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6259,6 +7403,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6276,6 +7424,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6293,6 +7445,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6310,6 +7466,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6327,6 +7487,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6344,6 +7508,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
@@ -42,10 +42,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -63,10 +59,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -84,10 +76,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -105,10 +93,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -126,10 +110,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -147,10 +127,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -168,10 +144,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -210,10 +182,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -231,10 +199,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -270,10 +234,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -291,10 +251,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -312,10 +268,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -333,10 +285,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -354,10 +302,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -375,10 +319,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -396,10 +336,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -480,10 +416,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -522,10 +454,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -585,10 +513,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -606,10 +530,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -627,10 +547,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -648,10 +564,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -669,10 +581,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -690,10 +598,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -711,10 +615,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -732,10 +632,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -795,10 +691,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -816,10 +708,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -837,10 +725,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -876,10 +760,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -897,10 +777,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1023,10 +899,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1058,10 +930,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1079,10 +947,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1100,10 +964,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1121,10 +981,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1142,10 +998,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1160,10 +1012,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1181,10 +1029,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1202,10 +1046,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1223,10 +1063,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1244,10 +1080,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1265,10 +1097,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1283,10 +1111,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1301,10 +1125,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1319,10 +1139,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1337,10 +1153,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1355,10 +1167,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1373,10 +1181,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1391,10 +1195,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1409,10 +1209,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1427,10 +1223,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1445,10 +1237,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1463,10 +1251,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1481,10 +1265,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1502,10 +1282,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1523,10 +1299,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1544,10 +1316,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1565,10 +1333,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1583,10 +1347,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1601,10 +1361,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1619,10 +1375,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1637,10 +1389,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1655,10 +1403,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1673,10 +1417,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1691,10 +1431,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1709,10 +1445,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1727,10 +1459,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1745,10 +1473,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1763,10 +1487,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1781,10 +1501,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1799,10 +1515,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1817,10 +1529,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1835,10 +1543,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1853,10 +1557,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1874,10 +1574,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1895,10 +1591,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1916,10 +1608,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1937,10 +1625,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1955,10 +1639,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1973,10 +1653,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1991,10 +1667,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2009,10 +1681,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2027,10 +1695,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2045,10 +1709,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2063,10 +1723,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2081,10 +1737,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2099,10 +1751,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2117,10 +1765,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2135,10 +1779,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2156,10 +1796,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2177,10 +1813,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2219,10 +1851,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2275,10 +1903,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2296,10 +1920,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2317,10 +1937,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2338,10 +1954,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2359,10 +1971,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2380,10 +1988,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2401,10 +2005,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2422,10 +2022,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2443,10 +2039,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2464,10 +2056,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2485,10 +2073,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2506,10 +2090,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2527,10 +2107,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2548,10 +2124,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2569,10 +2141,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2590,10 +2158,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2611,10 +2175,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2632,10 +2192,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2653,10 +2209,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2674,10 +2226,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2695,10 +2243,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2716,10 +2260,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2737,10 +2277,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2755,10 +2291,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2860,10 +2392,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2881,10 +2409,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2958,10 +2482,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2979,10 +2499,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3042,10 +2558,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3081,10 +2593,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3102,10 +2610,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3123,10 +2627,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3144,10 +2644,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3165,10 +2661,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3186,10 +2678,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3207,10 +2695,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3228,10 +2712,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3249,10 +2729,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3270,10 +2746,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3291,10 +2763,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3312,10 +2780,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3333,10 +2797,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3354,10 +2814,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3372,10 +2828,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3390,10 +2842,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3444,10 +2892,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3483,10 +2927,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3630,10 +3070,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3648,10 +3084,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3750,10 +3182,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3771,10 +3199,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3792,10 +3216,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3813,10 +3233,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3834,10 +3250,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3855,10 +3267,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3873,10 +3281,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3996,10 +3400,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4017,10 +3417,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4038,10 +3434,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4059,10 +3451,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4080,10 +3468,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4101,10 +3485,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4122,10 +3502,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4140,10 +3516,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4161,10 +3533,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4179,10 +3547,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4197,10 +3561,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4215,10 +3575,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4233,10 +3589,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4251,10 +3603,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4269,10 +3617,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4287,10 +3631,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4305,10 +3645,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4323,10 +3659,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4341,10 +3673,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4359,10 +3687,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4377,10 +3701,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4395,10 +3715,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4413,10 +3729,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4431,10 +3743,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4449,10 +3757,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4467,10 +3771,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4485,10 +3785,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4503,10 +3799,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4521,10 +3813,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4542,10 +3830,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4560,10 +3844,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4578,10 +3858,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4596,10 +3872,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4614,10 +3886,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4632,10 +3900,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4650,10 +3914,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4668,10 +3928,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4686,10 +3942,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4704,10 +3956,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4722,10 +3970,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4740,10 +3984,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4758,10 +3998,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4779,10 +4015,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4800,10 +4032,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4821,10 +4049,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4842,10 +4066,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4863,10 +4083,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4884,10 +4100,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4905,10 +4117,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4926,10 +4134,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4947,10 +4151,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4968,10 +4168,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4989,10 +4185,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5010,10 +4202,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5031,10 +4219,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5052,10 +4236,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5070,10 +4250,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5088,10 +4264,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5109,10 +4281,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5130,10 +4298,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5151,10 +4315,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5172,10 +4332,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5193,10 +4349,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5214,10 +4366,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5235,10 +4383,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5256,10 +4400,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5277,10 +4417,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5298,10 +4434,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5319,10 +4451,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5340,10 +4468,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5361,10 +4485,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5382,10 +4502,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5403,10 +4519,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5487,10 +4599,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5508,10 +4616,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5529,10 +4633,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5592,10 +4692,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5718,10 +4814,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5736,10 +4828,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5772,10 +4860,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5790,10 +4874,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5808,10 +4888,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5826,10 +4902,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5844,10 +4916,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5865,10 +4933,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5886,10 +4950,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5907,10 +4967,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5928,10 +4984,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5949,10 +5001,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5970,10 +5018,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5991,10 +5035,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6012,10 +5052,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6033,10 +5069,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6054,10 +5086,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6075,10 +5103,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6096,10 +5120,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6117,10 +5137,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6138,10 +5154,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6159,10 +5171,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6180,10 +5188,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6201,10 +5205,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6219,10 +5219,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6240,10 +5236,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6261,10 +5253,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6282,10 +5270,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6303,10 +5287,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6324,10 +5304,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6345,10 +5321,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6366,10 +5338,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6387,10 +5355,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6408,10 +5372,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6429,10 +5389,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6447,10 +5403,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6465,10 +5417,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6483,10 +5431,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6501,10 +5445,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6522,10 +5462,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6540,10 +5476,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6624,10 +5556,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6645,10 +5573,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6666,10 +5590,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6687,10 +5607,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6708,10 +5624,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6729,10 +5641,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6750,10 +5658,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6792,10 +5696,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6834,10 +5734,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -6992,10 +5888,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7097,10 +5989,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7139,10 +6027,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7265,10 +6149,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7283,10 +6163,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7304,10 +6180,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7322,10 +6194,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7340,10 +6208,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7361,10 +6225,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7382,10 +6242,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7403,10 +6259,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7424,10 +6276,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7445,10 +6293,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7466,10 +6310,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7487,10 +6327,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7508,10 +6344,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusFor.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusFor.json
@@ -5,7 +5,7 @@
     "detail": "for",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n[for item in list: {\n\t\n}]\n```"
+      "value": "```bicep\n[for item in list: {\n\t\n}]\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -23,7 +23,7 @@
     "detail": "for-filtered",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n[for (item, index) in list: if (condition) {\n\t\n}]\n```"
+      "value": "```bicep\n[for (item, index) in list: if (condition) {\n\t\n}]\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -41,7 +41,7 @@
     "detail": "for-indexed",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n[for (item, index) in list: {\n\t\n}]\n```"
+      "value": "```bicep\n[for (item, index) in list: {\n\t\n}]\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -73,7 +73,7 @@
     "detail": "Required properties",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n{\n\tname: \n\tlocation: \n}\n```"
+      "value": "```bicep\n{\n\tname: \n\tlocation: \n}\n```  \n"
     },
     "deprecated": false,
     "preselect": true,
@@ -104,7 +104,7 @@
     "detail": "DNS Record",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n{\n  name: 'name'\n  location: location\n}\n\n```"
+      "value": "```bicep\n{\n  name: 'name'\n  location: location\n}\n\n```  \n"
     },
     "deprecated": false,
     "preselect": true,
@@ -135,7 +135,7 @@
     "detail": "{}",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n{\n\t\n}\n```"
+      "value": "```bicep\n{\n\t\n}\n```  \n"
     },
     "deprecated": false,
     "preselect": true,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbols.json
@@ -4,7 +4,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24,6 +24,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -41,6 +45,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -58,6 +66,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -75,6 +87,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -92,6 +108,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -109,6 +129,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -126,6 +150,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -144,7 +172,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -164,6 +192,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -181,6 +213,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -216,6 +252,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -233,6 +273,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -250,6 +294,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -267,6 +315,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -284,6 +336,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -301,6 +357,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -318,6 +378,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -336,7 +400,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -357,7 +421,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -378,7 +442,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -398,6 +462,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -416,7 +484,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -436,6 +504,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -454,7 +526,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -475,7 +547,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -495,6 +567,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -512,6 +588,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -529,6 +609,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -546,6 +630,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -563,6 +651,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -580,6 +672,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -597,6 +693,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -614,6 +714,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -632,7 +736,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -653,7 +757,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -673,6 +777,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -690,6 +798,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -707,6 +819,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -726,7 +842,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -742,6 +858,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -759,6 +879,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -777,7 +901,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -798,7 +922,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -819,7 +943,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -840,7 +964,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -861,7 +985,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -881,6 +1005,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -896,7 +1024,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -912,6 +1040,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -929,6 +1061,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -946,6 +1082,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -963,6 +1103,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -980,6 +1124,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -994,6 +1142,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1011,6 +1163,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1028,6 +1184,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1045,6 +1205,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1062,6 +1226,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1079,6 +1247,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1093,6 +1265,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1107,6 +1283,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1121,6 +1301,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1135,6 +1319,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1149,6 +1337,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1163,6 +1355,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1177,6 +1373,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1191,6 +1391,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1205,6 +1409,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1219,6 +1427,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1233,6 +1445,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1247,6 +1463,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1264,6 +1484,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1281,6 +1505,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1298,6 +1526,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1315,6 +1547,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1329,6 +1565,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1343,6 +1583,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1357,6 +1601,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1371,6 +1619,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1385,6 +1637,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1399,6 +1655,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1413,6 +1673,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1427,6 +1691,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1441,6 +1709,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1455,6 +1727,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1469,6 +1745,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1483,6 +1763,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1497,6 +1781,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1511,6 +1799,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1525,6 +1817,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1539,6 +1835,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1556,6 +1856,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1573,6 +1877,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1590,6 +1898,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1607,6 +1919,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1621,6 +1937,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1635,6 +1955,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1649,6 +1973,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1663,6 +1991,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1677,6 +2009,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -1691,6 +2027,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -1705,6 +2045,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -1719,6 +2063,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -1733,6 +2081,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -1747,6 +2099,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -1761,6 +2117,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -1775,6 +2135,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -1792,6 +2156,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -1809,6 +2177,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -1827,7 +2199,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1847,6 +2219,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -1862,7 +2238,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1883,7 +2259,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1899,6 +2275,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -1916,6 +2296,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -1933,6 +2317,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -1950,6 +2338,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -1967,6 +2359,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -1984,6 +2380,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2001,6 +2401,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2018,6 +2422,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2035,6 +2443,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2052,6 +2464,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2069,6 +2485,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2086,6 +2506,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2103,6 +2527,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2120,6 +2548,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2137,6 +2569,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2154,6 +2590,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2171,6 +2611,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2188,6 +2632,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2205,6 +2653,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2222,6 +2674,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2239,6 +2695,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2256,6 +2716,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2273,6 +2737,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2287,6 +2755,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2305,7 +2777,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2326,7 +2798,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2347,7 +2819,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2368,7 +2840,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2388,6 +2860,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2405,6 +2881,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2423,7 +2903,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2444,7 +2924,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2478,6 +2958,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2496,7 +2980,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2517,7 +3001,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2537,6 +3021,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2552,7 +3040,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2572,6 +3060,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2589,6 +3081,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2606,6 +3102,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2623,6 +3123,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2640,6 +3144,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2657,6 +3165,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2674,6 +3186,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2691,6 +3207,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2708,6 +3228,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2725,6 +3249,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -2742,6 +3270,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -2759,6 +3291,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -2776,6 +3312,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -2793,6 +3333,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -2807,6 +3351,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -2821,6 +3369,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -2837,7 +3389,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2855,7 +3407,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2871,6 +3423,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -2890,7 +3446,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2906,6 +3462,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -2924,7 +3484,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2945,7 +3505,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2966,7 +3526,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2987,7 +3547,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3008,7 +3568,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3029,7 +3589,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3049,6 +3609,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3063,6 +3627,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3078,7 +3646,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3099,7 +3667,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3120,7 +3688,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3141,7 +3709,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3161,6 +3729,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3178,6 +3750,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3195,6 +3771,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3212,6 +3792,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3229,6 +3813,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3246,6 +3834,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3260,6 +3852,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3275,7 +3871,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3296,7 +3892,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3317,7 +3913,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3338,7 +3934,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3359,7 +3955,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3379,6 +3975,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3396,6 +3996,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3413,6 +4017,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3430,6 +4038,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3447,6 +4059,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3464,6 +4080,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3481,6 +4101,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3495,6 +4119,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3512,6 +4140,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3526,6 +4158,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3540,6 +4176,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3554,6 +4194,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3568,6 +4212,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3582,6 +4230,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3596,6 +4248,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3610,6 +4266,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3624,6 +4284,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3638,6 +4302,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3652,6 +4320,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3666,6 +4338,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3680,6 +4356,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3694,6 +4374,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3708,6 +4392,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3722,6 +4410,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -3736,6 +4428,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -3750,6 +4446,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -3764,6 +4464,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -3778,6 +4482,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -3792,6 +4500,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -3809,6 +4521,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -3823,6 +4539,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -3837,6 +4557,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -3851,6 +4575,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -3865,6 +4593,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -3879,6 +4611,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -3893,6 +4629,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -3907,6 +4647,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -3921,6 +4665,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -3935,6 +4683,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -3949,6 +4701,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -3963,6 +4719,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -3977,6 +4737,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -3994,6 +4758,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4011,6 +4779,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4028,6 +4800,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4045,6 +4821,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4062,6 +4842,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4079,6 +4863,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4096,6 +4884,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4113,6 +4905,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4130,6 +4926,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4147,6 +4947,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4164,6 +4968,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4181,6 +4989,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4198,6 +5010,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4215,6 +5031,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4229,6 +5049,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4243,6 +5067,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4260,6 +5088,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4277,6 +5109,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4294,6 +5130,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4311,6 +5151,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4328,6 +5172,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4345,6 +5193,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4362,6 +5214,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4379,6 +5235,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4396,6 +5256,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4413,6 +5277,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4430,6 +5298,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4447,6 +5319,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4464,6 +5340,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4481,6 +5361,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4498,6 +5382,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4516,7 +5404,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4537,7 +5425,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4558,7 +5446,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4578,6 +5466,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -4595,6 +5487,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4612,6 +5508,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4630,7 +5530,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4651,7 +5551,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4671,6 +5571,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4689,7 +5593,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4710,7 +5614,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4731,7 +5635,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4752,7 +5656,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4773,7 +5677,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4793,6 +5697,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -4807,6 +5715,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -4823,7 +5735,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4839,6 +5751,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -4853,6 +5769,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -4867,6 +5787,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -4881,6 +5805,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -4895,6 +5823,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -4912,6 +5844,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -4929,6 +5865,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -4946,6 +5886,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -4963,6 +5907,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -4980,6 +5928,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -4997,6 +5949,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5014,6 +5970,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5031,6 +5991,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5048,6 +6012,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5065,6 +6033,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5082,6 +6054,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5099,6 +6075,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5116,6 +6096,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5133,6 +6117,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5150,6 +6138,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5167,6 +6159,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5184,6 +6180,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5198,6 +6198,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5215,6 +6219,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5232,6 +6240,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5249,6 +6261,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5266,6 +6282,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5283,6 +6303,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5300,6 +6324,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5317,6 +6345,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5334,6 +6366,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5351,6 +6387,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5368,6 +6408,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5382,6 +6426,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5396,6 +6444,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5410,6 +6462,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5424,6 +6480,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5441,6 +6501,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5455,6 +6519,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5473,7 +6541,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5494,7 +6562,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5515,7 +6583,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5535,6 +6603,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5552,6 +6624,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5569,6 +6645,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5586,6 +6666,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5603,6 +6687,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5620,6 +6708,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5637,6 +6729,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5655,7 +6751,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5675,6 +6771,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5693,7 +6793,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5713,6 +6813,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -5731,7 +6835,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5752,7 +6856,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5773,7 +6877,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5813,7 +6917,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5830,7 +6934,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5851,7 +6955,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5867,6 +6971,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -5885,7 +6993,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5906,7 +7014,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5927,7 +7035,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5948,7 +7056,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5968,6 +7076,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -5986,7 +7098,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6006,6 +7118,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6024,7 +7140,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6045,7 +7161,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6066,7 +7182,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6087,7 +7203,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6108,7 +7224,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6128,6 +7244,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6142,6 +7262,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6159,6 +7283,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6173,6 +7301,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6187,6 +7319,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6204,6 +7340,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6221,6 +7361,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6238,6 +7382,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6255,6 +7403,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6272,6 +7424,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6289,6 +7445,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6306,6 +7466,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6323,6 +7487,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",
@@ -6342,7 +7510,7 @@
     "detail": "{}",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n{\n\t\n}\n```"
+      "value": "```bicep\n{\n\t\n}\n```  \n"
     },
     "deprecated": false,
     "preselect": true,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbols.json
@@ -24,10 +24,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -45,10 +41,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -66,10 +58,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -87,10 +75,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -108,10 +92,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -129,10 +109,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -150,10 +126,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -192,10 +164,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -213,10 +181,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -252,10 +216,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -273,10 +233,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -294,10 +250,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -315,10 +267,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -336,10 +284,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -357,10 +301,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -378,10 +318,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -462,10 +398,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -504,10 +436,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -567,10 +495,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -588,10 +512,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -609,10 +529,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -630,10 +546,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -651,10 +563,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -672,10 +580,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -693,10 +597,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -714,10 +614,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -777,10 +673,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -798,10 +690,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -819,10 +707,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -858,10 +742,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -879,10 +759,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1005,10 +881,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1040,10 +912,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1061,10 +929,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1082,10 +946,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1103,10 +963,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1124,10 +980,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1142,10 +994,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1163,10 +1011,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1184,10 +1028,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1205,10 +1045,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1226,10 +1062,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1247,10 +1079,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1265,10 +1093,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1283,10 +1107,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1301,10 +1121,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1319,10 +1135,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1337,10 +1149,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1355,10 +1163,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1373,10 +1177,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1391,10 +1191,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1409,10 +1205,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1427,10 +1219,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1445,10 +1233,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1463,10 +1247,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1484,10 +1264,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1505,10 +1281,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1526,10 +1298,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1547,10 +1315,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1565,10 +1329,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1583,10 +1343,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1601,10 +1357,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1619,10 +1371,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1637,10 +1385,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1655,10 +1399,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1673,10 +1413,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1691,10 +1427,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1709,10 +1441,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1727,10 +1455,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1745,10 +1469,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1763,10 +1483,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1781,10 +1497,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1799,10 +1511,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1817,10 +1525,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1835,10 +1539,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1856,10 +1556,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1877,10 +1573,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1898,10 +1590,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1919,10 +1607,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1937,10 +1621,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1955,10 +1635,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1973,10 +1649,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1991,10 +1663,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2009,10 +1677,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2027,10 +1691,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2045,10 +1705,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2063,10 +1719,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2081,10 +1733,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2099,10 +1747,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2117,10 +1761,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2135,10 +1775,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2156,10 +1792,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2177,10 +1809,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2219,10 +1847,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2275,10 +1899,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2296,10 +1916,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2317,10 +1933,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2338,10 +1950,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2359,10 +1967,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2380,10 +1984,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2401,10 +2001,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2422,10 +2018,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2443,10 +2035,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2464,10 +2052,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2485,10 +2069,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2506,10 +2086,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2527,10 +2103,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2548,10 +2120,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2569,10 +2137,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2590,10 +2154,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2611,10 +2171,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2632,10 +2188,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2653,10 +2205,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2674,10 +2222,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2695,10 +2239,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2716,10 +2256,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2737,10 +2273,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2755,10 +2287,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2860,10 +2388,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2881,10 +2405,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2958,10 +2478,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -3021,10 +2537,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3060,10 +2572,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3081,10 +2589,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3102,10 +2606,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3123,10 +2623,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3144,10 +2640,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3165,10 +2657,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3186,10 +2674,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3207,10 +2691,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3228,10 +2708,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3249,10 +2725,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3270,10 +2742,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3291,10 +2759,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3312,10 +2776,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3333,10 +2793,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3351,10 +2807,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3369,10 +2821,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3423,10 +2871,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3462,10 +2906,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3609,10 +3049,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3627,10 +3063,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3729,10 +3161,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3750,10 +3178,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3771,10 +3195,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3792,10 +3212,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3813,10 +3229,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3834,10 +3246,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3852,10 +3260,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3975,10 +3379,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3996,10 +3396,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4017,10 +3413,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4038,10 +3430,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4059,10 +3447,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4080,10 +3464,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4101,10 +3481,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4119,10 +3495,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4140,10 +3512,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4158,10 +3526,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4176,10 +3540,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4194,10 +3554,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4212,10 +3568,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4230,10 +3582,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4248,10 +3596,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4266,10 +3610,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4284,10 +3624,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4302,10 +3638,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4320,10 +3652,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4338,10 +3666,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4356,10 +3680,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4374,10 +3694,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4392,10 +3708,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4410,10 +3722,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4428,10 +3736,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4446,10 +3750,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4464,10 +3764,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4482,10 +3778,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4500,10 +3792,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4521,10 +3809,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4539,10 +3823,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4557,10 +3837,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4575,10 +3851,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4593,10 +3865,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4611,10 +3879,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4629,10 +3893,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4647,10 +3907,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4665,10 +3921,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4683,10 +3935,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4701,10 +3949,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4719,10 +3963,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4737,10 +3977,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4758,10 +3994,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4779,10 +4011,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4800,10 +4028,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4821,10 +4045,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4842,10 +4062,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4863,10 +4079,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4884,10 +4096,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4905,10 +4113,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4926,10 +4130,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4947,10 +4147,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4968,10 +4164,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4989,10 +4181,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5010,10 +4198,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5031,10 +4215,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5049,10 +4229,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5067,10 +4243,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5088,10 +4260,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5109,10 +4277,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5130,10 +4294,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5151,10 +4311,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5172,10 +4328,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5193,10 +4345,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5214,10 +4362,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5235,10 +4379,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5256,10 +4396,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5277,10 +4413,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5298,10 +4430,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5319,10 +4447,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5340,10 +4464,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5361,10 +4481,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5382,10 +4498,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5466,10 +4578,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5487,10 +4595,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5508,10 +4612,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5571,10 +4671,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5697,10 +4793,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5715,10 +4807,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5751,10 +4839,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5769,10 +4853,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5787,10 +4867,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5805,10 +4881,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5823,10 +4895,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5844,10 +4912,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5865,10 +4929,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5886,10 +4946,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5907,10 +4963,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5928,10 +4980,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5949,10 +4997,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5970,10 +5014,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5991,10 +5031,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6012,10 +5048,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6033,10 +5065,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6054,10 +5082,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6075,10 +5099,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6096,10 +5116,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6117,10 +5133,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6138,10 +5150,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6159,10 +5167,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6180,10 +5184,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6198,10 +5198,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6219,10 +5215,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6240,10 +5232,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6261,10 +5249,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6282,10 +5266,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6303,10 +5283,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6324,10 +5300,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6345,10 +5317,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6366,10 +5334,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6387,10 +5351,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6408,10 +5368,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6426,10 +5382,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6444,10 +5396,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6462,10 +5410,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6480,10 +5424,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6501,10 +5441,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6519,10 +5455,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6603,10 +5535,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6624,10 +5552,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6645,10 +5569,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6666,10 +5586,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6687,10 +5603,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6708,10 +5620,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6729,10 +5637,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6771,10 +5675,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6813,10 +5713,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -6971,10 +5867,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7076,10 +5968,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7118,10 +6006,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7244,10 +6128,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7262,10 +6142,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7283,10 +6159,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7301,10 +6173,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7319,10 +6187,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7340,10 +6204,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7361,10 +6221,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7382,10 +6238,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7403,10 +6255,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7424,10 +6272,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7445,10 +6289,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7466,10 +6306,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7487,10 +6323,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
@@ -4,7 +4,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24,6 +24,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -41,6 +45,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -58,6 +66,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -75,6 +87,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -92,6 +108,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -109,6 +129,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -126,6 +150,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -144,7 +172,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -164,6 +192,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -181,6 +213,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -216,6 +252,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -233,6 +273,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -250,6 +294,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -267,6 +315,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -284,6 +336,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -301,6 +357,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -318,6 +378,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -336,7 +400,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -357,7 +421,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -378,7 +442,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -398,6 +462,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -416,7 +484,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -436,6 +504,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -454,7 +526,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -475,7 +547,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -495,6 +567,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -512,6 +588,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -529,6 +609,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -546,6 +630,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -563,6 +651,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -580,6 +672,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -597,6 +693,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -614,6 +714,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -632,7 +736,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -653,7 +757,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -673,6 +777,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -690,6 +798,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -707,6 +819,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -726,7 +842,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -742,6 +858,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -759,6 +879,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -777,7 +901,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -798,7 +922,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -819,7 +943,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -840,7 +964,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -861,7 +985,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -881,6 +1005,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -896,7 +1024,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -912,6 +1040,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -929,6 +1061,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -946,6 +1082,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -963,6 +1103,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -980,6 +1124,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -994,6 +1142,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1011,6 +1163,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1028,6 +1184,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1045,6 +1205,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1062,6 +1226,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1079,6 +1247,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1093,6 +1265,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1107,6 +1283,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1121,6 +1301,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1135,6 +1319,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1149,6 +1337,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1163,6 +1355,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1177,6 +1373,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1191,6 +1391,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1205,6 +1409,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1219,6 +1427,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1233,6 +1445,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1247,6 +1463,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1264,6 +1484,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1281,6 +1505,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1298,6 +1526,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1315,6 +1547,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1329,6 +1565,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1343,6 +1583,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1357,6 +1601,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1371,6 +1619,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1385,6 +1637,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1399,6 +1655,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1413,6 +1673,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1427,6 +1691,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1441,6 +1709,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1455,6 +1727,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1469,6 +1745,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1483,6 +1763,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1497,6 +1781,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1511,6 +1799,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1525,6 +1817,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1539,6 +1835,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1556,6 +1856,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1573,6 +1877,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1590,6 +1898,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1607,6 +1919,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1621,6 +1937,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1635,6 +1955,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1649,6 +1973,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1663,6 +1991,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1677,6 +2009,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -1691,6 +2027,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -1705,6 +2045,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -1719,6 +2063,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -1733,6 +2081,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -1747,6 +2099,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -1761,6 +2117,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -1775,6 +2135,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -1792,6 +2156,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -1809,6 +2177,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -1827,7 +2199,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1847,6 +2219,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -1862,7 +2238,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1883,7 +2259,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1899,6 +2275,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -1916,6 +2296,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -1933,6 +2317,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -1950,6 +2338,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -1967,6 +2359,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -1984,6 +2380,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2001,6 +2401,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2018,6 +2422,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2035,6 +2443,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2052,6 +2464,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2069,6 +2485,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2086,6 +2506,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2103,6 +2527,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2120,6 +2548,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2137,6 +2569,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2154,6 +2590,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2171,6 +2611,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2188,6 +2632,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2205,6 +2653,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2222,6 +2674,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2239,6 +2695,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2256,6 +2716,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2273,6 +2737,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2287,6 +2755,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2305,7 +2777,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2326,7 +2798,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2347,7 +2819,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2368,7 +2840,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2388,6 +2860,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2405,6 +2881,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2423,7 +2903,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2444,7 +2924,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2478,6 +2958,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2496,7 +2980,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2517,7 +3001,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2537,6 +3021,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2552,7 +3040,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2572,6 +3060,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2589,6 +3081,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2606,6 +3102,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2623,6 +3123,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2640,6 +3144,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2657,6 +3165,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2674,6 +3186,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2691,6 +3207,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2708,6 +3228,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2725,6 +3249,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -2742,6 +3270,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -2759,6 +3291,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -2776,6 +3312,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -2793,6 +3333,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -2807,6 +3351,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -2821,6 +3369,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -2837,7 +3389,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2855,7 +3407,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2871,6 +3423,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -2890,7 +3446,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2906,6 +3462,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -2924,7 +3484,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2945,7 +3505,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2966,7 +3526,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2987,7 +3547,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3008,7 +3568,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3029,7 +3589,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3049,6 +3609,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3063,6 +3627,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3078,7 +3646,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3099,7 +3667,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3120,7 +3688,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3141,7 +3709,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3161,6 +3729,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3178,6 +3750,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3195,6 +3771,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3212,6 +3792,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3229,6 +3813,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3246,6 +3834,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3260,6 +3852,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3275,7 +3871,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3296,7 +3892,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3317,7 +3913,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3338,7 +3934,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3359,7 +3955,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3379,6 +3975,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3396,6 +3996,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3413,6 +4017,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3430,6 +4038,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3447,6 +4059,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3464,6 +4080,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3481,6 +4101,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3495,6 +4119,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3512,6 +4140,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3526,6 +4158,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3540,6 +4176,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3554,6 +4194,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3568,6 +4212,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3582,6 +4230,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3596,6 +4248,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3610,6 +4266,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3624,6 +4284,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3638,6 +4302,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3652,6 +4320,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3666,6 +4338,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3680,6 +4356,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3694,6 +4374,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3708,6 +4392,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3722,6 +4410,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -3736,6 +4428,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -3750,6 +4446,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -3764,6 +4464,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -3778,6 +4482,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -3792,6 +4500,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -3809,6 +4521,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -3823,6 +4539,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -3837,6 +4557,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -3851,6 +4575,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -3865,6 +4593,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -3879,6 +4611,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -3893,6 +4629,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -3907,6 +4647,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -3921,6 +4665,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -3935,6 +4683,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -3949,6 +4701,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -3963,6 +4719,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -3977,6 +4737,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -3994,6 +4758,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4011,6 +4779,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4028,6 +4800,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4045,6 +4821,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4062,6 +4842,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4079,6 +4863,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4096,6 +4884,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4113,6 +4905,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4130,6 +4926,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4147,6 +4947,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4164,6 +4968,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4181,6 +4989,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4198,6 +5010,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4215,6 +5031,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4229,6 +5049,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4243,6 +5067,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4260,6 +5088,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4277,6 +5109,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4294,6 +5130,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4311,6 +5151,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4328,6 +5172,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4345,6 +5193,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4362,6 +5214,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4379,6 +5235,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4396,6 +5256,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4413,6 +5277,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4430,6 +5298,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4447,6 +5319,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4464,6 +5340,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4481,6 +5361,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4498,6 +5382,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4516,7 +5404,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4537,7 +5425,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4558,7 +5446,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4578,6 +5466,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -4595,6 +5487,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4612,6 +5508,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4630,7 +5530,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4651,7 +5551,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4671,6 +5571,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4689,7 +5593,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4710,7 +5614,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4731,7 +5635,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4753,7 +5657,7 @@
     "detail": "Required properties",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n{\n\tname: \n}\n```"
+      "value": "```bicep\n{\n\tname: \n}\n```  \n"
     },
     "deprecated": false,
     "preselect": true,
@@ -4782,7 +5686,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4803,7 +5707,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4823,6 +5727,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -4837,6 +5745,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -4853,7 +5765,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4869,6 +5781,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -4883,6 +5799,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -4897,6 +5817,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -4911,6 +5835,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -4925,6 +5853,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -4942,6 +5874,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -4959,6 +5895,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -4976,6 +5916,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -4993,6 +5937,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5010,6 +5958,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5027,6 +5979,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5044,6 +6000,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5061,6 +6021,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5078,6 +6042,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5095,6 +6063,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5112,6 +6084,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5129,6 +6105,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5146,6 +6126,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5163,6 +6147,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5180,6 +6168,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5197,6 +6189,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5214,6 +6210,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5228,6 +6228,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5245,6 +6249,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5262,6 +6270,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5279,6 +6291,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5296,6 +6312,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5313,6 +6333,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5330,6 +6354,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5347,6 +6375,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5364,6 +6396,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5381,6 +6417,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5398,6 +6438,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5412,6 +6456,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5426,6 +6474,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5440,6 +6492,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5454,6 +6510,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5471,6 +6531,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5485,6 +6549,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5503,7 +6571,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5524,7 +6592,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5545,7 +6613,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5565,6 +6633,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5582,6 +6654,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5599,6 +6675,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5616,6 +6696,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5633,6 +6717,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5650,6 +6738,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5667,6 +6759,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5685,7 +6781,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5705,6 +6801,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5723,7 +6823,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5743,6 +6843,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -5761,7 +6865,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5782,7 +6886,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5803,7 +6907,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5843,7 +6947,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5860,7 +6964,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5881,7 +6985,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5897,6 +7001,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -5915,7 +7023,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5936,7 +7044,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5957,7 +7065,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5978,7 +7086,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5998,6 +7106,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6016,7 +7128,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6036,6 +7148,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6054,7 +7170,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6075,7 +7191,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6096,7 +7212,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6117,7 +7233,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6138,7 +7254,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6158,6 +7274,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6172,6 +7292,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6189,6 +7313,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6203,6 +7331,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6217,6 +7349,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6234,6 +7370,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6251,6 +7391,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6268,6 +7412,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6285,6 +7433,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6302,6 +7454,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6319,6 +7475,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6336,6 +7496,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6353,6 +7517,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",
@@ -6372,7 +7540,7 @@
     "detail": "{}",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n{\n\t\n}\n```"
+      "value": "```bicep\n{\n\t\n}\n```  \n"
     },
     "deprecated": false,
     "preselect": true,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
@@ -24,10 +24,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -45,10 +41,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -66,10 +58,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -87,10 +75,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -108,10 +92,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -129,10 +109,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -150,10 +126,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -192,10 +164,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -213,10 +181,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -252,10 +216,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -273,10 +233,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -294,10 +250,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -315,10 +267,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -336,10 +284,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -357,10 +301,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -378,10 +318,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -462,10 +398,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -504,10 +436,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -567,10 +495,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -588,10 +512,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -609,10 +529,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -630,10 +546,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -651,10 +563,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -672,10 +580,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -693,10 +597,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -714,10 +614,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -777,10 +673,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -798,10 +690,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -819,10 +707,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -858,10 +742,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -879,10 +759,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1005,10 +881,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1040,10 +912,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1061,10 +929,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1082,10 +946,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1103,10 +963,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1124,10 +980,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1142,10 +994,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1163,10 +1011,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1184,10 +1028,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1205,10 +1045,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1226,10 +1062,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1247,10 +1079,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1265,10 +1093,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1283,10 +1107,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1301,10 +1121,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1319,10 +1135,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1337,10 +1149,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1355,10 +1163,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1373,10 +1177,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1391,10 +1191,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1409,10 +1205,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1427,10 +1219,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1445,10 +1233,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1463,10 +1247,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1484,10 +1264,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1505,10 +1281,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1526,10 +1298,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1547,10 +1315,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1565,10 +1329,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1583,10 +1343,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1601,10 +1357,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1619,10 +1371,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1637,10 +1385,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1655,10 +1399,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1673,10 +1413,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1691,10 +1427,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1709,10 +1441,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1727,10 +1455,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1745,10 +1469,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1763,10 +1483,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1781,10 +1497,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1799,10 +1511,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1817,10 +1525,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1835,10 +1539,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1856,10 +1556,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1877,10 +1573,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1898,10 +1590,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1919,10 +1607,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1937,10 +1621,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1955,10 +1635,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1973,10 +1649,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1991,10 +1663,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2009,10 +1677,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2027,10 +1691,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2045,10 +1705,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2063,10 +1719,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2081,10 +1733,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2099,10 +1747,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2117,10 +1761,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2135,10 +1775,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2156,10 +1792,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2177,10 +1809,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2219,10 +1847,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2275,10 +1899,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2296,10 +1916,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2317,10 +1933,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2338,10 +1950,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2359,10 +1967,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2380,10 +1984,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2401,10 +2001,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2422,10 +2018,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2443,10 +2035,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2464,10 +2052,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2485,10 +2069,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2506,10 +2086,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2527,10 +2103,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2548,10 +2120,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2569,10 +2137,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2590,10 +2154,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2611,10 +2171,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2632,10 +2188,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2653,10 +2205,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2674,10 +2222,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2695,10 +2239,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2716,10 +2256,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2737,10 +2273,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2755,10 +2287,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2860,10 +2388,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2881,10 +2405,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2958,10 +2478,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -3021,10 +2537,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3060,10 +2572,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3081,10 +2589,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3102,10 +2606,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3123,10 +2623,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3144,10 +2640,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3165,10 +2657,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3186,10 +2674,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3207,10 +2691,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3228,10 +2708,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3249,10 +2725,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3270,10 +2742,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3291,10 +2759,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3312,10 +2776,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3333,10 +2793,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3351,10 +2807,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3369,10 +2821,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3423,10 +2871,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3462,10 +2906,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3609,10 +3049,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3627,10 +3063,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3729,10 +3161,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3750,10 +3178,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3771,10 +3195,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3792,10 +3212,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3813,10 +3229,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3834,10 +3246,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3852,10 +3260,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3975,10 +3379,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3996,10 +3396,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4017,10 +3413,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4038,10 +3430,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4059,10 +3447,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4080,10 +3464,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4101,10 +3481,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4119,10 +3495,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4140,10 +3512,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4158,10 +3526,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4176,10 +3540,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4194,10 +3554,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4212,10 +3568,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4230,10 +3582,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4248,10 +3596,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4266,10 +3610,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4284,10 +3624,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4302,10 +3638,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4320,10 +3652,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4338,10 +3666,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4356,10 +3680,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4374,10 +3694,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4392,10 +3708,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4410,10 +3722,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4428,10 +3736,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4446,10 +3750,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4464,10 +3764,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4482,10 +3778,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4500,10 +3792,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4521,10 +3809,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4539,10 +3823,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4557,10 +3837,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4575,10 +3851,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4593,10 +3865,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4611,10 +3879,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4629,10 +3893,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4647,10 +3907,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4665,10 +3921,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4683,10 +3935,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4701,10 +3949,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4719,10 +3963,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4737,10 +3977,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4758,10 +3994,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4779,10 +4011,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4800,10 +4028,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4821,10 +4045,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4842,10 +4062,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4863,10 +4079,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4884,10 +4096,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4905,10 +4113,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4926,10 +4130,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4947,10 +4147,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4968,10 +4164,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4989,10 +4181,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5010,10 +4198,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5031,10 +4215,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5049,10 +4229,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5067,10 +4243,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5088,10 +4260,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5109,10 +4277,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5130,10 +4294,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5151,10 +4311,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5172,10 +4328,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5193,10 +4345,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5214,10 +4362,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5235,10 +4379,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5256,10 +4396,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5277,10 +4413,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5298,10 +4430,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5319,10 +4447,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5340,10 +4464,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5361,10 +4481,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5382,10 +4498,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5466,10 +4578,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5487,10 +4595,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5508,10 +4612,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5571,10 +4671,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5727,10 +4823,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5745,10 +4837,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5781,10 +4869,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5799,10 +4883,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5817,10 +4897,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5835,10 +4911,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5853,10 +4925,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5874,10 +4942,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5895,10 +4959,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5916,10 +4976,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5937,10 +4993,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5958,10 +5010,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5979,10 +5027,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -6000,10 +5044,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6021,10 +5061,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6042,10 +5078,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6063,10 +5095,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6084,10 +5112,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6105,10 +5129,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6126,10 +5146,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6147,10 +5163,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6168,10 +5180,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6189,10 +5197,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6210,10 +5214,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6228,10 +5228,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6249,10 +5245,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6270,10 +5262,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6291,10 +5279,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6312,10 +5296,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6333,10 +5313,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6354,10 +5330,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6375,10 +5347,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6396,10 +5364,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6417,10 +5381,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6438,10 +5398,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6456,10 +5412,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6474,10 +5426,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6492,10 +5440,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6510,10 +5454,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6531,10 +5471,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6549,10 +5485,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6633,10 +5565,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6654,10 +5582,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6675,10 +5599,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6696,10 +5616,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6717,10 +5633,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6738,10 +5650,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6759,10 +5667,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6801,10 +5705,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6843,10 +5743,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -7001,10 +5897,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7106,10 +5998,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7148,10 +6036,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7274,10 +6158,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7292,10 +6172,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7313,10 +6189,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7331,10 +6203,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7349,10 +6217,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7370,10 +6234,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7391,10 +6251,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7412,10 +6268,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7433,10 +6285,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7454,10 +6302,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7475,10 +6319,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7496,10 +6336,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7517,10 +6353,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/storageAccountsResourceTypes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/storageAccountsResourceTypes.json
@@ -4,7 +4,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2015-05-01-preview`"
+      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2015-05-01-preview`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22,7 +22,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2015-06-15`"
+      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2015-06-15`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40,7 +40,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2016-01-01`"
+      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2016-01-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -58,7 +58,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2016-05-01`"
+      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2016-05-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -76,7 +76,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2016-12-01`"
+      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2016-12-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -94,7 +94,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2017-06-01`"
+      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2017-06-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -112,7 +112,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2017-10-01`"
+      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2017-10-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -130,7 +130,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2018-02-01`"
+      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2018-02-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -148,7 +148,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2018-03-01-preview`"
+      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2018-03-01-preview`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -166,7 +166,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2018-07-01`"
+      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2018-07-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -184,7 +184,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2018-11-01`"
+      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2018-11-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -202,7 +202,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2019-04-01`"
+      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2019-04-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -220,7 +220,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2019-06-01`"
+      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2019-06-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -238,7 +238,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2020-08-01-preview`"
+      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2020-08-01-preview`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -256,7 +256,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2021-01-01`"
+      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2021-01-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -274,7 +274,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2021-02-01`"
+      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2021-02-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -292,7 +292,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2021-04-01`"
+      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2021-04-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -310,7 +310,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2021-06-01`"
+      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2021-06-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -328,7 +328,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2021-08-01`"
+      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2021-08-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -346,7 +346,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2021-09-01`"
+      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2021-09-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -364,7 +364,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2022-05-01`"
+      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2022-05-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -382,7 +382,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2022-09-01`"
+      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2022-09-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -400,7 +400,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2023-01-01`"
+      "value": "Type: `Microsoft.Storage/storageAccounts`  \nAPI Version: `2023-01-01`  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
@@ -130,7 +130,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -150,6 +150,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -167,6 +171,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -184,6 +192,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -201,6 +213,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -218,6 +234,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -235,6 +255,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -252,6 +276,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -270,7 +298,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -290,6 +318,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -307,6 +339,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -342,6 +378,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -359,6 +399,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -376,6 +420,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -393,6 +441,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -410,6 +462,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -427,6 +483,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -444,6 +504,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -462,7 +526,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -483,7 +547,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -504,7 +568,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -524,6 +588,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -542,7 +610,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -562,6 +630,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -580,7 +652,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -601,7 +673,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -621,6 +693,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -638,6 +714,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -655,6 +735,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -672,6 +756,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -689,6 +777,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -706,6 +798,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -723,6 +819,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -740,6 +840,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -758,7 +862,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -779,7 +883,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -799,6 +903,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -816,6 +924,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -833,6 +945,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -852,7 +968,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -868,6 +984,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -885,6 +1005,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -903,7 +1027,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -924,7 +1048,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -945,7 +1069,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -966,7 +1090,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -987,7 +1111,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1007,6 +1131,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1022,7 +1150,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1038,6 +1166,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1055,6 +1187,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1072,6 +1208,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1089,6 +1229,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1106,6 +1250,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1120,6 +1268,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1137,6 +1289,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1154,6 +1310,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1171,6 +1331,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1188,6 +1352,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1205,6 +1373,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1219,6 +1391,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1233,6 +1409,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1247,6 +1427,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1261,6 +1445,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1275,6 +1463,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1289,6 +1481,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1303,6 +1499,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1317,6 +1517,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1331,6 +1535,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1345,6 +1553,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1359,6 +1571,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1373,6 +1589,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1390,6 +1610,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1407,6 +1631,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1424,6 +1652,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1441,6 +1673,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1455,6 +1691,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1469,6 +1709,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1483,6 +1727,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1497,6 +1745,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1511,6 +1763,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1525,6 +1781,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1539,6 +1799,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1553,6 +1817,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1567,6 +1835,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1581,6 +1853,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1595,6 +1871,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1609,6 +1889,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1623,6 +1907,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1637,6 +1925,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1651,6 +1943,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1665,6 +1961,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1682,6 +1982,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1699,6 +2003,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1716,6 +2024,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1733,6 +2045,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1747,6 +2063,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1761,6 +2081,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1775,6 +2099,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1789,6 +2117,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1803,6 +2135,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -1817,6 +2153,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -1831,6 +2171,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -1845,6 +2189,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -1859,6 +2207,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -1873,6 +2225,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -1887,6 +2243,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -1901,6 +2261,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -1918,6 +2282,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -1935,6 +2303,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -1953,7 +2325,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1973,6 +2345,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -1988,7 +2364,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2009,7 +2385,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2025,6 +2401,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2042,6 +2422,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2059,6 +2443,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2076,6 +2464,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2093,6 +2485,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2110,6 +2506,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2127,6 +2527,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2144,6 +2548,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2161,6 +2569,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2178,6 +2590,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2195,6 +2611,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2212,6 +2632,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2229,6 +2653,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2246,6 +2674,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2263,6 +2695,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2280,6 +2716,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2297,6 +2737,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2314,6 +2758,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2331,6 +2779,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2348,6 +2800,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2365,6 +2821,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2382,6 +2842,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2399,6 +2863,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2413,6 +2881,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2431,7 +2903,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2452,7 +2924,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2473,7 +2945,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2494,7 +2966,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2514,6 +2986,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2531,6 +3007,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2549,7 +3029,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2570,7 +3050,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2604,6 +3084,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2621,6 +3105,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -2639,7 +3127,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2660,7 +3148,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2680,6 +3168,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2695,7 +3187,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2715,6 +3207,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2732,6 +3228,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2749,6 +3249,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2766,6 +3270,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2783,6 +3291,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2800,6 +3312,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2817,6 +3333,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2834,6 +3354,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2851,6 +3375,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2868,6 +3396,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -2885,6 +3417,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -2902,6 +3438,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -2919,6 +3459,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -2936,6 +3480,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -2950,6 +3498,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -2964,6 +3516,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -2980,7 +3536,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2998,7 +3554,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3014,6 +3570,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3033,7 +3593,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3049,6 +3609,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3067,7 +3631,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3088,7 +3652,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3109,7 +3673,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3130,7 +3694,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3151,7 +3715,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3172,7 +3736,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3192,6 +3756,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3206,6 +3774,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3221,7 +3793,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3242,7 +3814,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3263,7 +3835,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3284,7 +3856,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3304,6 +3876,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3321,6 +3897,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3338,6 +3918,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3355,6 +3939,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3372,6 +3960,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3389,6 +3981,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3403,6 +3999,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3418,7 +4018,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3439,7 +4039,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3460,7 +4060,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3481,7 +4081,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3502,7 +4102,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3522,6 +4122,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3539,6 +4143,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3556,6 +4164,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3573,6 +4185,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3590,6 +4206,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3607,6 +4227,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3624,6 +4248,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3638,6 +4266,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3655,6 +4287,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3669,6 +4305,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3683,6 +4323,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3697,6 +4341,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3711,6 +4359,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3725,6 +4377,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3739,6 +4395,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3753,6 +4413,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3767,6 +4431,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3781,6 +4449,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3795,6 +4467,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3809,6 +4485,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3823,6 +4503,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3837,6 +4521,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3851,6 +4539,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3865,6 +4557,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -3879,6 +4575,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -3893,6 +4593,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -3907,6 +4611,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -3921,6 +4629,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -3935,6 +4647,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -3952,6 +4668,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -3966,6 +4686,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -3980,6 +4704,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -3994,6 +4722,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4008,6 +4740,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4022,6 +4758,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4036,6 +4776,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4050,6 +4794,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4064,6 +4812,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4078,6 +4830,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4092,6 +4848,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4106,6 +4866,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4120,6 +4884,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4137,6 +4905,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4154,6 +4926,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4171,6 +4947,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4188,6 +4968,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4205,6 +4989,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4222,6 +5010,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4239,6 +5031,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4256,6 +5052,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4273,6 +5073,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4290,6 +5094,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4307,6 +5115,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4324,6 +5136,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4341,6 +5157,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4358,6 +5178,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4372,6 +5196,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4386,6 +5214,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4403,6 +5235,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4420,6 +5256,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4437,6 +5277,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4454,6 +5298,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4471,6 +5319,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4488,6 +5340,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4505,6 +5361,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4522,6 +5382,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4539,6 +5403,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4556,6 +5424,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4573,6 +5445,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4590,6 +5466,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4607,6 +5487,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4624,6 +5508,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4641,6 +5529,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4659,7 +5551,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4680,7 +5572,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4701,7 +5593,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4721,6 +5613,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4738,6 +5634,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4756,7 +5656,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4777,7 +5677,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4797,6 +5697,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4815,7 +5719,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4836,7 +5740,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4857,7 +5761,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4878,7 +5782,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4899,7 +5803,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4919,6 +5823,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -4933,6 +5841,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -4949,7 +5861,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4965,6 +5877,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -4979,6 +5895,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -4993,6 +5913,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5007,6 +5931,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5021,6 +5949,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5038,6 +5970,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5055,6 +5991,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5072,6 +6012,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5089,6 +6033,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5106,6 +6054,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5123,6 +6075,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5140,6 +6096,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5157,6 +6117,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5174,6 +6138,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5191,6 +6159,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5208,6 +6180,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5225,6 +6201,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5242,6 +6222,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5259,6 +6243,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5276,6 +6264,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5293,6 +6285,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5310,6 +6306,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5324,6 +6324,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5341,6 +6345,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5358,6 +6366,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5375,6 +6387,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5392,6 +6408,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5409,6 +6429,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5426,6 +6450,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5443,6 +6471,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5460,6 +6492,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5477,6 +6513,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5494,6 +6534,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5508,6 +6552,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5522,6 +6570,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5536,6 +6588,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5550,6 +6606,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5567,6 +6627,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5581,6 +6645,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5599,7 +6667,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5620,7 +6688,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5641,7 +6709,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5661,6 +6729,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5678,6 +6750,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5695,6 +6771,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5712,6 +6792,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5729,6 +6813,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5746,6 +6834,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5763,6 +6855,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5781,7 +6877,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5801,6 +6897,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5819,7 +6919,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5839,6 +6939,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -5857,7 +6961,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5878,7 +6982,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5899,7 +7003,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5939,7 +7043,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5956,7 +7060,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5977,7 +7081,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5993,6 +7097,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -6011,7 +7119,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6032,7 +7140,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6053,7 +7161,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6074,7 +7182,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6094,6 +7202,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6112,7 +7224,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6132,6 +7244,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6150,7 +7266,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6171,7 +7287,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6192,7 +7308,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6213,7 +7329,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6234,7 +7350,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6254,6 +7370,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6268,6 +7388,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6285,6 +7409,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6299,6 +7427,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6313,6 +7445,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6330,6 +7466,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6347,6 +7487,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6364,6 +7508,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6381,6 +7529,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6398,6 +7550,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6415,6 +7571,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6432,6 +7592,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6449,6 +7613,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
@@ -150,10 +150,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -171,10 +167,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -192,10 +184,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -213,10 +201,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -234,10 +218,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -255,10 +235,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -276,10 +252,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -318,10 +290,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -339,10 +307,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -378,10 +342,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -399,10 +359,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -420,10 +376,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -441,10 +393,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -462,10 +410,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -483,10 +427,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -504,10 +444,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -588,10 +524,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -630,10 +562,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -693,10 +621,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -714,10 +638,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -735,10 +655,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -756,10 +672,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -777,10 +689,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -798,10 +706,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -819,10 +723,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -840,10 +740,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -903,10 +799,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -924,10 +816,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -945,10 +833,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -984,10 +868,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -1005,10 +885,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1131,10 +1007,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1166,10 +1038,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1187,10 +1055,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1208,10 +1072,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1229,10 +1089,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1250,10 +1106,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1268,10 +1120,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1289,10 +1137,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1310,10 +1154,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1331,10 +1171,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1352,10 +1188,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1373,10 +1205,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1391,10 +1219,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1409,10 +1233,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1427,10 +1247,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1445,10 +1261,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1463,10 +1275,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1481,10 +1289,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1499,10 +1303,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1517,10 +1317,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1535,10 +1331,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1553,10 +1345,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1571,10 +1359,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1589,10 +1373,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1610,10 +1390,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1631,10 +1407,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1652,10 +1424,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1673,10 +1441,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1691,10 +1455,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1709,10 +1469,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1727,10 +1483,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1745,10 +1497,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1763,10 +1511,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1781,10 +1525,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1799,10 +1539,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1817,10 +1553,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1835,10 +1567,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1853,10 +1581,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1871,10 +1595,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1889,10 +1609,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1907,10 +1623,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1925,10 +1637,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1943,10 +1651,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1961,10 +1665,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1982,10 +1682,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -2003,10 +1699,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -2024,10 +1716,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -2045,10 +1733,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -2063,10 +1747,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -2081,10 +1761,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -2099,10 +1775,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2117,10 +1789,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2135,10 +1803,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2153,10 +1817,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2171,10 +1831,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2189,10 +1845,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2207,10 +1859,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2225,10 +1873,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2243,10 +1887,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2261,10 +1901,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2282,10 +1918,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2303,10 +1935,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2345,10 +1973,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2401,10 +2025,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2422,10 +2042,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2443,10 +2059,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2464,10 +2076,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2485,10 +2093,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2506,10 +2110,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2527,10 +2127,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2548,10 +2144,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2569,10 +2161,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2590,10 +2178,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2611,10 +2195,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2632,10 +2212,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2653,10 +2229,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2674,10 +2246,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2695,10 +2263,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2716,10 +2280,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2737,10 +2297,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2758,10 +2314,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2779,10 +2331,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2800,10 +2348,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2821,10 +2365,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2842,10 +2382,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2863,10 +2399,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2881,10 +2413,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2986,10 +2514,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -3007,10 +2531,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -3084,10 +2604,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -3105,10 +2621,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3168,10 +2680,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3207,10 +2715,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3228,10 +2732,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3249,10 +2749,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3270,10 +2766,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3291,10 +2783,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3312,10 +2800,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3333,10 +2817,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3354,10 +2834,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3375,10 +2851,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3396,10 +2868,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3417,10 +2885,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3438,10 +2902,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3459,10 +2919,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3480,10 +2936,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3498,10 +2950,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3516,10 +2964,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3570,10 +3014,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3609,10 +3049,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3756,10 +3192,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3774,10 +3206,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3876,10 +3304,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3897,10 +3321,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3918,10 +3338,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3939,10 +3355,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3960,10 +3372,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3981,10 +3389,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3999,10 +3403,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -4122,10 +3522,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4143,10 +3539,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4164,10 +3556,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4185,10 +3573,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4206,10 +3590,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4227,10 +3607,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4248,10 +3624,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4266,10 +3638,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4287,10 +3655,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4305,10 +3669,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4323,10 +3683,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4341,10 +3697,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4359,10 +3711,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4377,10 +3725,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4395,10 +3739,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4413,10 +3753,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4431,10 +3767,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4449,10 +3781,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4467,10 +3795,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4485,10 +3809,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4503,10 +3823,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4521,10 +3837,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4539,10 +3851,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4557,10 +3865,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4575,10 +3879,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4593,10 +3893,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4611,10 +3907,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4629,10 +3921,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4647,10 +3935,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4668,10 +3952,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4686,10 +3966,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4704,10 +3980,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4722,10 +3994,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4740,10 +4008,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4758,10 +4022,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4776,10 +4036,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4794,10 +4050,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4812,10 +4064,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4830,10 +4078,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4848,10 +4092,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4866,10 +4106,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4884,10 +4120,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4905,10 +4137,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4926,10 +4154,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4947,10 +4171,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4968,10 +4188,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4989,10 +4205,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -5010,10 +4222,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -5031,10 +4239,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -5052,10 +4256,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -5073,10 +4273,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -5094,10 +4290,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -5115,10 +4307,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5136,10 +4324,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5157,10 +4341,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5178,10 +4358,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5196,10 +4372,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5214,10 +4386,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5235,10 +4403,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5256,10 +4420,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5277,10 +4437,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5298,10 +4454,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5319,10 +4471,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5340,10 +4488,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5361,10 +4505,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5382,10 +4522,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5403,10 +4539,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5424,10 +4556,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5445,10 +4573,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5466,10 +4590,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5487,10 +4607,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5508,10 +4624,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5529,10 +4641,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5613,10 +4721,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5634,10 +4738,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5697,10 +4797,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5823,10 +4919,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5841,10 +4933,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5877,10 +4965,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5895,10 +4979,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5913,10 +4993,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5931,10 +5007,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5949,10 +5021,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5970,10 +5038,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5991,10 +5055,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -6012,10 +5072,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -6033,10 +5089,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -6054,10 +5106,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -6075,10 +5123,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -6096,10 +5140,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6117,10 +5157,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6138,10 +5174,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6159,10 +5191,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6180,10 +5208,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6201,10 +5225,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6222,10 +5242,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6243,10 +5259,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6264,10 +5276,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6285,10 +5293,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6306,10 +5310,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6324,10 +5324,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6345,10 +5341,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6366,10 +5358,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6387,10 +5375,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6408,10 +5392,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6429,10 +5409,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6450,10 +5426,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6471,10 +5443,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6492,10 +5460,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6513,10 +5477,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6534,10 +5494,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6552,10 +5508,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6570,10 +5522,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6588,10 +5536,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6606,10 +5550,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6627,10 +5567,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6645,10 +5581,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6729,10 +5661,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6750,10 +5678,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6771,10 +5695,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6792,10 +5712,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6813,10 +5729,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6834,10 +5746,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6855,10 +5763,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6897,10 +5801,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6939,10 +5839,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -7097,10 +5993,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7202,10 +6094,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7244,10 +6132,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7370,10 +6254,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7388,10 +6268,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7409,10 +6285,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7427,10 +6299,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7445,10 +6313,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7466,10 +6330,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7487,10 +6347,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7508,10 +6364,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7529,10 +6381,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7550,10 +6398,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7571,10 +6415,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7592,10 +6432,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7613,10 +6449,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbols.json
@@ -24,10 +24,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -45,10 +41,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -66,10 +58,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -87,10 +75,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -108,10 +92,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -129,10 +109,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -150,10 +126,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -192,10 +164,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -213,10 +181,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -252,10 +216,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -273,10 +233,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -294,10 +250,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -315,10 +267,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -336,10 +284,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -357,10 +301,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -378,10 +318,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -462,10 +398,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -504,10 +436,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -567,10 +495,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -588,10 +512,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -609,10 +529,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -630,10 +546,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -651,10 +563,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -672,10 +580,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -693,10 +597,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -714,10 +614,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -777,10 +673,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -798,10 +690,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -819,10 +707,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -858,10 +742,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -879,10 +759,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1005,10 +881,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1040,10 +912,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1061,10 +929,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1082,10 +946,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1103,10 +963,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1124,10 +980,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1142,10 +994,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1163,10 +1011,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1184,10 +1028,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1205,10 +1045,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1226,10 +1062,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1247,10 +1079,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1265,10 +1093,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1283,10 +1107,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1301,10 +1121,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1319,10 +1135,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1337,10 +1149,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1355,10 +1163,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1373,10 +1177,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1391,10 +1191,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1409,10 +1205,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1427,10 +1219,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1445,10 +1233,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1463,10 +1247,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1484,10 +1264,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1505,10 +1281,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1526,10 +1298,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1547,10 +1315,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1565,10 +1329,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1583,10 +1343,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1601,10 +1357,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1619,10 +1371,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1637,10 +1385,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1655,10 +1399,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1673,10 +1413,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1691,10 +1427,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1709,10 +1441,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1727,10 +1455,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1745,10 +1469,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1763,10 +1483,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1781,10 +1497,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1799,10 +1511,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1817,10 +1525,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1835,10 +1539,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1856,10 +1556,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1877,10 +1573,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1898,10 +1590,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1919,10 +1607,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1937,10 +1621,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1955,10 +1635,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1973,10 +1649,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1991,10 +1663,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2009,10 +1677,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2027,10 +1691,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2045,10 +1705,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2063,10 +1719,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2081,10 +1733,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2099,10 +1747,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2117,10 +1761,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2135,10 +1775,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2156,10 +1792,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2177,10 +1809,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2219,10 +1847,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2275,10 +1899,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2296,10 +1916,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2317,10 +1933,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2338,10 +1950,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2359,10 +1967,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2380,10 +1984,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2401,10 +2001,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2422,10 +2018,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2443,10 +2035,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2464,10 +2052,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2485,10 +2069,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2506,10 +2086,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2527,10 +2103,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2548,10 +2120,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2569,10 +2137,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2590,10 +2154,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2611,10 +2171,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2632,10 +2188,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2653,10 +2205,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2674,10 +2222,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2695,10 +2239,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2716,10 +2256,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2737,10 +2273,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2755,10 +2287,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2860,10 +2388,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2881,10 +2405,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2958,10 +2478,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2979,10 +2495,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3042,10 +2554,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3081,10 +2589,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3102,10 +2606,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3123,10 +2623,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3144,10 +2640,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3165,10 +2657,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3186,10 +2674,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3207,10 +2691,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3228,10 +2708,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3249,10 +2725,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3270,10 +2742,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3291,10 +2759,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3312,10 +2776,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3333,10 +2793,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3354,10 +2810,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3372,10 +2824,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3390,10 +2838,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3444,10 +2888,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3483,10 +2923,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3630,10 +3066,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3648,10 +3080,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3750,10 +3178,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3771,10 +3195,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3792,10 +3212,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3813,10 +3229,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3834,10 +3246,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3855,10 +3263,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3873,10 +3277,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3996,10 +3396,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4017,10 +3413,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4038,10 +3430,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4059,10 +3447,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4080,10 +3464,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4101,10 +3481,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4122,10 +3498,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4140,10 +3512,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4161,10 +3529,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4179,10 +3543,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4197,10 +3557,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4215,10 +3571,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4233,10 +3585,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4251,10 +3599,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4269,10 +3613,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4287,10 +3627,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4305,10 +3641,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4323,10 +3655,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4341,10 +3669,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4359,10 +3683,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4377,10 +3697,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4395,10 +3711,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4413,10 +3725,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4431,10 +3739,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4449,10 +3753,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4467,10 +3767,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4485,10 +3781,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4503,10 +3795,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4521,10 +3809,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4542,10 +3826,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4560,10 +3840,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4578,10 +3854,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4596,10 +3868,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4614,10 +3882,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4632,10 +3896,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4650,10 +3910,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4668,10 +3924,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4686,10 +3938,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4704,10 +3952,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4722,10 +3966,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4740,10 +3980,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4758,10 +3994,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4779,10 +4011,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4800,10 +4028,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4821,10 +4045,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4842,10 +4062,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4863,10 +4079,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4884,10 +4096,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4905,10 +4113,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4926,10 +4130,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4947,10 +4147,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4968,10 +4164,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4989,10 +4181,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5010,10 +4198,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5031,10 +4215,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5052,10 +4232,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5070,10 +4246,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5088,10 +4260,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5109,10 +4277,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5130,10 +4294,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5151,10 +4311,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5172,10 +4328,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5193,10 +4345,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5214,10 +4362,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5235,10 +4379,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5256,10 +4396,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5277,10 +4413,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5298,10 +4430,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5319,10 +4447,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5340,10 +4464,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5361,10 +4481,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5382,10 +4498,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5403,10 +4515,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5487,10 +4595,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5508,10 +4612,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5529,10 +4629,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5592,10 +4688,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5718,10 +4810,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5736,10 +4824,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5772,10 +4856,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5790,10 +4870,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5808,10 +4884,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5826,10 +4898,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5844,10 +4912,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5865,10 +4929,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5886,10 +4946,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5907,10 +4963,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5928,10 +4980,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5949,10 +4997,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5970,10 +5014,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5991,10 +5031,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6012,10 +5048,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6033,10 +5065,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6054,10 +5082,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6075,10 +5099,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6096,10 +5116,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6117,10 +5133,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6138,10 +5150,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6159,10 +5167,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6180,10 +5184,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6201,10 +5201,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6219,10 +5215,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6240,10 +5232,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6261,10 +5249,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6282,10 +5266,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6303,10 +5283,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6324,10 +5300,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6345,10 +5317,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6366,10 +5334,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6387,10 +5351,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6408,10 +5368,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6429,10 +5385,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6447,10 +5399,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6465,10 +5413,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6483,10 +5427,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6501,10 +5441,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6522,10 +5458,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6540,10 +5472,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6624,10 +5552,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6645,10 +5569,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6666,10 +5586,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6687,10 +5603,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6708,10 +5620,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6729,10 +5637,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6750,10 +5654,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6792,10 +5692,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6834,10 +5730,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -6992,10 +5884,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7097,10 +5985,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7139,10 +6023,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7265,10 +6145,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7283,10 +6159,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7304,10 +6176,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7322,10 +6190,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7340,10 +6204,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7361,10 +6221,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7382,10 +6238,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7403,10 +6255,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7424,10 +6272,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7445,10 +6289,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7466,10 +6306,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7487,10 +6323,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7508,10 +6340,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbols.json
@@ -4,7 +4,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -24,6 +24,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -41,6 +45,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -58,6 +66,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -75,6 +87,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -92,6 +108,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -109,6 +129,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -126,6 +150,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -144,7 +172,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -164,6 +192,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -181,6 +213,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -216,6 +252,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -233,6 +273,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -250,6 +294,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -267,6 +315,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -284,6 +336,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -301,6 +357,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -318,6 +378,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -336,7 +400,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -357,7 +421,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -378,7 +442,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -398,6 +462,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -416,7 +484,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -436,6 +504,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -454,7 +526,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -475,7 +547,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -495,6 +567,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -512,6 +588,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -529,6 +609,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -546,6 +630,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -563,6 +651,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -580,6 +672,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -597,6 +693,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -614,6 +714,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -632,7 +736,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -653,7 +757,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -673,6 +777,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -690,6 +798,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -707,6 +819,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -726,7 +842,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -742,6 +858,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -759,6 +879,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -777,7 +901,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -798,7 +922,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -819,7 +943,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -840,7 +964,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -861,7 +985,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -881,6 +1005,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -896,7 +1024,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -912,6 +1040,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -929,6 +1061,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -946,6 +1082,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -963,6 +1103,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -980,6 +1124,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -994,6 +1142,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1011,6 +1163,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1028,6 +1184,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1045,6 +1205,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1062,6 +1226,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1079,6 +1247,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1093,6 +1265,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1107,6 +1283,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1121,6 +1301,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1135,6 +1319,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1149,6 +1337,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1163,6 +1355,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1177,6 +1373,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1191,6 +1391,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1205,6 +1409,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1219,6 +1427,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1233,6 +1445,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1247,6 +1463,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1264,6 +1484,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1281,6 +1505,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1298,6 +1526,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1315,6 +1547,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1329,6 +1565,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1343,6 +1583,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1357,6 +1601,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1371,6 +1619,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1385,6 +1637,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1399,6 +1655,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1413,6 +1673,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1427,6 +1691,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1441,6 +1709,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1455,6 +1727,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1469,6 +1745,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1483,6 +1763,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1497,6 +1781,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1511,6 +1799,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1525,6 +1817,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1539,6 +1835,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1556,6 +1856,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1573,6 +1877,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1590,6 +1898,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1607,6 +1919,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1621,6 +1937,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1635,6 +1955,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1649,6 +1973,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1663,6 +1991,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1677,6 +2009,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -1691,6 +2027,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -1705,6 +2045,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -1719,6 +2063,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -1733,6 +2081,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -1747,6 +2099,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -1761,6 +2117,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -1775,6 +2135,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -1792,6 +2156,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -1809,6 +2177,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -1827,7 +2199,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1847,6 +2219,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -1862,7 +2238,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1883,7 +2259,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1899,6 +2275,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -1916,6 +2296,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -1933,6 +2317,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -1950,6 +2338,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -1967,6 +2359,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -1984,6 +2380,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2001,6 +2401,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2018,6 +2422,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2035,6 +2443,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2052,6 +2464,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2069,6 +2485,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2086,6 +2506,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2103,6 +2527,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2120,6 +2548,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2137,6 +2569,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2154,6 +2590,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2171,6 +2611,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2188,6 +2632,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2205,6 +2653,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2222,6 +2674,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2239,6 +2695,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2256,6 +2716,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2273,6 +2737,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2287,6 +2755,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2305,7 +2777,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2326,7 +2798,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2347,7 +2819,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2368,7 +2840,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2388,6 +2860,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2405,6 +2881,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2423,7 +2903,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2444,7 +2924,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2478,6 +2958,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2495,6 +2979,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -2513,7 +3001,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2534,7 +3022,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2554,6 +3042,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2569,7 +3061,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2589,6 +3081,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2606,6 +3102,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2623,6 +3123,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2640,6 +3144,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2657,6 +3165,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2674,6 +3186,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2691,6 +3207,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2708,6 +3228,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2725,6 +3249,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2742,6 +3270,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -2759,6 +3291,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -2776,6 +3312,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -2793,6 +3333,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -2810,6 +3354,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -2824,6 +3372,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -2838,6 +3390,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -2854,7 +3410,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2872,7 +3428,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2888,6 +3444,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -2907,7 +3467,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2923,6 +3483,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -2941,7 +3505,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2962,7 +3526,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2983,7 +3547,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3004,7 +3568,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3025,7 +3589,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3046,7 +3610,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3066,6 +3630,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3080,6 +3648,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3095,7 +3667,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3116,7 +3688,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3137,7 +3709,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3158,7 +3730,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3178,6 +3750,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3195,6 +3771,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3212,6 +3792,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3229,6 +3813,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3246,6 +3834,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3263,6 +3855,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3277,6 +3873,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3292,7 +3892,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3313,7 +3913,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3334,7 +3934,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3355,7 +3955,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3376,7 +3976,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3396,6 +3996,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3413,6 +4017,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3430,6 +4038,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3447,6 +4059,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3464,6 +4080,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3481,6 +4101,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3498,6 +4122,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3512,6 +4140,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3529,6 +4161,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3543,6 +4179,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3557,6 +4197,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3571,6 +4215,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3585,6 +4233,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3599,6 +4251,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3613,6 +4269,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3627,6 +4287,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3641,6 +4305,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3655,6 +4323,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3669,6 +4341,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3683,6 +4359,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3697,6 +4377,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3711,6 +4395,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3725,6 +4413,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3739,6 +4431,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -3753,6 +4449,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -3767,6 +4467,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -3781,6 +4485,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -3795,6 +4503,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -3809,6 +4521,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -3826,6 +4542,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -3840,6 +4560,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -3854,6 +4578,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -3868,6 +4596,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -3882,6 +4614,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -3896,6 +4632,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -3910,6 +4650,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -3924,6 +4668,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -3938,6 +4686,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -3952,6 +4704,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -3966,6 +4722,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -3980,6 +4740,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -3994,6 +4758,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4011,6 +4779,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4028,6 +4800,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4045,6 +4821,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4062,6 +4842,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4079,6 +4863,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4096,6 +4884,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4113,6 +4905,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4130,6 +4926,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4147,6 +4947,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4164,6 +4968,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4181,6 +4989,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4198,6 +5010,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4215,6 +5031,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4232,6 +5052,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4246,6 +5070,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4260,6 +5088,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4277,6 +5109,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4294,6 +5130,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4311,6 +5151,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4328,6 +5172,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4345,6 +5193,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4362,6 +5214,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4379,6 +5235,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4396,6 +5256,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4413,6 +5277,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4430,6 +5298,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4447,6 +5319,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4464,6 +5340,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4481,6 +5361,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4498,6 +5382,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4515,6 +5403,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4533,7 +5425,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4554,7 +5446,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4575,7 +5467,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4595,6 +5487,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -4612,6 +5508,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4629,6 +5529,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4647,7 +5551,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4668,7 +5572,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4688,6 +5592,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4706,7 +5614,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4727,7 +5635,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4748,7 +5656,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4769,7 +5677,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4790,7 +5698,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4810,6 +5718,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -4824,6 +5736,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -4840,7 +5756,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4856,6 +5772,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -4870,6 +5790,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -4884,6 +5808,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -4898,6 +5826,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -4912,6 +5844,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -4929,6 +5865,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -4946,6 +5886,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -4963,6 +5907,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -4980,6 +5928,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -4997,6 +5949,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5014,6 +5970,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5031,6 +5991,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5048,6 +6012,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5065,6 +6033,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5082,6 +6054,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5099,6 +6075,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5116,6 +6096,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5133,6 +6117,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5150,6 +6138,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5167,6 +6159,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5184,6 +6180,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5201,6 +6201,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5215,6 +6219,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5232,6 +6240,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5249,6 +6261,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5266,6 +6282,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5283,6 +6303,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5300,6 +6324,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5317,6 +6345,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5334,6 +6366,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5351,6 +6387,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5368,6 +6408,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5385,6 +6429,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5399,6 +6447,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5413,6 +6465,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5427,6 +6483,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5441,6 +6501,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5458,6 +6522,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5472,6 +6540,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5490,7 +6562,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5511,7 +6583,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5532,7 +6604,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5552,6 +6624,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5569,6 +6645,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5586,6 +6666,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5603,6 +6687,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5620,6 +6708,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5637,6 +6729,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5654,6 +6750,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5672,7 +6772,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5692,6 +6792,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5710,7 +6814,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5730,6 +6834,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -5748,7 +6856,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5769,7 +6877,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5790,7 +6898,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5830,7 +6938,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5847,7 +6955,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5868,7 +6976,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5884,6 +6992,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -5902,7 +7014,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5923,7 +7035,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5944,7 +7056,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5965,7 +7077,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5985,6 +7097,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6003,7 +7119,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6023,6 +7139,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6041,7 +7161,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6062,7 +7182,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6083,7 +7203,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6104,7 +7224,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6125,7 +7245,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6145,6 +7265,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6159,6 +7283,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6176,6 +7304,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6190,6 +7322,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6204,6 +7340,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6221,6 +7361,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6238,6 +7382,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6255,6 +7403,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6272,6 +7424,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6289,6 +7445,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6306,6 +7466,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6323,6 +7487,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6340,6 +7508,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
@@ -18,7 +18,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38,6 +38,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -55,6 +59,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -72,6 +80,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -89,6 +101,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -106,6 +122,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -123,6 +143,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -140,6 +164,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -158,7 +186,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -178,6 +206,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -195,6 +227,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -230,6 +266,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -247,6 +287,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -264,6 +308,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -281,6 +329,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -298,6 +350,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -315,6 +371,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -332,6 +392,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -350,7 +414,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -371,7 +435,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -392,7 +456,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -412,6 +476,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -430,7 +498,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -450,6 +518,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -468,7 +540,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -489,7 +561,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -509,6 +581,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -526,6 +602,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -543,6 +623,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -560,6 +644,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -577,6 +665,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -594,6 +686,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -611,6 +707,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -628,6 +728,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -646,7 +750,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -667,7 +771,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -687,6 +791,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -704,6 +812,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -721,6 +833,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -740,7 +856,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -756,6 +872,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -773,6 +893,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -791,7 +915,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -812,7 +936,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -833,7 +957,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -854,7 +978,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -875,7 +999,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -895,6 +1019,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -910,7 +1038,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -926,6 +1054,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -943,6 +1075,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -960,6 +1096,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -977,6 +1117,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -994,6 +1138,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1008,6 +1156,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1025,6 +1177,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1042,6 +1198,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1059,6 +1219,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1076,6 +1240,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1093,6 +1261,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1107,6 +1279,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1121,6 +1297,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1135,6 +1315,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1149,6 +1333,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1163,6 +1351,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1177,6 +1369,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1191,6 +1387,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1205,6 +1405,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1219,6 +1423,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1233,6 +1441,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1247,6 +1459,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1261,6 +1477,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1278,6 +1498,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1295,6 +1519,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1312,6 +1540,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1329,6 +1561,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1343,6 +1579,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1357,6 +1597,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1371,6 +1615,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1385,6 +1633,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1399,6 +1651,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1413,6 +1669,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1427,6 +1687,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1441,6 +1705,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1455,6 +1723,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1469,6 +1741,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1483,6 +1759,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1497,6 +1777,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1511,6 +1795,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1525,6 +1813,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1539,6 +1831,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1553,6 +1849,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1570,6 +1870,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1587,6 +1891,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1604,6 +1912,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1621,6 +1933,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1635,6 +1951,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1649,6 +1969,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1663,6 +1987,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1677,6 +2005,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1691,6 +2023,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -1705,6 +2041,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -1719,6 +2059,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -1733,6 +2077,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -1747,6 +2095,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -1761,6 +2113,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -1775,6 +2131,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -1789,6 +2149,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -1806,6 +2170,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -1823,6 +2191,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -1841,7 +2213,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1861,6 +2233,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -1876,7 +2252,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1897,7 +2273,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1913,6 +2289,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -1930,6 +2310,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -1947,6 +2331,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -1964,6 +2352,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -1981,6 +2373,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -1998,6 +2394,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2015,6 +2415,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2032,6 +2436,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2049,6 +2457,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2066,6 +2478,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2083,6 +2499,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2100,6 +2520,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2117,6 +2541,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2134,6 +2562,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2151,6 +2583,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2168,6 +2604,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2185,6 +2625,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2202,6 +2646,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2219,6 +2667,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2236,6 +2688,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2253,6 +2709,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2270,6 +2730,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2287,6 +2751,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2301,6 +2769,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2319,7 +2791,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2340,7 +2812,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2361,7 +2833,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2382,7 +2854,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2402,6 +2874,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2419,6 +2895,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2437,7 +2917,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2458,7 +2938,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2492,6 +2972,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2509,6 +2993,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -2527,7 +3015,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2548,7 +3036,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2568,6 +3056,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2583,7 +3075,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2603,6 +3095,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2620,6 +3116,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2637,6 +3137,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2654,6 +3158,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2671,6 +3179,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2688,6 +3200,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2705,6 +3221,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2722,6 +3242,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2739,6 +3263,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2756,6 +3284,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -2773,6 +3305,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -2790,6 +3326,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -2807,6 +3347,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -2824,6 +3368,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -2838,6 +3386,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -2852,6 +3404,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -2868,7 +3424,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2886,7 +3442,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2902,6 +3458,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -2921,7 +3481,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2937,6 +3497,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -2955,7 +3519,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2976,7 +3540,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2997,7 +3561,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3018,7 +3582,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3039,7 +3603,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3060,7 +3624,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3080,6 +3644,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3094,6 +3662,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3109,7 +3681,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3130,7 +3702,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3151,7 +3723,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3172,7 +3744,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3192,6 +3764,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3209,6 +3785,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3226,6 +3806,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3243,6 +3827,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3260,6 +3848,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3277,6 +3869,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3291,6 +3887,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3306,7 +3906,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3327,7 +3927,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3348,7 +3948,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3369,7 +3969,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3390,7 +3990,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3410,6 +4010,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3427,6 +4031,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3444,6 +4052,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3461,6 +4073,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3478,6 +4094,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3495,6 +4115,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3512,6 +4136,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3526,6 +4154,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3543,6 +4175,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3557,6 +4193,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3571,6 +4211,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3585,6 +4229,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3599,6 +4247,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3613,6 +4265,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3627,6 +4283,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3641,6 +4301,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3655,6 +4319,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3669,6 +4337,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3683,6 +4355,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3697,6 +4373,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3711,6 +4391,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3725,6 +4409,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3739,6 +4427,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3753,6 +4445,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -3767,6 +4463,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -3781,6 +4481,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -3795,6 +4499,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -3809,6 +4517,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -3823,6 +4535,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -3840,6 +4556,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -3854,6 +4574,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -3868,6 +4592,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -3882,6 +4610,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -3896,6 +4628,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -3910,6 +4646,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -3924,6 +4664,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -3938,6 +4682,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -3952,6 +4700,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -3966,6 +4718,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -3980,6 +4736,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -3994,6 +4754,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4008,6 +4772,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4025,6 +4793,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4042,6 +4814,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4059,6 +4835,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4076,6 +4856,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4093,6 +4877,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4110,6 +4898,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4127,6 +4919,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4144,6 +4940,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4161,6 +4961,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4178,6 +4982,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4195,6 +5003,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4212,6 +5024,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4229,6 +5045,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4246,6 +5066,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4260,6 +5084,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4274,6 +5102,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4291,6 +5123,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4308,6 +5144,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4325,6 +5165,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4342,6 +5186,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4359,6 +5207,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4376,6 +5228,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4393,6 +5249,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4410,6 +5270,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4427,6 +5291,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4444,6 +5312,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4461,6 +5333,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4478,6 +5354,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4495,6 +5375,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4512,6 +5396,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4529,6 +5417,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4547,7 +5439,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4568,7 +5460,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4589,7 +5481,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4609,6 +5501,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4626,6 +5522,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4644,7 +5544,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4665,7 +5565,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4685,6 +5585,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4703,7 +5607,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4724,7 +5628,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4745,7 +5649,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4766,7 +5670,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4787,7 +5691,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4807,6 +5711,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -4821,6 +5729,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -4837,7 +5749,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4853,6 +5765,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -4867,6 +5783,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -4881,6 +5801,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -4895,6 +5819,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -4909,6 +5837,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -4926,6 +5858,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -4943,6 +5879,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -4960,6 +5900,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -4977,6 +5921,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -4994,6 +5942,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5011,6 +5963,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5028,6 +5984,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5045,6 +6005,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5062,6 +6026,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5079,6 +6047,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5096,6 +6068,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5113,6 +6089,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5130,6 +6110,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5147,6 +6131,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5164,6 +6152,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5181,6 +6173,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5198,6 +6194,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5212,6 +6212,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5229,6 +6233,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5246,6 +6254,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5263,6 +6275,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5280,6 +6296,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5297,6 +6317,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5314,6 +6338,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5331,6 +6359,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5348,6 +6380,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5365,6 +6401,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5382,6 +6422,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5396,6 +6440,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5410,6 +6458,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5424,6 +6476,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5438,6 +6494,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5455,6 +6515,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5469,6 +6533,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5487,7 +6555,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5508,7 +6576,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5529,7 +6597,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5549,6 +6617,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5566,6 +6638,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5583,6 +6659,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5600,6 +6680,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5617,6 +6701,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5634,6 +6722,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5651,6 +6743,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5669,7 +6765,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5689,6 +6785,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5707,7 +6807,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5727,6 +6827,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -5745,7 +6849,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5766,7 +6870,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5787,7 +6891,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5827,7 +6931,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5844,7 +6948,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5865,7 +6969,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5881,6 +6985,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -5899,7 +7007,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5920,7 +7028,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5941,7 +7049,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5962,7 +7070,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5982,6 +7090,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6000,7 +7112,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6020,6 +7132,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6038,7 +7154,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6059,7 +7175,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6080,7 +7196,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6101,7 +7217,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6122,7 +7238,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6142,6 +7258,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6156,6 +7276,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6173,6 +7297,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6187,6 +7315,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6201,6 +7333,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6218,6 +7354,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6235,6 +7375,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6252,6 +7396,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6269,6 +7417,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6286,6 +7438,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6303,6 +7459,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6320,6 +7480,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6337,6 +7501,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
@@ -38,10 +38,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -59,10 +55,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -80,10 +72,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -101,10 +89,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -122,10 +106,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -143,10 +123,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -164,10 +140,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -206,10 +178,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -227,10 +195,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -266,10 +230,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -287,10 +247,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -308,10 +264,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -329,10 +281,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -350,10 +298,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -371,10 +315,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -392,10 +332,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -476,10 +412,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -518,10 +450,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -581,10 +509,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -602,10 +526,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -623,10 +543,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -644,10 +560,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -665,10 +577,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -686,10 +594,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -707,10 +611,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -728,10 +628,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -791,10 +687,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -812,10 +704,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -833,10 +721,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -872,10 +756,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -893,10 +773,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1019,10 +895,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1054,10 +926,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1075,10 +943,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1096,10 +960,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1117,10 +977,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1138,10 +994,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1156,10 +1008,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1177,10 +1025,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1198,10 +1042,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1219,10 +1059,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1240,10 +1076,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1261,10 +1093,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1279,10 +1107,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1297,10 +1121,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1315,10 +1135,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1333,10 +1149,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1351,10 +1163,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1369,10 +1177,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1387,10 +1191,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1405,10 +1205,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1423,10 +1219,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1441,10 +1233,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1459,10 +1247,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1477,10 +1261,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1498,10 +1278,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1519,10 +1295,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1540,10 +1312,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1561,10 +1329,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1579,10 +1343,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1597,10 +1357,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1615,10 +1371,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1633,10 +1385,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1651,10 +1399,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1669,10 +1413,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1687,10 +1427,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1705,10 +1441,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1723,10 +1455,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1741,10 +1469,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1759,10 +1483,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1777,10 +1497,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1795,10 +1511,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1813,10 +1525,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1831,10 +1539,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1849,10 +1553,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1870,10 +1570,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1891,10 +1587,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1912,10 +1604,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1933,10 +1621,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1951,10 +1635,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1969,10 +1649,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1987,10 +1663,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2005,10 +1677,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2023,10 +1691,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2041,10 +1705,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2059,10 +1719,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2077,10 +1733,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2095,10 +1747,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2113,10 +1761,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2131,10 +1775,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2149,10 +1789,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2170,10 +1806,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2191,10 +1823,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2233,10 +1861,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2289,10 +1913,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2310,10 +1930,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2331,10 +1947,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2352,10 +1964,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2373,10 +1981,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2394,10 +1998,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2415,10 +2015,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2436,10 +2032,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2457,10 +2049,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2478,10 +2066,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2499,10 +2083,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2520,10 +2100,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2541,10 +2117,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2562,10 +2134,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2583,10 +2151,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2604,10 +2168,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2625,10 +2185,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2646,10 +2202,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2667,10 +2219,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2688,10 +2236,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2709,10 +2253,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2730,10 +2270,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2751,10 +2287,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2769,10 +2301,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2874,10 +2402,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2895,10 +2419,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2972,10 +2492,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2993,10 +2509,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3056,10 +2568,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3095,10 +2603,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3116,10 +2620,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3137,10 +2637,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3158,10 +2654,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3179,10 +2671,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3200,10 +2688,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3221,10 +2705,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3242,10 +2722,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3263,10 +2739,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3284,10 +2756,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3305,10 +2773,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3326,10 +2790,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3347,10 +2807,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3368,10 +2824,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3386,10 +2838,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3404,10 +2852,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3458,10 +2902,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3497,10 +2937,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3644,10 +3080,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3662,10 +3094,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3764,10 +3192,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3785,10 +3209,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3806,10 +3226,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3827,10 +3243,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3848,10 +3260,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3869,10 +3277,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3887,10 +3291,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -4010,10 +3410,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4031,10 +3427,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4052,10 +3444,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4073,10 +3461,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4094,10 +3478,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4115,10 +3495,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4136,10 +3512,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4154,10 +3526,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4175,10 +3543,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4193,10 +3557,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4211,10 +3571,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4229,10 +3585,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4247,10 +3599,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4265,10 +3613,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4283,10 +3627,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4301,10 +3641,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4319,10 +3655,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4337,10 +3669,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4355,10 +3683,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4373,10 +3697,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4391,10 +3711,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4409,10 +3725,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4427,10 +3739,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4445,10 +3753,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4463,10 +3767,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4481,10 +3781,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4499,10 +3795,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4517,10 +3809,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4535,10 +3823,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4556,10 +3840,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4574,10 +3854,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4592,10 +3868,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4610,10 +3882,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4628,10 +3896,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4646,10 +3910,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4664,10 +3924,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4682,10 +3938,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4700,10 +3952,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4718,10 +3966,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4736,10 +3980,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4754,10 +3994,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4772,10 +4008,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4793,10 +4025,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4814,10 +4042,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4835,10 +4059,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4856,10 +4076,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4877,10 +4093,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4898,10 +4110,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4919,10 +4127,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4940,10 +4144,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4961,10 +4161,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4982,10 +4178,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -5003,10 +4195,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5024,10 +4212,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5045,10 +4229,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5066,10 +4246,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5084,10 +4260,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5102,10 +4274,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5123,10 +4291,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5144,10 +4308,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5165,10 +4325,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5186,10 +4342,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5207,10 +4359,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5228,10 +4376,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5249,10 +4393,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5270,10 +4410,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5291,10 +4427,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5312,10 +4444,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5333,10 +4461,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5354,10 +4478,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5375,10 +4495,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5396,10 +4512,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5417,10 +4529,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5501,10 +4609,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5522,10 +4626,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5585,10 +4685,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5711,10 +4807,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5729,10 +4821,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5765,10 +4853,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5783,10 +4867,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5801,10 +4881,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5819,10 +4895,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5837,10 +4909,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5858,10 +4926,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5879,10 +4943,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5900,10 +4960,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5921,10 +4977,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5942,10 +4994,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5963,10 +5011,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5984,10 +5028,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6005,10 +5045,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6026,10 +5062,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6047,10 +5079,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6068,10 +5096,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6089,10 +5113,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6110,10 +5130,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6131,10 +5147,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6152,10 +5164,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6173,10 +5181,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6194,10 +5198,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6212,10 +5212,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6233,10 +5229,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6254,10 +5246,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6275,10 +5263,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6296,10 +5280,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6317,10 +5297,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6338,10 +5314,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6359,10 +5331,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6380,10 +5348,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6401,10 +5365,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6422,10 +5382,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6440,10 +5396,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6458,10 +5410,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6476,10 +5424,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6494,10 +5438,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6515,10 +5455,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6533,10 +5469,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6617,10 +5549,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6638,10 +5566,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6659,10 +5583,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6680,10 +5600,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6701,10 +5617,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6722,10 +5634,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6743,10 +5651,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6785,10 +5689,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6827,10 +5727,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -6985,10 +5881,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7090,10 +5982,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7132,10 +6020,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7258,10 +6142,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7276,10 +6156,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7297,10 +6173,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7315,10 +6187,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7333,10 +6201,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7354,10 +6218,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7375,10 +6235,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7396,10 +6252,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7417,10 +6269,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7438,10 +6286,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7459,10 +6303,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7480,10 +6320,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7501,10 +6337,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
@@ -18,7 +18,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38,6 +38,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -55,6 +59,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -72,6 +80,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -89,6 +101,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -106,6 +122,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -123,6 +143,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -140,6 +164,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -158,7 +186,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -178,6 +206,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -195,6 +227,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -230,6 +266,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -247,6 +287,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -264,6 +308,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -281,6 +329,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -298,6 +350,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -315,6 +371,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -332,6 +392,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -350,7 +414,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -371,7 +435,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -392,7 +456,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -412,6 +476,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -430,7 +498,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -450,6 +518,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -468,7 +540,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -489,7 +561,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -509,6 +581,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -526,6 +602,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -543,6 +623,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -560,6 +644,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -577,6 +665,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -594,6 +686,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -611,6 +707,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -628,6 +728,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -646,7 +750,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -667,7 +771,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -687,6 +791,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -704,6 +812,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -721,6 +833,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -740,7 +856,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -756,6 +872,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -773,6 +893,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -791,7 +915,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -812,7 +936,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -833,7 +957,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -854,7 +978,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -875,7 +999,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -895,6 +1019,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -910,7 +1038,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -926,6 +1054,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -943,6 +1075,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -960,6 +1096,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -977,6 +1117,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -994,6 +1138,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1008,6 +1156,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1025,6 +1177,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1042,6 +1198,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1059,6 +1219,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1076,6 +1240,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1093,6 +1261,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1107,6 +1279,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1121,6 +1297,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1135,6 +1315,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1149,6 +1333,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1163,6 +1351,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1177,6 +1369,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1191,6 +1387,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1205,6 +1405,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1219,6 +1423,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1233,6 +1441,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1247,6 +1459,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1261,6 +1477,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1278,6 +1498,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1295,6 +1519,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1312,6 +1540,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1329,6 +1561,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1343,6 +1579,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1357,6 +1597,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1371,6 +1615,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1385,6 +1633,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1399,6 +1651,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1413,6 +1669,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1427,6 +1687,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1441,6 +1705,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1455,6 +1723,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1469,6 +1741,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1483,6 +1759,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1497,6 +1777,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1511,6 +1795,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1525,6 +1813,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1539,6 +1831,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1553,6 +1849,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1570,6 +1870,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1587,6 +1891,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1604,6 +1912,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1621,6 +1933,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1635,6 +1951,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1649,6 +1969,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1663,6 +1987,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1677,6 +2005,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1691,6 +2023,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -1705,6 +2041,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -1719,6 +2059,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -1733,6 +2077,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -1747,6 +2095,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -1761,6 +2113,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -1775,6 +2131,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -1789,6 +2149,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -1806,6 +2170,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -1823,6 +2191,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -1841,7 +2213,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1861,6 +2233,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -1876,7 +2252,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1897,7 +2273,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1913,6 +2289,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -1930,6 +2310,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -1947,6 +2331,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -1964,6 +2352,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -1981,6 +2373,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -1998,6 +2394,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2015,6 +2415,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2032,6 +2436,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2049,6 +2457,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2066,6 +2478,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2083,6 +2499,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2100,6 +2520,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2117,6 +2541,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2134,6 +2562,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2151,6 +2583,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2168,6 +2604,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2185,6 +2625,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2202,6 +2646,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2219,6 +2667,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2236,6 +2688,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2253,6 +2709,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2270,6 +2730,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2287,6 +2751,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2301,6 +2769,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2319,7 +2791,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2340,7 +2812,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2361,7 +2833,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2382,7 +2854,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2402,6 +2874,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2419,6 +2895,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2437,7 +2917,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2458,7 +2938,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2492,6 +2972,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2509,6 +2993,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -2527,7 +3015,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2548,7 +3036,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2568,6 +3056,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2583,7 +3075,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2603,6 +3095,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2620,6 +3116,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2637,6 +3137,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2654,6 +3158,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2671,6 +3179,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2688,6 +3200,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2705,6 +3221,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2722,6 +3242,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2739,6 +3263,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2756,6 +3284,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -2773,6 +3305,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -2790,6 +3326,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -2807,6 +3347,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -2824,6 +3368,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -2838,6 +3386,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -2852,6 +3404,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -2868,7 +3424,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2886,7 +3442,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2902,6 +3458,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -2921,7 +3481,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2937,6 +3497,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -2955,7 +3519,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2976,7 +3540,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2997,7 +3561,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3018,7 +3582,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3039,7 +3603,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3060,7 +3624,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3080,6 +3644,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3094,6 +3662,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3109,7 +3681,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3130,7 +3702,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3151,7 +3723,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3172,7 +3744,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3192,6 +3764,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3209,6 +3785,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3226,6 +3806,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3243,6 +3827,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3260,6 +3848,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3277,6 +3869,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3291,6 +3887,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3306,7 +3906,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3327,7 +3927,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3348,7 +3948,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3369,7 +3969,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3390,7 +3990,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3410,6 +4010,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3427,6 +4031,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3444,6 +4052,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3461,6 +4073,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3478,6 +4094,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3495,6 +4115,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3512,6 +4136,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3526,6 +4154,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3543,6 +4175,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3557,6 +4193,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3571,6 +4211,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3585,6 +4229,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3599,6 +4247,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3613,6 +4265,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3627,6 +4283,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3641,6 +4301,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3655,6 +4319,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3669,6 +4337,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3683,6 +4355,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3697,6 +4373,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3711,6 +4391,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3725,6 +4409,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3739,6 +4427,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3753,6 +4445,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -3767,6 +4463,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -3781,6 +4481,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -3795,6 +4499,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -3809,6 +4517,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -3823,6 +4535,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -3840,6 +4556,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -3854,6 +4574,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -3868,6 +4592,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -3882,6 +4610,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -3896,6 +4628,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -3910,6 +4646,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -3924,6 +4664,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -3938,6 +4682,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -3952,6 +4700,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -3966,6 +4718,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -3980,6 +4736,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -3994,6 +4754,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4008,6 +4772,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4025,6 +4793,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4042,6 +4814,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4059,6 +4835,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4076,6 +4856,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4093,6 +4877,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4110,6 +4898,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4127,6 +4919,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4144,6 +4940,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4161,6 +4961,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4178,6 +4982,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4195,6 +5003,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4212,6 +5024,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4229,6 +5045,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4246,6 +5066,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4260,6 +5084,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4274,6 +5102,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4291,6 +5123,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4308,6 +5144,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4325,6 +5165,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4342,6 +5186,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4359,6 +5207,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4376,6 +5228,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4393,6 +5249,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4410,6 +5270,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4427,6 +5291,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4444,6 +5312,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4461,6 +5333,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4478,6 +5354,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4495,6 +5375,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4512,6 +5396,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4529,6 +5417,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4547,7 +5439,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4568,7 +5460,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4589,7 +5481,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4609,6 +5501,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4626,6 +5522,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4644,7 +5544,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4665,7 +5565,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4685,6 +5585,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4703,7 +5607,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4724,7 +5628,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4745,7 +5649,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4766,7 +5670,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4787,7 +5691,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4807,6 +5711,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -4821,6 +5729,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -4837,7 +5749,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4853,6 +5765,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -4867,6 +5783,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -4881,6 +5801,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -4895,6 +5819,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -4909,6 +5837,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -4926,6 +5858,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -4943,6 +5879,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -4960,6 +5900,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -4977,6 +5921,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -4994,6 +5942,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5011,6 +5963,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5028,6 +5984,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5045,6 +6005,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5062,6 +6026,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5079,6 +6047,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5096,6 +6068,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5113,6 +6089,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5130,6 +6110,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5147,6 +6131,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5164,6 +6152,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5181,6 +6173,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5198,6 +6194,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5212,6 +6212,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5229,6 +6233,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5246,6 +6254,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5263,6 +6275,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5280,6 +6296,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5297,6 +6317,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5314,6 +6338,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5331,6 +6359,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5348,6 +6380,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5365,6 +6401,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5382,6 +6422,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5396,6 +6440,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5410,6 +6458,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5424,6 +6476,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5438,6 +6494,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5455,6 +6515,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5469,6 +6533,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5487,7 +6555,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5508,7 +6576,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5529,7 +6597,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5549,6 +6617,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5566,6 +6638,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5583,6 +6659,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5600,6 +6680,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5617,6 +6701,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5634,6 +6722,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5651,6 +6743,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5669,7 +6765,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5689,6 +6785,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5707,7 +6807,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5727,6 +6827,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -5745,7 +6849,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5766,7 +6870,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5787,7 +6891,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5827,7 +6931,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5844,7 +6948,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5865,7 +6969,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5881,6 +6985,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -5899,7 +7007,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5920,7 +7028,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5941,7 +7049,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5962,7 +7070,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5982,6 +7090,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6000,7 +7112,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6020,6 +7132,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6038,7 +7154,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6059,7 +7175,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6080,7 +7196,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6101,7 +7217,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6122,7 +7238,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6142,6 +7258,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6156,6 +7276,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6173,6 +7297,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6187,6 +7315,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6201,6 +7333,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6218,6 +7354,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6235,6 +7375,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6252,6 +7396,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6269,6 +7417,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6286,6 +7438,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6303,6 +7459,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6320,6 +7480,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6337,6 +7501,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
@@ -38,10 +38,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -59,10 +55,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -80,10 +72,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -101,10 +89,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -122,10 +106,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -143,10 +123,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -164,10 +140,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -206,10 +178,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -227,10 +195,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -266,10 +230,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -287,10 +247,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -308,10 +264,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -329,10 +281,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -350,10 +298,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -371,10 +315,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -392,10 +332,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -476,10 +412,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -518,10 +450,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -581,10 +509,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -602,10 +526,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -623,10 +543,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -644,10 +560,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -665,10 +577,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -686,10 +594,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -707,10 +611,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -728,10 +628,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -791,10 +687,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -812,10 +704,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -833,10 +721,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -872,10 +756,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -893,10 +773,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1019,10 +895,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1054,10 +926,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1075,10 +943,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1096,10 +960,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1117,10 +977,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1138,10 +994,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1156,10 +1008,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1177,10 +1025,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1198,10 +1042,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1219,10 +1059,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1240,10 +1076,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1261,10 +1093,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1279,10 +1107,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1297,10 +1121,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1315,10 +1135,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1333,10 +1149,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1351,10 +1163,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1369,10 +1177,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1387,10 +1191,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1405,10 +1205,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1423,10 +1219,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1441,10 +1233,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1459,10 +1247,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1477,10 +1261,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1498,10 +1278,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1519,10 +1295,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1540,10 +1312,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1561,10 +1329,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1579,10 +1343,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1597,10 +1357,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1615,10 +1371,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1633,10 +1385,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1651,10 +1399,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1669,10 +1413,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1687,10 +1427,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1705,10 +1441,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1723,10 +1455,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1741,10 +1469,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1759,10 +1483,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1777,10 +1497,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1795,10 +1511,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1813,10 +1525,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1831,10 +1539,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1849,10 +1553,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1870,10 +1570,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1891,10 +1587,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1912,10 +1604,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1933,10 +1621,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1951,10 +1635,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1969,10 +1649,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1987,10 +1663,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2005,10 +1677,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2023,10 +1691,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2041,10 +1705,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2059,10 +1719,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2077,10 +1733,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2095,10 +1747,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2113,10 +1761,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2131,10 +1775,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2149,10 +1789,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2170,10 +1806,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2191,10 +1823,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2233,10 +1861,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2289,10 +1913,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2310,10 +1930,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2331,10 +1947,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2352,10 +1964,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2373,10 +1981,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2394,10 +1998,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2415,10 +2015,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2436,10 +2032,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2457,10 +2049,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2478,10 +2066,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2499,10 +2083,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2520,10 +2100,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2541,10 +2117,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2562,10 +2134,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2583,10 +2151,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2604,10 +2168,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2625,10 +2185,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2646,10 +2202,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2667,10 +2219,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2688,10 +2236,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2709,10 +2253,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2730,10 +2270,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2751,10 +2287,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2769,10 +2301,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2874,10 +2402,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2895,10 +2419,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2972,10 +2492,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2993,10 +2509,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3056,10 +2568,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3095,10 +2603,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3116,10 +2620,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3137,10 +2637,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3158,10 +2654,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3179,10 +2671,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3200,10 +2688,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3221,10 +2705,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3242,10 +2722,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3263,10 +2739,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3284,10 +2756,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3305,10 +2773,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3326,10 +2790,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3347,10 +2807,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3368,10 +2824,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3386,10 +2838,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3404,10 +2852,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3458,10 +2902,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3497,10 +2937,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3644,10 +3080,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3662,10 +3094,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3764,10 +3192,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3785,10 +3209,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3806,10 +3226,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3827,10 +3243,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3848,10 +3260,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3869,10 +3277,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3887,10 +3291,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -4010,10 +3410,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4031,10 +3427,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4052,10 +3444,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4073,10 +3461,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4094,10 +3478,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4115,10 +3495,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4136,10 +3512,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4154,10 +3526,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4175,10 +3543,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4193,10 +3557,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4211,10 +3571,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4229,10 +3585,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4247,10 +3599,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4265,10 +3613,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4283,10 +3627,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4301,10 +3641,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4319,10 +3655,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4337,10 +3669,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4355,10 +3683,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4373,10 +3697,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4391,10 +3711,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4409,10 +3725,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4427,10 +3739,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4445,10 +3753,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4463,10 +3767,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4481,10 +3781,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4499,10 +3795,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4517,10 +3809,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4535,10 +3823,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4556,10 +3840,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4574,10 +3854,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4592,10 +3868,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4610,10 +3882,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4628,10 +3896,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4646,10 +3910,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4664,10 +3924,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4682,10 +3938,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4700,10 +3952,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4718,10 +3966,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4736,10 +3980,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4754,10 +3994,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4772,10 +4008,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4793,10 +4025,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4814,10 +4042,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4835,10 +4059,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4856,10 +4076,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4877,10 +4093,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4898,10 +4110,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4919,10 +4127,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4940,10 +4144,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4961,10 +4161,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4982,10 +4178,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -5003,10 +4195,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5024,10 +4212,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5045,10 +4229,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5066,10 +4246,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5084,10 +4260,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5102,10 +4274,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5123,10 +4291,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5144,10 +4308,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5165,10 +4325,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5186,10 +4342,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5207,10 +4359,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5228,10 +4376,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5249,10 +4393,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5270,10 +4410,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5291,10 +4427,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5312,10 +4444,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5333,10 +4461,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5354,10 +4478,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5375,10 +4495,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5396,10 +4512,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5417,10 +4529,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5501,10 +4609,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5522,10 +4626,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5585,10 +4685,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5711,10 +4807,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5729,10 +4821,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5765,10 +4853,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5783,10 +4867,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5801,10 +4881,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5819,10 +4895,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5837,10 +4909,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5858,10 +4926,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5879,10 +4943,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5900,10 +4960,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5921,10 +4977,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5942,10 +4994,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5963,10 +5011,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5984,10 +5028,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6005,10 +5045,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6026,10 +5062,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6047,10 +5079,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6068,10 +5096,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6089,10 +5113,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6110,10 +5130,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6131,10 +5147,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6152,10 +5164,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6173,10 +5181,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6194,10 +5198,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6212,10 +5212,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6233,10 +5229,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6254,10 +5246,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6275,10 +5263,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6296,10 +5280,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6317,10 +5297,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6338,10 +5314,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6359,10 +5331,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6380,10 +5348,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6401,10 +5365,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6422,10 +5382,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6440,10 +5396,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6458,10 +5410,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6476,10 +5424,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6494,10 +5438,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6515,10 +5455,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6533,10 +5469,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6617,10 +5549,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6638,10 +5566,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6659,10 +5583,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6680,10 +5600,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6701,10 +5617,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6722,10 +5634,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6743,10 +5651,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6785,10 +5689,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6827,10 +5727,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -6985,10 +5881,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7090,10 +5982,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7132,10 +6020,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7258,10 +6142,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7276,10 +6156,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7297,10 +6173,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7315,10 +6187,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7333,10 +6201,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7354,10 +6218,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7375,10 +6235,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7396,10 +6252,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7417,10 +6269,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7438,10 +6286,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7459,10 +6303,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7480,10 +6320,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7501,10 +6337,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
@@ -18,7 +18,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38,6 +38,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -55,6 +59,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -72,6 +80,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -89,6 +101,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -106,6 +122,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -123,6 +143,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -140,6 +164,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -158,7 +186,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -178,6 +206,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -195,6 +227,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -230,6 +266,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -247,6 +287,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -264,6 +308,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -281,6 +329,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -298,6 +350,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -315,6 +371,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -332,6 +392,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -350,7 +414,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -371,7 +435,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -392,7 +456,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -412,6 +476,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -430,7 +498,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -450,6 +518,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -468,7 +540,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -489,7 +561,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -509,6 +581,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -526,6 +602,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -543,6 +623,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -560,6 +644,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -577,6 +665,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -594,6 +686,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -611,6 +707,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -628,6 +728,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -646,7 +750,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -667,7 +771,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -687,6 +791,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -704,6 +812,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -721,6 +833,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -740,7 +856,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -756,6 +872,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -773,6 +893,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -791,7 +915,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -812,7 +936,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -833,7 +957,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -854,7 +978,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -875,7 +999,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -895,6 +1019,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -910,7 +1038,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -926,6 +1054,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -943,6 +1075,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -960,6 +1096,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -977,6 +1117,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -994,6 +1138,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1008,6 +1156,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1025,6 +1177,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1042,6 +1198,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1059,6 +1219,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1076,6 +1240,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1093,6 +1261,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1107,6 +1279,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1121,6 +1297,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1135,6 +1315,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1149,6 +1333,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1163,6 +1351,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1177,6 +1369,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1191,6 +1387,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1205,6 +1405,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1219,6 +1423,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1233,6 +1441,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1247,6 +1459,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1261,6 +1477,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1278,6 +1498,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1295,6 +1519,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1312,6 +1540,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1329,6 +1561,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1343,6 +1579,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1357,6 +1597,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1371,6 +1615,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1385,6 +1633,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1399,6 +1651,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1413,6 +1669,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1427,6 +1687,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1441,6 +1705,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1455,6 +1723,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1469,6 +1741,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1483,6 +1759,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1497,6 +1777,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1511,6 +1795,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1525,6 +1813,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1539,6 +1831,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1553,6 +1849,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1570,6 +1870,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1587,6 +1891,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1604,6 +1912,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1621,6 +1933,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1635,6 +1951,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1649,6 +1969,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1663,6 +1987,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1677,6 +2005,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1691,6 +2023,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -1705,6 +2041,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -1719,6 +2059,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -1733,6 +2077,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -1747,6 +2095,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -1761,6 +2113,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -1775,6 +2131,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -1789,6 +2149,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -1806,6 +2170,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -1823,6 +2191,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -1841,7 +2213,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1861,6 +2233,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -1876,7 +2252,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1897,7 +2273,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1913,6 +2289,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -1930,6 +2310,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -1947,6 +2331,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -1964,6 +2352,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -1981,6 +2373,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -1998,6 +2394,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2015,6 +2415,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2032,6 +2436,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2049,6 +2457,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2066,6 +2478,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2083,6 +2499,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2100,6 +2520,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2117,6 +2541,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2134,6 +2562,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2151,6 +2583,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2168,6 +2604,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2185,6 +2625,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2202,6 +2646,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2219,6 +2667,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2236,6 +2688,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2253,6 +2709,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2270,6 +2730,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2287,6 +2751,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2301,6 +2769,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2319,7 +2791,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2340,7 +2812,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2361,7 +2833,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2382,7 +2854,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2402,6 +2874,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2419,6 +2895,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2437,7 +2917,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2458,7 +2938,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2492,6 +2972,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2509,6 +2993,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -2527,7 +3015,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2548,7 +3036,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2568,6 +3056,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2583,7 +3075,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2603,6 +3095,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2620,6 +3116,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2637,6 +3137,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2654,6 +3158,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2671,6 +3179,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2688,6 +3200,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2705,6 +3221,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2722,6 +3242,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2739,6 +3263,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2756,6 +3284,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -2773,6 +3305,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -2790,6 +3326,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -2807,6 +3347,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -2824,6 +3368,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -2838,6 +3386,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -2852,6 +3404,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -2868,7 +3424,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2886,7 +3442,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2902,6 +3458,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -2921,7 +3481,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2937,6 +3497,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -2955,7 +3519,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2976,7 +3540,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2997,7 +3561,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3018,7 +3582,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3039,7 +3603,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3060,7 +3624,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3080,6 +3644,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3094,6 +3662,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3109,7 +3681,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3130,7 +3702,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3151,7 +3723,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3172,7 +3744,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3192,6 +3764,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3209,6 +3785,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3226,6 +3806,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3243,6 +3827,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3260,6 +3848,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3277,6 +3869,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3291,6 +3887,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3306,7 +3906,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3327,7 +3927,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3348,7 +3948,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3369,7 +3969,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3390,7 +3990,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3410,6 +4010,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3427,6 +4031,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3444,6 +4052,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3461,6 +4073,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3478,6 +4094,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3495,6 +4115,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3512,6 +4136,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3526,6 +4154,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3543,6 +4175,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3557,6 +4193,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3571,6 +4211,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3585,6 +4229,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3599,6 +4247,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3613,6 +4265,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3627,6 +4283,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3641,6 +4301,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3655,6 +4319,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3669,6 +4337,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3683,6 +4355,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3697,6 +4373,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3711,6 +4391,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3725,6 +4409,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3739,6 +4427,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3753,6 +4445,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -3767,6 +4463,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -3781,6 +4481,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -3795,6 +4499,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -3809,6 +4517,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -3823,6 +4535,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -3840,6 +4556,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -3854,6 +4574,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -3868,6 +4592,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -3882,6 +4610,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -3896,6 +4628,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -3910,6 +4646,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -3924,6 +4664,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -3938,6 +4682,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -3952,6 +4700,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -3966,6 +4718,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -3980,6 +4736,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -3994,6 +4754,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4008,6 +4772,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4025,6 +4793,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4042,6 +4814,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4059,6 +4835,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4076,6 +4856,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4093,6 +4877,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4110,6 +4898,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4127,6 +4919,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4144,6 +4940,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4161,6 +4961,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4178,6 +4982,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4195,6 +5003,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4212,6 +5024,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4229,6 +5045,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4246,6 +5066,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4260,6 +5084,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4274,6 +5102,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4291,6 +5123,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4308,6 +5144,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4325,6 +5165,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4342,6 +5186,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4359,6 +5207,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4376,6 +5228,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4393,6 +5249,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4410,6 +5270,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4427,6 +5291,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4444,6 +5312,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4461,6 +5333,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4478,6 +5354,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4495,6 +5375,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4512,6 +5396,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4529,6 +5417,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4547,7 +5439,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4568,7 +5460,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4589,7 +5481,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4609,6 +5501,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -4626,6 +5522,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4643,6 +5543,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4661,7 +5565,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4682,7 +5586,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4702,6 +5606,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4720,7 +5628,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4741,7 +5649,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4762,7 +5670,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4783,7 +5691,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4804,7 +5712,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4824,6 +5732,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -4838,6 +5750,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -4854,7 +5770,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4870,6 +5786,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -4898,6 +5818,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -4912,6 +5836,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -4926,6 +5854,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -4940,6 +5872,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -4957,6 +5893,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -4974,6 +5914,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -4991,6 +5935,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5008,6 +5956,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5025,6 +5977,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5042,6 +5998,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5059,6 +6019,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5076,6 +6040,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5093,6 +6061,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5110,6 +6082,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5127,6 +6103,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5144,6 +6124,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5161,6 +6145,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5178,6 +6166,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5195,6 +6187,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5212,6 +6208,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5229,6 +6229,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5243,6 +6247,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5260,6 +6268,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5277,6 +6289,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5294,6 +6310,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5311,6 +6331,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5328,6 +6352,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5345,6 +6373,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5362,6 +6394,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5379,6 +6415,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5396,6 +6436,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5413,6 +6457,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5427,6 +6475,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5441,6 +6493,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5455,6 +6511,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5469,6 +6529,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5486,6 +6550,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5500,6 +6568,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5518,7 +6590,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5539,7 +6611,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5560,7 +6632,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5580,6 +6652,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5597,6 +6673,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5614,6 +6694,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5631,6 +6715,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5648,6 +6736,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5665,6 +6757,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5682,6 +6778,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5700,7 +6800,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5734,6 +6834,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5752,7 +6856,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5772,6 +6876,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -5790,7 +6898,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5811,7 +6919,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5832,7 +6940,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5872,7 +6980,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5889,7 +6997,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5910,7 +7018,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5926,6 +7034,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -5944,7 +7056,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5965,7 +7077,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5986,7 +7098,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6007,7 +7119,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6027,6 +7139,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6045,7 +7161,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6065,6 +7181,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6083,7 +7203,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6104,7 +7224,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6125,7 +7245,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6146,7 +7266,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6167,7 +7287,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6187,6 +7307,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6201,6 +7325,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6218,6 +7346,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6232,6 +7364,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6246,6 +7382,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6263,6 +7403,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6280,6 +7424,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6297,6 +7445,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6314,6 +7466,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6331,6 +7487,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6348,6 +7508,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6365,6 +7529,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6382,6 +7550,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
@@ -38,10 +38,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -59,10 +55,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -80,10 +72,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -101,10 +89,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -122,10 +106,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -143,10 +123,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -164,10 +140,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -206,10 +178,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -227,10 +195,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -266,10 +230,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -287,10 +247,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -308,10 +264,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -329,10 +281,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -350,10 +298,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -371,10 +315,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -392,10 +332,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -476,10 +412,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -518,10 +450,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -581,10 +509,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -602,10 +526,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -623,10 +543,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -644,10 +560,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -665,10 +577,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -686,10 +594,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -707,10 +611,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -728,10 +628,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -791,10 +687,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -812,10 +704,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -833,10 +721,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -872,10 +756,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -893,10 +773,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1019,10 +895,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1054,10 +926,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1075,10 +943,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1096,10 +960,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1117,10 +977,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1138,10 +994,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1156,10 +1008,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1177,10 +1025,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1198,10 +1042,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1219,10 +1059,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1240,10 +1076,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1261,10 +1093,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1279,10 +1107,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1297,10 +1121,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1315,10 +1135,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1333,10 +1149,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1351,10 +1163,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1369,10 +1177,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1387,10 +1191,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1405,10 +1205,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1423,10 +1219,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1441,10 +1233,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1459,10 +1247,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1477,10 +1261,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1498,10 +1278,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1519,10 +1295,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1540,10 +1312,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1561,10 +1329,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1579,10 +1343,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1597,10 +1357,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1615,10 +1371,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1633,10 +1385,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1651,10 +1399,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1669,10 +1413,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1687,10 +1427,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1705,10 +1441,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1723,10 +1455,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1741,10 +1469,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1759,10 +1483,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1777,10 +1497,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1795,10 +1511,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1813,10 +1525,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1831,10 +1539,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1849,10 +1553,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1870,10 +1570,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1891,10 +1587,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1912,10 +1604,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1933,10 +1621,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1951,10 +1635,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1969,10 +1649,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1987,10 +1663,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2005,10 +1677,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2023,10 +1691,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2041,10 +1705,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2059,10 +1719,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2077,10 +1733,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2095,10 +1747,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2113,10 +1761,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2131,10 +1775,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2149,10 +1789,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2170,10 +1806,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2191,10 +1823,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2233,10 +1861,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2289,10 +1913,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2310,10 +1930,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2331,10 +1947,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2352,10 +1964,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2373,10 +1981,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2394,10 +1998,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2415,10 +2015,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2436,10 +2032,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2457,10 +2049,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2478,10 +2066,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2499,10 +2083,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2520,10 +2100,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2541,10 +2117,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2562,10 +2134,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2583,10 +2151,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2604,10 +2168,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2625,10 +2185,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2646,10 +2202,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2667,10 +2219,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2688,10 +2236,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2709,10 +2253,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2730,10 +2270,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2751,10 +2287,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2769,10 +2301,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2874,10 +2402,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2895,10 +2419,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2972,10 +2492,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2993,10 +2509,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3056,10 +2568,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3095,10 +2603,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3116,10 +2620,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3137,10 +2637,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3158,10 +2654,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3179,10 +2671,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3200,10 +2688,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3221,10 +2705,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3242,10 +2722,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3263,10 +2739,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3284,10 +2756,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3305,10 +2773,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3326,10 +2790,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3347,10 +2807,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3368,10 +2824,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3386,10 +2838,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3404,10 +2852,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3458,10 +2902,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3497,10 +2937,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3644,10 +3080,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3662,10 +3094,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3764,10 +3192,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3785,10 +3209,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3806,10 +3226,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3827,10 +3243,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3848,10 +3260,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3869,10 +3277,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3887,10 +3291,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -4010,10 +3410,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4031,10 +3427,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4052,10 +3444,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4073,10 +3461,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4094,10 +3478,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4115,10 +3495,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4136,10 +3512,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4154,10 +3526,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4175,10 +3543,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4193,10 +3557,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4211,10 +3571,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4229,10 +3585,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4247,10 +3599,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4265,10 +3613,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4283,10 +3627,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4301,10 +3641,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4319,10 +3655,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4337,10 +3669,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4355,10 +3683,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4373,10 +3697,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4391,10 +3711,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4409,10 +3725,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4427,10 +3739,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4445,10 +3753,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4463,10 +3767,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4481,10 +3781,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4499,10 +3795,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4517,10 +3809,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4535,10 +3823,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4556,10 +3840,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4574,10 +3854,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4592,10 +3868,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4610,10 +3882,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4628,10 +3896,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4646,10 +3910,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4664,10 +3924,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4682,10 +3938,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4700,10 +3952,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4718,10 +3966,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4736,10 +3980,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4754,10 +3994,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4772,10 +4008,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4793,10 +4025,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4814,10 +4042,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4835,10 +4059,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4856,10 +4076,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4877,10 +4093,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4898,10 +4110,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4919,10 +4127,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4940,10 +4144,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4961,10 +4161,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4982,10 +4178,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -5003,10 +4195,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5024,10 +4212,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5045,10 +4229,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5066,10 +4246,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5084,10 +4260,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5102,10 +4274,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5123,10 +4291,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5144,10 +4308,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5165,10 +4325,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5186,10 +4342,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5207,10 +4359,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5228,10 +4376,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5249,10 +4393,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5270,10 +4410,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5291,10 +4427,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5312,10 +4444,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5333,10 +4461,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5354,10 +4478,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5375,10 +4495,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5396,10 +4512,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5417,10 +4529,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5501,10 +4609,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5522,10 +4626,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5543,10 +4643,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5606,10 +4702,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5732,10 +4824,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5750,10 +4838,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5786,10 +4870,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5818,10 +4898,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5836,10 +4912,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5854,10 +4926,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5872,10 +4940,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5893,10 +4957,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5914,10 +4974,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5935,10 +4991,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5956,10 +5008,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5977,10 +5025,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5998,10 +5042,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -6019,10 +5059,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6040,10 +5076,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6061,10 +5093,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6082,10 +5110,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6103,10 +5127,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6124,10 +5144,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6145,10 +5161,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6166,10 +5178,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6187,10 +5195,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6208,10 +5212,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6229,10 +5229,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6247,10 +5243,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6268,10 +5260,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6289,10 +5277,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6310,10 +5294,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6331,10 +5311,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6352,10 +5328,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6373,10 +5345,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6394,10 +5362,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6415,10 +5379,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6436,10 +5396,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6457,10 +5413,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6475,10 +5427,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6493,10 +5441,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6511,10 +5455,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6529,10 +5469,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6550,10 +5486,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6568,10 +5500,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6652,10 +5580,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6673,10 +5597,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6694,10 +5614,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6715,10 +5631,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6736,10 +5648,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6757,10 +5665,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6778,10 +5682,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6834,10 +5734,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6876,10 +5772,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -7034,10 +5926,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7139,10 +6027,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7181,10 +6065,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7307,10 +6187,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7325,10 +6201,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7346,10 +6218,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7364,10 +6232,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7382,10 +6246,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7403,10 +6263,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7424,10 +6280,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7445,10 +6297,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7466,10 +6314,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7487,10 +6331,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7508,10 +6348,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7529,10 +6365,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7550,10 +6382,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
@@ -18,7 +18,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38,6 +38,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -55,6 +59,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -72,6 +80,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -89,6 +101,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -106,6 +122,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -123,6 +143,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -140,6 +164,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -158,7 +186,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -178,6 +206,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -195,6 +227,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -230,6 +266,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -247,6 +287,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -264,6 +308,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -281,6 +329,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -298,6 +350,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -315,6 +371,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -332,6 +392,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -350,7 +414,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -371,7 +435,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -392,7 +456,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -412,6 +476,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -430,7 +498,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -450,6 +518,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -468,7 +540,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -489,7 +561,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -509,6 +581,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -526,6 +602,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -543,6 +623,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -560,6 +644,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -577,6 +665,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -594,6 +686,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -611,6 +707,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -628,6 +728,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -646,7 +750,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -667,7 +771,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -687,6 +791,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -704,6 +812,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -721,6 +833,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -740,7 +856,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -756,6 +872,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -773,6 +893,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -791,7 +915,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -812,7 +936,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -833,7 +957,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -854,7 +978,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -875,7 +999,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -895,6 +1019,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -910,7 +1038,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -926,6 +1054,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -943,6 +1075,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -960,6 +1096,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -977,6 +1117,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -994,6 +1138,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1008,6 +1156,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1025,6 +1177,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1042,6 +1198,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1059,6 +1219,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1076,6 +1240,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1093,6 +1261,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1107,6 +1279,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1121,6 +1297,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1135,6 +1315,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1149,6 +1333,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1163,6 +1351,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1177,6 +1369,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1191,6 +1387,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1205,6 +1405,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1219,6 +1423,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1233,6 +1441,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1247,6 +1459,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1261,6 +1477,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1278,6 +1498,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1295,6 +1519,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1312,6 +1540,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1329,6 +1561,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1343,6 +1579,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1357,6 +1597,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1371,6 +1615,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1385,6 +1633,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1399,6 +1651,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1413,6 +1669,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1427,6 +1687,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1441,6 +1705,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1455,6 +1723,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1469,6 +1741,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1483,6 +1759,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1497,6 +1777,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1511,6 +1795,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1525,6 +1813,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1539,6 +1831,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1553,6 +1849,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1570,6 +1870,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1587,6 +1891,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1604,6 +1912,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1621,6 +1933,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1635,6 +1951,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1649,6 +1969,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1663,6 +1987,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1677,6 +2005,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1691,6 +2023,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -1705,6 +2041,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -1719,6 +2059,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -1733,6 +2077,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -1747,6 +2095,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -1761,6 +2113,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -1775,6 +2131,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -1789,6 +2149,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -1806,6 +2170,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -1823,6 +2191,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -1841,7 +2213,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1861,6 +2233,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -1876,7 +2252,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1897,7 +2273,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1913,6 +2289,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -1930,6 +2310,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -1947,6 +2331,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -1964,6 +2352,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -1981,6 +2373,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -1998,6 +2394,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2015,6 +2415,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2032,6 +2436,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2049,6 +2457,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2066,6 +2478,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2083,6 +2499,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2100,6 +2520,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2117,6 +2541,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2134,6 +2562,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2151,6 +2583,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2168,6 +2604,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2185,6 +2625,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2202,6 +2646,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2219,6 +2667,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2236,6 +2688,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2253,6 +2709,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2270,6 +2730,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2287,6 +2751,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2301,6 +2769,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2319,7 +2791,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2340,7 +2812,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2361,7 +2833,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2382,7 +2854,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2402,6 +2874,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2419,6 +2895,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2438,7 +2918,7 @@
     "detail": "for",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n[for item in list: {\n\t\n}]\n```"
+      "value": "```bicep\n[for item in list: {\n\t\n}]\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2456,7 +2936,7 @@
     "detail": "for-indexed",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n[for (item, index) in list: {\n\t\n}]\n```"
+      "value": "```bicep\n[for (item, index) in list: {\n\t\n}]\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2473,7 +2953,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2494,7 +2974,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2528,6 +3008,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2545,6 +3029,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -2563,7 +3051,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2584,7 +3072,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2604,6 +3092,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2619,7 +3111,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2639,6 +3131,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2656,6 +3152,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2673,6 +3173,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2690,6 +3194,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2707,6 +3215,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2724,6 +3236,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2741,6 +3257,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2758,6 +3278,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2775,6 +3299,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2792,6 +3320,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -2809,6 +3341,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -2826,6 +3362,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -2843,6 +3383,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -2860,6 +3404,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -2874,6 +3422,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -2888,6 +3440,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -2904,7 +3460,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2922,7 +3478,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2938,6 +3494,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -2957,7 +3517,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2987,6 +3547,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3005,7 +3569,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3026,7 +3590,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3047,7 +3611,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3068,7 +3632,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3089,7 +3653,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3110,7 +3674,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3130,6 +3694,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3144,6 +3712,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3159,7 +3731,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3180,7 +3752,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3201,7 +3773,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3222,7 +3794,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3242,6 +3814,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3259,6 +3835,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3276,6 +3856,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3293,6 +3877,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3310,6 +3898,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3327,6 +3919,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3341,6 +3937,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3356,7 +3956,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3377,7 +3977,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3398,7 +3998,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3419,7 +4019,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3440,7 +4040,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3460,6 +4060,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3477,6 +4081,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3494,6 +4102,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3511,6 +4123,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3528,6 +4144,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3545,6 +4165,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3562,6 +4186,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3576,6 +4204,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3593,6 +4225,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3607,6 +4243,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3621,6 +4261,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3635,6 +4279,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3649,6 +4297,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3663,6 +4315,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3677,6 +4333,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3691,6 +4351,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3705,6 +4369,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3719,6 +4387,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3733,6 +4405,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3747,6 +4423,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3761,6 +4441,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3775,6 +4459,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3789,6 +4477,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3803,6 +4495,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -3817,6 +4513,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -3831,6 +4531,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -3845,6 +4549,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -3859,6 +4567,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -3873,6 +4585,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -3890,6 +4606,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -3904,6 +4624,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -3918,6 +4642,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -3932,6 +4660,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -3946,6 +4678,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -3960,6 +4696,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -3974,6 +4714,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -3988,6 +4732,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4002,6 +4750,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4016,6 +4768,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4030,6 +4786,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4044,6 +4804,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4058,6 +4822,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4075,6 +4843,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4092,6 +4864,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4109,6 +4885,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4126,6 +4906,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4143,6 +4927,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4160,6 +4948,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4177,6 +4969,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4194,6 +4990,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4211,6 +5011,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4228,6 +5032,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4245,6 +5053,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4262,6 +5074,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4279,6 +5095,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4296,6 +5116,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4310,6 +5134,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4324,6 +5152,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4341,6 +5173,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4358,6 +5194,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4375,6 +5215,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4392,6 +5236,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4409,6 +5257,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4426,6 +5278,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4443,6 +5299,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4460,6 +5320,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4477,6 +5341,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4494,6 +5362,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4511,6 +5383,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4528,6 +5404,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4545,6 +5425,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4562,6 +5446,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4579,6 +5467,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4597,7 +5489,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4618,7 +5510,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4639,7 +5531,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4659,6 +5551,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -4676,6 +5572,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4693,6 +5593,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4711,7 +5615,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4732,7 +5636,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4752,6 +5656,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4770,7 +5678,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4791,7 +5699,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4812,7 +5720,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4833,7 +5741,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4854,7 +5762,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4874,6 +5782,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -4888,6 +5800,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -4904,7 +5820,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4920,6 +5836,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -4934,6 +5854,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -4948,6 +5872,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -4962,6 +5890,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -4976,6 +5908,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -4993,6 +5929,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5010,6 +5950,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5027,6 +5971,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5044,6 +5992,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5061,6 +6013,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5078,6 +6034,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5095,6 +6055,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5112,6 +6076,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5129,6 +6097,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5146,6 +6118,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5163,6 +6139,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5180,6 +6160,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5197,6 +6181,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5214,6 +6202,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5231,6 +6223,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5248,6 +6244,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5265,6 +6265,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5279,6 +6283,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5296,6 +6304,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5313,6 +6325,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5330,6 +6346,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5347,6 +6367,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5364,6 +6388,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5381,6 +6409,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5398,6 +6430,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5415,6 +6451,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5432,6 +6472,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5449,6 +6493,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5463,6 +6511,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5477,6 +6529,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5491,6 +6547,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5505,6 +6565,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5522,6 +6586,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5536,6 +6604,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5554,7 +6626,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5575,7 +6647,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5596,7 +6668,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5616,6 +6688,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5633,6 +6709,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5650,6 +6730,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5667,6 +6751,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5684,6 +6772,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5701,6 +6793,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5718,6 +6814,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5736,7 +6836,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5756,6 +6856,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5774,7 +6878,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5794,6 +6898,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -5812,7 +6920,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5833,7 +6941,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5854,7 +6962,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5894,7 +7002,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5911,7 +7019,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5932,7 +7040,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5948,6 +7056,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -5966,7 +7078,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5987,7 +7099,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6008,7 +7120,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6029,7 +7141,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6049,6 +7161,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6067,7 +7183,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6087,6 +7203,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6105,7 +7225,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6126,7 +7246,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6147,7 +7267,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6168,7 +7288,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6189,7 +7309,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6209,6 +7329,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6223,6 +7347,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6240,6 +7368,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6254,6 +7386,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6268,6 +7404,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6285,6 +7425,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6302,6 +7446,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6319,6 +7467,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6336,6 +7488,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6353,6 +7509,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6370,6 +7530,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6387,6 +7551,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6404,6 +7572,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
@@ -38,10 +38,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -59,10 +55,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -80,10 +72,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -101,10 +89,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -122,10 +106,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -143,10 +123,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -164,10 +140,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -206,10 +178,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -227,10 +195,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -266,10 +230,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -287,10 +247,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -308,10 +264,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -329,10 +281,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -350,10 +298,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -371,10 +315,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -392,10 +332,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -476,10 +412,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -518,10 +450,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -581,10 +509,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -602,10 +526,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -623,10 +543,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -644,10 +560,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -665,10 +577,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -686,10 +594,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -707,10 +611,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -728,10 +628,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -791,10 +687,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -812,10 +704,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -833,10 +721,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -872,10 +756,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -893,10 +773,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1019,10 +895,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1054,10 +926,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1075,10 +943,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1096,10 +960,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1117,10 +977,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1138,10 +994,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1156,10 +1008,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1177,10 +1025,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1198,10 +1042,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1219,10 +1059,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1240,10 +1076,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1261,10 +1093,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1279,10 +1107,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1297,10 +1121,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1315,10 +1135,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1333,10 +1149,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1351,10 +1163,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1369,10 +1177,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1387,10 +1191,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1405,10 +1205,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1423,10 +1219,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1441,10 +1233,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1459,10 +1247,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1477,10 +1261,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1498,10 +1278,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1519,10 +1295,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1540,10 +1312,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1561,10 +1329,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1579,10 +1343,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1597,10 +1357,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1615,10 +1371,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1633,10 +1385,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1651,10 +1399,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1669,10 +1413,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1687,10 +1427,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1705,10 +1441,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1723,10 +1455,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1741,10 +1469,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1759,10 +1483,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1777,10 +1497,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1795,10 +1511,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1813,10 +1525,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1831,10 +1539,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1849,10 +1553,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1870,10 +1570,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1891,10 +1587,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1912,10 +1604,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1933,10 +1621,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1951,10 +1635,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1969,10 +1649,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1987,10 +1663,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2005,10 +1677,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2023,10 +1691,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2041,10 +1705,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2059,10 +1719,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2077,10 +1733,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2095,10 +1747,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2113,10 +1761,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2131,10 +1775,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2149,10 +1789,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2170,10 +1806,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2191,10 +1823,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2233,10 +1861,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2289,10 +1913,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2310,10 +1930,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2331,10 +1947,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2352,10 +1964,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2373,10 +1981,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2394,10 +1998,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2415,10 +2015,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2436,10 +2032,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2457,10 +2049,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2478,10 +2066,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2499,10 +2083,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2520,10 +2100,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2541,10 +2117,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2562,10 +2134,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2583,10 +2151,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2604,10 +2168,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2625,10 +2185,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2646,10 +2202,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2667,10 +2219,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2688,10 +2236,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2709,10 +2253,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2730,10 +2270,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2751,10 +2287,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2769,10 +2301,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2874,10 +2402,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2895,10 +2419,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -3008,10 +2528,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -3029,10 +2545,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3092,10 +2604,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3131,10 +2639,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3152,10 +2656,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3173,10 +2673,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3194,10 +2690,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3215,10 +2707,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3236,10 +2724,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3257,10 +2741,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3278,10 +2758,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3299,10 +2775,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3320,10 +2792,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3341,10 +2809,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3362,10 +2826,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3383,10 +2843,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3404,10 +2860,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3422,10 +2874,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3440,10 +2888,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3494,10 +2938,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3547,10 +2987,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3694,10 +3130,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3712,10 +3144,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3814,10 +3242,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3835,10 +3259,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3856,10 +3276,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3877,10 +3293,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3898,10 +3310,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3919,10 +3327,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3937,10 +3341,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -4060,10 +3460,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4081,10 +3477,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4102,10 +3494,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4123,10 +3511,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4144,10 +3528,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4165,10 +3545,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4186,10 +3562,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4204,10 +3576,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4225,10 +3593,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4243,10 +3607,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4261,10 +3621,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4279,10 +3635,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4297,10 +3649,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4315,10 +3663,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4333,10 +3677,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4351,10 +3691,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4369,10 +3705,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4387,10 +3719,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4405,10 +3733,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4423,10 +3747,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4441,10 +3761,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4459,10 +3775,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4477,10 +3789,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4495,10 +3803,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4513,10 +3817,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4531,10 +3831,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4549,10 +3845,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4567,10 +3859,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4585,10 +3873,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4606,10 +3890,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4624,10 +3904,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4642,10 +3918,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4660,10 +3932,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4678,10 +3946,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4696,10 +3960,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4714,10 +3974,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4732,10 +3988,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4750,10 +4002,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4768,10 +4016,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4786,10 +4030,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4804,10 +4044,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4822,10 +4058,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4843,10 +4075,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4864,10 +4092,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4885,10 +4109,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4906,10 +4126,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4927,10 +4143,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4948,10 +4160,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4969,10 +4177,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4990,10 +4194,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -5011,10 +4211,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -5032,10 +4228,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -5053,10 +4245,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5074,10 +4262,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5095,10 +4279,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5116,10 +4296,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5134,10 +4310,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5152,10 +4324,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5173,10 +4341,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5194,10 +4358,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5215,10 +4375,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5236,10 +4392,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5257,10 +4409,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5278,10 +4426,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5299,10 +4443,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5320,10 +4460,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5341,10 +4477,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5362,10 +4494,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5383,10 +4511,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5404,10 +4528,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5425,10 +4545,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5446,10 +4562,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5467,10 +4579,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5551,10 +4659,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5572,10 +4676,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5593,10 +4693,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5656,10 +4752,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5782,10 +4874,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5800,10 +4888,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5836,10 +4920,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5854,10 +4934,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5872,10 +4948,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5890,10 +4962,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5908,10 +4976,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5929,10 +4993,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5950,10 +5010,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5971,10 +5027,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5992,10 +5044,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -6013,10 +5061,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -6034,10 +5078,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -6055,10 +5095,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6076,10 +5112,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6097,10 +5129,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6118,10 +5146,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6139,10 +5163,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6160,10 +5180,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6181,10 +5197,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6202,10 +5214,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6223,10 +5231,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6244,10 +5248,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6265,10 +5265,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6283,10 +5279,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6304,10 +5296,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6325,10 +5313,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6346,10 +5330,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6367,10 +5347,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6388,10 +5364,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6409,10 +5381,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6430,10 +5398,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6451,10 +5415,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6472,10 +5432,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6493,10 +5449,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6511,10 +5463,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6529,10 +5477,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6547,10 +5491,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6565,10 +5505,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6586,10 +5522,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6604,10 +5536,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6688,10 +5616,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6709,10 +5633,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6730,10 +5650,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6751,10 +5667,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6772,10 +5684,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6793,10 +5701,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6814,10 +5718,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6856,10 +5756,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6898,10 +5794,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -7056,10 +5948,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7161,10 +6049,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7203,10 +6087,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7329,10 +6209,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7347,10 +6223,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7368,10 +6240,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7386,10 +6254,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7404,10 +6268,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7425,10 +6285,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7446,10 +6302,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7467,10 +6319,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7488,10 +6336,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7509,10 +6353,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7530,10 +6370,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7551,10 +6387,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7572,10 +6404,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
@@ -38,10 +38,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -59,10 +55,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -80,10 +72,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -101,10 +89,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -122,10 +106,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -143,10 +123,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -164,10 +140,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -206,10 +178,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -227,10 +195,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -266,10 +230,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -287,10 +247,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -308,10 +264,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -329,10 +281,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -350,10 +298,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -371,10 +315,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -392,10 +332,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -476,10 +412,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -518,10 +450,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -581,10 +509,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -602,10 +526,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -623,10 +543,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -644,10 +560,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -665,10 +577,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -686,10 +594,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -707,10 +611,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -728,10 +628,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -791,10 +687,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -812,10 +704,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -833,10 +721,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -872,10 +756,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -893,10 +773,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1019,10 +895,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1054,10 +926,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1075,10 +943,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1096,10 +960,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1117,10 +977,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1138,10 +994,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1156,10 +1008,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1177,10 +1025,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1198,10 +1042,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1219,10 +1059,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1240,10 +1076,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1261,10 +1093,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1279,10 +1107,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1297,10 +1121,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1315,10 +1135,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1333,10 +1149,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1351,10 +1163,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1369,10 +1177,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1387,10 +1191,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1405,10 +1205,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1423,10 +1219,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1441,10 +1233,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1459,10 +1247,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1477,10 +1261,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1498,10 +1278,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1519,10 +1295,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1540,10 +1312,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1561,10 +1329,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1579,10 +1343,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1597,10 +1357,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1615,10 +1371,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1633,10 +1385,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1651,10 +1399,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1669,10 +1413,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1687,10 +1427,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1705,10 +1441,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1723,10 +1455,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1741,10 +1469,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1759,10 +1483,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1777,10 +1497,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1795,10 +1511,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1813,10 +1525,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1831,10 +1539,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1849,10 +1553,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1870,10 +1570,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1891,10 +1587,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1912,10 +1604,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1933,10 +1621,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1951,10 +1635,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1969,10 +1649,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1987,10 +1663,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2005,10 +1677,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2023,10 +1691,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2041,10 +1705,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2059,10 +1719,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2077,10 +1733,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2095,10 +1747,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2113,10 +1761,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2131,10 +1775,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2149,10 +1789,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2170,10 +1806,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2191,10 +1823,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2233,10 +1861,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2289,10 +1913,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2310,10 +1930,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2331,10 +1947,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2352,10 +1964,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2373,10 +1981,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2394,10 +1998,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2415,10 +2015,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2436,10 +2032,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2457,10 +2049,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2478,10 +2066,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2499,10 +2083,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2520,10 +2100,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2541,10 +2117,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2562,10 +2134,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2583,10 +2151,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2604,10 +2168,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2625,10 +2185,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2646,10 +2202,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2667,10 +2219,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2688,10 +2236,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2709,10 +2253,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2730,10 +2270,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2751,10 +2287,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2769,10 +2301,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2874,10 +2402,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2895,10 +2419,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2972,10 +2492,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2993,10 +2509,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3056,10 +2568,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3095,10 +2603,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3116,10 +2620,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3137,10 +2637,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3158,10 +2654,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3179,10 +2671,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3200,10 +2688,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3221,10 +2705,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3242,10 +2722,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3263,10 +2739,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3284,10 +2756,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3305,10 +2773,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3326,10 +2790,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3347,10 +2807,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3368,10 +2824,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3386,10 +2838,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3404,10 +2852,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3458,10 +2902,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3511,10 +2951,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3658,10 +3094,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3676,10 +3108,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3778,10 +3206,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3799,10 +3223,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3820,10 +3240,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3841,10 +3257,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3862,10 +3274,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3883,10 +3291,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3901,10 +3305,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -4024,10 +3424,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4045,10 +3441,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4066,10 +3458,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4087,10 +3475,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4108,10 +3492,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4129,10 +3509,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4150,10 +3526,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4168,10 +3540,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4189,10 +3557,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4207,10 +3571,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4225,10 +3585,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4243,10 +3599,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4261,10 +3613,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4279,10 +3627,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4297,10 +3641,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4315,10 +3655,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4333,10 +3669,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4351,10 +3683,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4369,10 +3697,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4387,10 +3711,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4405,10 +3725,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4423,10 +3739,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4441,10 +3753,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4459,10 +3767,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4477,10 +3781,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4495,10 +3795,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4513,10 +3809,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4531,10 +3823,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4549,10 +3837,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4570,10 +3854,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4588,10 +3868,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4606,10 +3882,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4624,10 +3896,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4642,10 +3910,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4660,10 +3924,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4678,10 +3938,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4696,10 +3952,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4714,10 +3966,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4732,10 +3980,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4750,10 +3994,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4768,10 +4008,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4786,10 +4022,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4807,10 +4039,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4828,10 +4056,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4849,10 +4073,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4870,10 +4090,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4891,10 +4107,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4912,10 +4124,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4933,10 +4141,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4954,10 +4158,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4975,10 +4175,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4996,10 +4192,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -5017,10 +4209,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5038,10 +4226,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5059,10 +4243,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5080,10 +4260,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5098,10 +4274,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5116,10 +4288,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5137,10 +4305,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5158,10 +4322,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5179,10 +4339,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5200,10 +4356,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5221,10 +4373,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5242,10 +4390,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5263,10 +4407,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5284,10 +4424,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5305,10 +4441,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5326,10 +4458,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5347,10 +4475,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5368,10 +4492,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5389,10 +4509,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5410,10 +4526,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5431,10 +4543,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5515,10 +4623,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5536,10 +4640,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5557,10 +4657,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5620,10 +4716,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5746,10 +4838,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5764,10 +4852,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5800,10 +4884,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5818,10 +4898,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5836,10 +4912,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5854,10 +4926,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5872,10 +4940,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5893,10 +4957,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5914,10 +4974,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5935,10 +4991,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5956,10 +5008,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5977,10 +5025,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5998,10 +5042,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -6019,10 +5059,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6040,10 +5076,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6061,10 +5093,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6082,10 +5110,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6103,10 +5127,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6124,10 +5144,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6145,10 +5161,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6166,10 +5178,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6187,10 +5195,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6208,10 +5212,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6229,10 +5229,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6247,10 +5243,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6268,10 +5260,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6289,10 +5277,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6310,10 +5294,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6331,10 +5311,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6352,10 +5328,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6373,10 +5345,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6394,10 +5362,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6415,10 +5379,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6436,10 +5396,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6457,10 +5413,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6475,10 +5427,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6493,10 +5441,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6511,10 +5455,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6529,10 +5469,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6550,10 +5486,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6568,10 +5500,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6652,10 +5580,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6673,10 +5597,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6694,10 +5614,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6715,10 +5631,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6736,10 +5648,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6757,10 +5665,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6778,10 +5682,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6820,10 +5720,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6862,10 +5758,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -7020,10 +5912,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7125,10 +6013,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7167,10 +6051,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7293,10 +6173,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7311,10 +6187,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7332,10 +6204,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7350,10 +6218,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7368,10 +6232,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7389,10 +6249,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7410,10 +6266,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7431,10 +6283,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7452,10 +6300,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7473,10 +6317,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7494,10 +6334,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7515,10 +6351,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
@@ -18,7 +18,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38,6 +38,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -55,6 +59,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -72,6 +80,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -89,6 +101,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -106,6 +122,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -123,6 +143,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -140,6 +164,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -158,7 +186,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -178,6 +206,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -195,6 +227,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -230,6 +266,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -247,6 +287,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -264,6 +308,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -281,6 +329,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -298,6 +350,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -315,6 +371,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -332,6 +392,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -350,7 +414,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -371,7 +435,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -392,7 +456,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -412,6 +476,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -430,7 +498,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -450,6 +518,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -468,7 +540,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -489,7 +561,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -509,6 +581,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -526,6 +602,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -543,6 +623,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -560,6 +644,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -577,6 +665,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -594,6 +686,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -611,6 +707,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -628,6 +728,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -646,7 +750,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -667,7 +771,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -687,6 +791,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -704,6 +812,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -721,6 +833,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -740,7 +856,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -756,6 +872,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -773,6 +893,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -791,7 +915,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -812,7 +936,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -833,7 +957,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -854,7 +978,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -875,7 +999,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -895,6 +1019,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -910,7 +1038,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -926,6 +1054,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -943,6 +1075,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -960,6 +1096,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -977,6 +1117,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -994,6 +1138,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1008,6 +1156,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1025,6 +1177,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1042,6 +1198,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1059,6 +1219,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1076,6 +1240,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1093,6 +1261,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1107,6 +1279,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1121,6 +1297,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1135,6 +1315,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1149,6 +1333,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1163,6 +1351,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1177,6 +1369,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1191,6 +1387,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1205,6 +1405,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1219,6 +1423,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1233,6 +1441,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1247,6 +1459,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1261,6 +1477,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1278,6 +1498,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1295,6 +1519,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1312,6 +1540,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1329,6 +1561,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1343,6 +1579,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1357,6 +1597,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1371,6 +1615,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1385,6 +1633,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1399,6 +1651,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1413,6 +1669,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1427,6 +1687,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1441,6 +1705,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1455,6 +1723,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1469,6 +1741,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1483,6 +1759,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1497,6 +1777,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1511,6 +1795,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1525,6 +1813,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1539,6 +1831,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1553,6 +1849,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1570,6 +1870,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1587,6 +1891,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1604,6 +1912,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1621,6 +1933,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1635,6 +1951,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1649,6 +1969,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1663,6 +1987,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1677,6 +2005,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1691,6 +2023,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -1705,6 +2041,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -1719,6 +2059,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -1733,6 +2077,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -1747,6 +2095,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -1761,6 +2113,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -1775,6 +2131,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -1789,6 +2149,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -1806,6 +2170,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -1823,6 +2191,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -1841,7 +2213,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1861,6 +2233,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -1876,7 +2252,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1897,7 +2273,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1913,6 +2289,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -1930,6 +2310,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -1947,6 +2331,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -1964,6 +2352,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -1981,6 +2373,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -1998,6 +2394,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2015,6 +2415,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2032,6 +2436,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2049,6 +2457,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2066,6 +2478,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2083,6 +2499,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2100,6 +2520,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2117,6 +2541,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2134,6 +2562,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2151,6 +2583,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2168,6 +2604,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2185,6 +2625,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2202,6 +2646,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2219,6 +2667,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2236,6 +2688,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2253,6 +2709,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2270,6 +2730,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2287,6 +2751,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2301,6 +2769,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2319,7 +2791,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2340,7 +2812,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2361,7 +2833,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2382,7 +2854,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2402,6 +2874,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2419,6 +2895,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2437,7 +2917,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2458,7 +2938,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2492,6 +2972,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2509,6 +2993,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -2527,7 +3015,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2548,7 +3036,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2568,6 +3056,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2583,7 +3075,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2603,6 +3095,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2620,6 +3116,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2637,6 +3137,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2654,6 +3158,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2671,6 +3179,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2688,6 +3200,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2705,6 +3221,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2722,6 +3242,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2739,6 +3263,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2756,6 +3284,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -2773,6 +3305,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -2790,6 +3326,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -2807,6 +3347,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -2824,6 +3368,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -2838,6 +3386,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -2852,6 +3404,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -2868,7 +3424,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2886,7 +3442,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2902,6 +3458,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -2921,7 +3481,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2951,6 +3511,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -2969,7 +3533,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2990,7 +3554,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3011,7 +3575,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3032,7 +3596,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3053,7 +3617,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3074,7 +3638,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3094,6 +3658,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3108,6 +3676,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3123,7 +3695,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3144,7 +3716,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3165,7 +3737,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3186,7 +3758,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3206,6 +3778,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3223,6 +3799,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3240,6 +3820,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3257,6 +3841,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3274,6 +3862,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3291,6 +3883,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3305,6 +3901,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3320,7 +3920,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3341,7 +3941,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3362,7 +3962,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3383,7 +3983,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3404,7 +4004,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3424,6 +4024,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3441,6 +4045,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3458,6 +4066,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3475,6 +4087,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3492,6 +4108,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3509,6 +4129,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3526,6 +4150,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3540,6 +4168,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3557,6 +4189,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3571,6 +4207,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3585,6 +4225,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3599,6 +4243,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3613,6 +4261,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3627,6 +4279,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3641,6 +4297,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3655,6 +4315,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3669,6 +4333,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3683,6 +4351,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3697,6 +4369,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3711,6 +4387,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3725,6 +4405,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3739,6 +4423,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3753,6 +4441,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3767,6 +4459,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -3781,6 +4477,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -3795,6 +4495,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -3809,6 +4513,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -3823,6 +4531,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -3837,6 +4549,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -3854,6 +4570,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -3868,6 +4588,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -3882,6 +4606,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -3896,6 +4624,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -3910,6 +4642,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -3924,6 +4660,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -3938,6 +4678,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -3952,6 +4696,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -3966,6 +4714,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -3980,6 +4732,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -3994,6 +4750,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4008,6 +4768,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4022,6 +4786,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4039,6 +4807,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4056,6 +4828,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4073,6 +4849,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4090,6 +4870,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4107,6 +4891,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4124,6 +4912,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4141,6 +4933,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4158,6 +4954,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4175,6 +4975,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4192,6 +4996,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4209,6 +5017,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4226,6 +5038,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4243,6 +5059,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4260,6 +5080,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4274,6 +5098,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4288,6 +5116,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4305,6 +5137,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4322,6 +5158,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4339,6 +5179,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4356,6 +5200,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4373,6 +5221,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4390,6 +5242,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4407,6 +5263,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4424,6 +5284,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4441,6 +5305,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4458,6 +5326,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4475,6 +5347,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4492,6 +5368,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4509,6 +5389,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4526,6 +5410,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4543,6 +5431,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4561,7 +5453,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4582,7 +5474,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4603,7 +5495,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4623,6 +5515,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -4640,6 +5536,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4657,6 +5557,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4675,7 +5579,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4696,7 +5600,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4716,6 +5620,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4734,7 +5642,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4755,7 +5663,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4776,7 +5684,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4797,7 +5705,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4818,7 +5726,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4838,6 +5746,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -4852,6 +5764,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -4868,7 +5784,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4884,6 +5800,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -4898,6 +5818,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -4912,6 +5836,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -4926,6 +5854,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -4940,6 +5872,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -4957,6 +5893,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -4974,6 +5914,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -4991,6 +5935,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5008,6 +5956,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5025,6 +5977,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5042,6 +5998,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5059,6 +6019,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5076,6 +6040,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5093,6 +6061,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5110,6 +6082,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5127,6 +6103,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5144,6 +6124,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5161,6 +6145,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5178,6 +6166,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5195,6 +6187,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5212,6 +6208,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5229,6 +6229,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5243,6 +6247,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5260,6 +6268,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5277,6 +6289,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5294,6 +6310,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5311,6 +6331,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5328,6 +6352,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5345,6 +6373,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5362,6 +6394,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5379,6 +6415,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5396,6 +6436,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5413,6 +6457,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5427,6 +6475,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5441,6 +6493,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5455,6 +6511,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5469,6 +6529,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5486,6 +6550,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5500,6 +6568,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5518,7 +6590,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5539,7 +6611,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5560,7 +6632,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5580,6 +6652,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5597,6 +6673,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5614,6 +6694,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5631,6 +6715,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5648,6 +6736,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5665,6 +6757,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5682,6 +6778,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5700,7 +6800,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5720,6 +6820,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5738,7 +6842,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5758,6 +6862,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -5776,7 +6884,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5797,7 +6905,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5818,7 +6926,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5858,7 +6966,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5875,7 +6983,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5896,7 +7004,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5912,6 +7020,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -5930,7 +7042,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5951,7 +7063,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5972,7 +7084,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5993,7 +7105,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6013,6 +7125,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6031,7 +7147,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6051,6 +7167,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6069,7 +7189,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6090,7 +7210,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6111,7 +7231,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6132,7 +7252,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6153,7 +7273,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6173,6 +7293,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6187,6 +7311,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6204,6 +7332,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6218,6 +7350,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6232,6 +7368,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6249,6 +7389,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6266,6 +7410,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6283,6 +7431,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6300,6 +7452,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6317,6 +7473,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6334,6 +7494,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6351,6 +7515,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusRule.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusRule.json
@@ -38,10 +38,6 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -59,10 +55,6 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -80,10 +72,6 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -101,10 +89,6 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -122,10 +106,6 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -143,10 +123,6 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -164,10 +140,6 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -206,10 +178,6 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -227,10 +195,6 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -266,10 +230,6 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -287,10 +247,6 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -308,10 +264,6 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -329,10 +281,6 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -350,10 +298,6 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -371,10 +315,6 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -392,10 +332,6 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -476,10 +412,6 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -518,10 +450,6 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -581,10 +509,6 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -602,10 +526,6 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -623,10 +543,6 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -644,10 +560,6 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -665,10 +577,6 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -686,10 +594,6 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -707,10 +611,6 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -728,10 +628,6 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -791,10 +687,6 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -812,10 +704,6 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -833,10 +721,6 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -872,10 +756,6 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -893,10 +773,6 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -1019,10 +895,6 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -1054,10 +926,6 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -1075,10 +943,6 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -1096,10 +960,6 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -1117,10 +977,6 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -1138,10 +994,6 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1156,10 +1008,6 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1177,10 +1025,6 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1198,10 +1042,6 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1219,10 +1059,6 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1240,10 +1076,6 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1261,10 +1093,6 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1279,10 +1107,6 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1297,10 +1121,6 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1315,10 +1135,6 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1333,10 +1149,6 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1351,10 +1163,6 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1369,10 +1177,6 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1387,10 +1191,6 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1405,10 +1205,6 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1423,10 +1219,6 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1441,10 +1233,6 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1459,10 +1247,6 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1477,10 +1261,6 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1498,10 +1278,6 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1519,10 +1295,6 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1540,10 +1312,6 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1561,10 +1329,6 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1579,10 +1343,6 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1597,10 +1357,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1615,10 +1371,6 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1633,10 +1385,6 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1651,10 +1399,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1669,10 +1413,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1687,10 +1427,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1705,10 +1441,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1723,10 +1455,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1741,10 +1469,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1759,10 +1483,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1777,10 +1497,6 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1795,10 +1511,6 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1813,10 +1525,6 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1831,10 +1539,6 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1849,10 +1553,6 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1870,10 +1570,6 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1891,10 +1587,6 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1912,10 +1604,6 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1933,10 +1621,6 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1951,10 +1635,6 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1969,10 +1649,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1987,10 +1663,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -2005,10 +1677,6 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -2023,10 +1691,6 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -2041,10 +1705,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -2059,10 +1719,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -2077,10 +1733,6 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -2095,10 +1747,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -2113,10 +1761,6 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -2131,10 +1775,6 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -2149,10 +1789,6 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -2170,10 +1806,6 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -2191,10 +1823,6 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -2233,10 +1861,6 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -2289,10 +1913,6 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -2310,10 +1930,6 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -2331,10 +1947,6 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -2352,10 +1964,6 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -2373,10 +1981,6 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -2394,10 +1998,6 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2415,10 +2015,6 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2436,10 +2032,6 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2457,10 +2049,6 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2478,10 +2066,6 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2499,10 +2083,6 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2520,10 +2100,6 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2541,10 +2117,6 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2562,10 +2134,6 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2583,10 +2151,6 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2604,10 +2168,6 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2625,10 +2185,6 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2646,10 +2202,6 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2667,10 +2219,6 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2688,10 +2236,6 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2709,10 +2253,6 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2730,10 +2270,6 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2751,10 +2287,6 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2769,10 +2301,6 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2874,10 +2402,6 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2895,10 +2419,6 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2972,10 +2492,6 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2993,10 +2509,6 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -3056,10 +2568,6 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -3095,10 +2603,6 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -3116,10 +2620,6 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -3137,10 +2637,6 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -3158,10 +2654,6 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -3179,10 +2671,6 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -3200,10 +2688,6 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -3221,10 +2705,6 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -3242,10 +2722,6 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -3263,10 +2739,6 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -3284,10 +2756,6 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -3305,10 +2773,6 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -3326,10 +2790,6 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -3347,10 +2807,6 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -3368,10 +2824,6 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -3386,10 +2838,6 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -3404,10 +2852,6 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -3458,10 +2902,6 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -3497,10 +2937,6 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -3644,10 +3080,6 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3662,10 +3094,6 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3764,10 +3192,6 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3785,10 +3209,6 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3806,10 +3226,6 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3827,10 +3243,6 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3848,10 +3260,6 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3869,10 +3277,6 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3887,10 +3291,6 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -4010,10 +3410,6 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -4031,10 +3427,6 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -4052,10 +3444,6 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -4073,10 +3461,6 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -4094,10 +3478,6 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -4115,10 +3495,6 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -4136,10 +3512,6 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -4154,10 +3526,6 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -4175,10 +3543,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -4193,10 +3557,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -4211,10 +3571,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -4229,10 +3585,6 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -4247,10 +3599,6 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -4265,10 +3613,6 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -4283,10 +3627,6 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -4301,10 +3641,6 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -4319,10 +3655,6 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -4337,10 +3669,6 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -4355,10 +3683,6 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -4373,10 +3697,6 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -4391,10 +3711,6 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -4409,10 +3725,6 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -4427,10 +3739,6 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -4445,10 +3753,6 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -4463,10 +3767,6 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -4481,10 +3781,6 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -4499,10 +3795,6 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -4517,10 +3809,6 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -4535,10 +3823,6 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -4556,10 +3840,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -4574,10 +3854,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -4592,10 +3868,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -4610,10 +3882,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -4628,10 +3896,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -4646,10 +3910,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -4664,10 +3924,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -4682,10 +3938,6 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -4700,10 +3952,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -4718,10 +3966,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -4736,10 +3980,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -4754,10 +3994,6 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4772,10 +4008,6 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4793,10 +4025,6 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4814,10 +4042,6 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4835,10 +4059,6 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4856,10 +4076,6 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4877,10 +4093,6 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4898,10 +4110,6 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4919,10 +4127,6 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4940,10 +4144,6 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4961,10 +4161,6 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4982,10 +4178,6 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -5003,10 +4195,6 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -5024,10 +4212,6 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -5045,10 +4229,6 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -5066,10 +4246,6 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -5084,10 +4260,6 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -5102,10 +4274,6 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -5123,10 +4291,6 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -5144,10 +4308,6 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -5165,10 +4325,6 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -5186,10 +4342,6 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -5207,10 +4359,6 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -5228,10 +4376,6 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -5249,10 +4393,6 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -5270,10 +4410,6 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -5291,10 +4427,6 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -5312,10 +4444,6 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -5333,10 +4461,6 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -5354,10 +4478,6 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -5375,10 +4495,6 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -5396,10 +4512,6 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -5417,10 +4529,6 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -5501,10 +4609,6 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -5522,10 +4626,6 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -5543,10 +4643,6 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -5606,10 +4702,6 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -5732,10 +4824,6 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -5750,10 +4838,6 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -5786,10 +4870,6 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -5818,10 +4898,6 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -5836,10 +4912,6 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -5854,10 +4926,6 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -5872,10 +4940,6 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -5893,10 +4957,6 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -5914,10 +4974,6 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -5935,10 +4991,6 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5956,10 +5008,6 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5977,10 +5025,6 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5998,10 +5042,6 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -6019,10 +5059,6 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -6040,10 +5076,6 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -6061,10 +5093,6 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -6082,10 +5110,6 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -6103,10 +5127,6 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -6124,10 +5144,6 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -6145,10 +5161,6 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -6166,10 +5178,6 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -6187,10 +5195,6 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -6208,10 +5212,6 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -6229,10 +5229,6 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -6247,10 +5243,6 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -6268,10 +5260,6 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -6289,10 +5277,6 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -6310,10 +5294,6 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -6331,10 +5311,6 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -6352,10 +5328,6 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -6373,10 +5345,6 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -6394,10 +5362,6 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -6415,10 +5379,6 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -6436,10 +5396,6 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -6457,10 +5413,6 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -6475,10 +5427,6 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -6493,10 +5441,6 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -6511,10 +5455,6 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -6529,10 +5469,6 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -6550,10 +5486,6 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -6568,10 +5500,6 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -6652,10 +5580,6 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -6673,10 +5597,6 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -6694,10 +5614,6 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -6715,10 +5631,6 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -6736,10 +5648,6 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -6757,10 +5665,6 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -6778,10 +5682,6 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -6820,10 +5720,6 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -6862,10 +5758,6 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -7020,10 +5912,6 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -7125,10 +6013,6 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -7167,10 +6051,6 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -7293,10 +6173,6 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -7311,10 +6187,6 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -7332,10 +6204,6 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -7350,10 +6218,6 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -7368,10 +6232,6 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -7389,10 +6249,6 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -7410,10 +6266,6 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -7431,10 +6283,6 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -7452,10 +6300,6 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -7473,10 +6317,6 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -7494,10 +6334,6 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -7515,10 +6351,6 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -7536,10 +6368,6 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusRule.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusRule.json
@@ -18,7 +18,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -38,6 +38,10 @@
     "label": "anyTypeInDependsOn",
     "kind": "interface",
     "detail": "anyTypeInDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInDependsOn",
@@ -55,6 +59,10 @@
     "label": "anyTypeInExistingScope",
     "kind": "interface",
     "detail": "anyTypeInExistingScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScope",
@@ -72,6 +80,10 @@
     "label": "anyTypeInExistingScopeLoop",
     "kind": "interface",
     "detail": "anyTypeInExistingScopeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInExistingScopeLoop",
@@ -89,6 +101,10 @@
     "label": "anyTypeInParent",
     "kind": "interface",
     "detail": "anyTypeInParent",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParent",
@@ -106,6 +122,10 @@
     "label": "anyTypeInParentLoop",
     "kind": "interface",
     "detail": "anyTypeInParentLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInParentLoop",
@@ -123,6 +143,10 @@
     "label": "anyTypeInScope",
     "kind": "interface",
     "detail": "anyTypeInScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScope",
@@ -140,6 +164,10 @@
     "label": "anyTypeInScopeConditional",
     "kind": "interface",
     "detail": "anyTypeInScopeConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyTypeInScopeConditional",
@@ -158,7 +186,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -178,6 +206,10 @@
     "label": "arrayExpressionErrors",
     "kind": "interface",
     "detail": "arrayExpressionErrors",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors",
@@ -195,6 +227,10 @@
     "label": "arrayExpressionErrors2",
     "kind": "interface",
     "detail": "arrayExpressionErrors2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayExpressionErrors2",
@@ -230,6 +266,10 @@
     "label": "badDepends",
     "kind": "interface",
     "detail": "badDepends",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends",
@@ -247,6 +287,10 @@
     "label": "badDepends2",
     "kind": "interface",
     "detail": "badDepends2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends2",
@@ -264,6 +308,10 @@
     "label": "badDepends3",
     "kind": "interface",
     "detail": "badDepends3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends3",
@@ -281,6 +329,10 @@
     "label": "badDepends4",
     "kind": "interface",
     "detail": "badDepends4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends4",
@@ -298,6 +350,10 @@
     "label": "badDepends5",
     "kind": "interface",
     "detail": "badDepends5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badDepends5",
@@ -315,6 +371,10 @@
     "label": "badInterp",
     "kind": "interface",
     "detail": "badInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterp",
@@ -332,6 +392,10 @@
     "label": "bar",
     "kind": "interface",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -350,7 +414,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -371,7 +435,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -392,7 +456,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -412,6 +476,10 @@
     "label": "baz",
     "kind": "interface",
     "detail": "baz",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_baz",
@@ -430,7 +498,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -450,6 +518,10 @@
     "label": "booleanPropertyPartialValue",
     "kind": "interface",
     "detail": "booleanPropertyPartialValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_booleanPropertyPartialValue",
@@ -468,7 +540,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -489,7 +561,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -509,6 +581,10 @@
     "label": "comp1",
     "kind": "interface",
     "detail": "comp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp1",
@@ -526,6 +602,10 @@
     "label": "comp2",
     "kind": "interface",
     "detail": "comp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp2",
@@ -543,6 +623,10 @@
     "label": "comp3",
     "kind": "interface",
     "detail": "comp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp3",
@@ -560,6 +644,10 @@
     "label": "comp4",
     "kind": "interface",
     "detail": "comp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp4",
@@ -577,6 +665,10 @@
     "label": "comp5",
     "kind": "interface",
     "detail": "comp5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp5",
@@ -594,6 +686,10 @@
     "label": "comp6",
     "kind": "interface",
     "detail": "comp6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp6",
@@ -611,6 +707,10 @@
     "label": "comp7",
     "kind": "interface",
     "detail": "comp7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp7",
@@ -628,6 +728,10 @@
     "label": "comp8",
     "kind": "interface",
     "detail": "comp8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_comp8",
@@ -646,7 +750,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -667,7 +771,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -687,6 +791,10 @@
     "label": "cyclicExistingRes",
     "kind": "interface",
     "detail": "cyclicExistingRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicExistingRes",
@@ -704,6 +812,10 @@
     "label": "cyclicRes",
     "kind": "interface",
     "detail": "cyclicRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_cyclicRes",
@@ -721,6 +833,10 @@
     "label": "dashesInPropertyNames",
     "kind": "interface",
     "detail": "dashesInPropertyNames",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dashesInPropertyNames",
@@ -740,7 +856,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -756,6 +872,10 @@
     "label": "dataCollectionRuleRes",
     "kind": "interface",
     "detail": "dataCollectionRuleRes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes",
@@ -773,6 +893,10 @@
     "label": "dataCollectionRuleRes2",
     "kind": "interface",
     "detail": "dataCollectionRuleRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRuleRes2",
@@ -791,7 +915,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -812,7 +936,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -833,7 +957,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -854,7 +978,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -875,7 +999,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -895,6 +1019,10 @@
     "label": "defaultLogAnalyticsWorkspace",
     "kind": "variable",
     "detail": "defaultLogAnalyticsWorkspace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultLogAnalyticsWorkspace",
@@ -910,7 +1038,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -926,6 +1054,10 @@
     "label": "directRefViaSingleConditionalResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleConditionalResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleConditionalResourceBody",
@@ -943,6 +1075,10 @@
     "label": "directRefViaSingleLoopResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBody",
@@ -960,6 +1096,10 @@
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
     "kind": "interface",
     "detail": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -977,6 +1117,10 @@
     "label": "directRefViaSingleResourceBody",
     "kind": "interface",
     "detail": "directRefViaSingleResourceBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaSingleResourceBody",
@@ -994,6 +1138,10 @@
     "label": "directRefViaVar",
     "kind": "variable",
     "detail": "directRefViaVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_directRefViaVar",
@@ -1008,6 +1156,10 @@
     "label": "discriminatorKeyMissing",
     "kind": "interface",
     "detail": "discriminatorKeyMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing",
@@ -1025,6 +1177,10 @@
     "label": "discriminatorKeyMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for",
@@ -1042,6 +1198,10 @@
     "label": "discriminatorKeyMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_for_if",
@@ -1059,6 +1219,10 @@
     "label": "discriminatorKeyMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyMissing_if",
@@ -1076,6 +1240,10 @@
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne",
@@ -1093,6 +1261,10 @@
     "label": "discriminatorKeySetOneCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions",
@@ -1107,6 +1279,10 @@
     "label": "discriminatorKeySetOneCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2",
@@ -1121,6 +1297,10 @@
     "label": "discriminatorKeySetOneCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for",
@@ -1135,6 +1315,10 @@
     "label": "discriminatorKeySetOneCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_for_if",
@@ -1149,6 +1333,10 @@
     "label": "discriminatorKeySetOneCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions2_if",
@@ -1163,6 +1351,10 @@
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3",
@@ -1177,6 +1369,10 @@
     "label": "discriminatorKeySetOneCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for",
@@ -1191,6 +1387,10 @@
     "label": "discriminatorKeySetOneCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_for_if",
@@ -1205,6 +1405,10 @@
     "label": "discriminatorKeySetOneCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions3_if",
@@ -1219,6 +1423,10 @@
     "label": "discriminatorKeySetOneCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for",
@@ -1233,6 +1441,10 @@
     "label": "discriminatorKeySetOneCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_for_if",
@@ -1247,6 +1459,10 @@
     "label": "discriminatorKeySetOneCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOneCompletions_if",
@@ -1261,6 +1477,10 @@
     "label": "discriminatorKeySetOne_for",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for",
@@ -1278,6 +1498,10 @@
     "label": "discriminatorKeySetOne_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_for_if",
@@ -1295,6 +1519,10 @@
     "label": "discriminatorKeySetOne_if",
     "kind": "interface",
     "detail": "discriminatorKeySetOne_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetOne_if",
@@ -1312,6 +1540,10 @@
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo",
@@ -1329,6 +1561,10 @@
     "label": "discriminatorKeySetTwoCompletions",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions",
@@ -1343,6 +1579,10 @@
     "label": "discriminatorKeySetTwoCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2",
@@ -1357,6 +1597,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for",
@@ -1371,6 +1615,10 @@
     "label": "discriminatorKeySetTwoCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_for_if",
@@ -1385,6 +1633,10 @@
     "label": "discriminatorKeySetTwoCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions2_if",
@@ -1399,6 +1651,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1413,6 +1669,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
@@ -1427,6 +1687,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
@@ -1441,6 +1705,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for_if",
@@ -1455,6 +1723,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
@@ -1469,6 +1741,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
@@ -1483,6 +1759,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for_if",
@@ -1497,6 +1777,10 @@
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
@@ -1511,6 +1795,10 @@
     "label": "discriminatorKeySetTwoCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for",
@@ -1525,6 +1813,10 @@
     "label": "discriminatorKeySetTwoCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_for_if",
@@ -1539,6 +1831,10 @@
     "label": "discriminatorKeySetTwoCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwoCompletions_if",
@@ -1553,6 +1849,10 @@
     "label": "discriminatorKeySetTwo_for",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for",
@@ -1570,6 +1870,10 @@
     "label": "discriminatorKeySetTwo_for_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_for_if",
@@ -1587,6 +1891,10 @@
     "label": "discriminatorKeySetTwo_if",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeySetTwo_if",
@@ -1604,6 +1912,10 @@
     "label": "discriminatorKeyValueMissing",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing",
@@ -1621,6 +1933,10 @@
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions",
@@ -1635,6 +1951,10 @@
     "label": "discriminatorKeyValueMissingCompletions2",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2",
@@ -1649,6 +1969,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
@@ -1663,6 +1987,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_for_if",
@@ -1677,6 +2005,10 @@
     "label": "discriminatorKeyValueMissingCompletions2_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
@@ -1691,6 +2023,10 @@
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3",
@@ -1705,6 +2041,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
@@ -1719,6 +2059,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_for_if",
@@ -1733,6 +2077,10 @@
     "label": "discriminatorKeyValueMissingCompletions3_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
@@ -1747,6 +2095,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for",
@@ -1761,6 +2113,10 @@
     "label": "discriminatorKeyValueMissingCompletions_for_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_for_if",
@@ -1775,6 +2131,10 @@
     "label": "discriminatorKeyValueMissingCompletions_if",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissingCompletions_if",
@@ -1789,6 +2149,10 @@
     "label": "discriminatorKeyValueMissing_for",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for",
@@ -1806,6 +2170,10 @@
     "label": "discriminatorKeyValueMissing_for_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_for_if",
@@ -1823,6 +2191,10 @@
     "label": "discriminatorKeyValueMissing_if",
     "kind": "interface",
     "detail": "discriminatorKeyValueMissing_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_discriminatorKeyValueMissing_if",
@@ -1841,7 +2213,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1861,6 +2233,10 @@
     "label": "emptyArray",
     "kind": "variable",
     "detail": "emptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyArray",
@@ -1876,7 +2252,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1897,7 +2273,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1913,6 +2289,10 @@
     "label": "existingResProperty",
     "kind": "interface",
     "detail": "existingResProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_existingResProperty",
@@ -1930,6 +2310,10 @@
     "label": "expectedArrayExpression",
     "kind": "interface",
     "detail": "expectedArrayExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression",
@@ -1947,6 +2331,10 @@
     "label": "expectedArrayExpression2",
     "kind": "interface",
     "detail": "expectedArrayExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedArrayExpression2",
@@ -1964,6 +2352,10 @@
     "label": "expectedColon",
     "kind": "interface",
     "detail": "expectedColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon",
@@ -1981,6 +2373,10 @@
     "label": "expectedColon2",
     "kind": "interface",
     "detail": "expectedColon2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedColon2",
@@ -1998,6 +2394,10 @@
     "label": "expectedComma",
     "kind": "interface",
     "detail": "expectedComma",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedComma",
@@ -2015,6 +2415,10 @@
     "label": "expectedForKeyword",
     "kind": "interface",
     "detail": "expectedForKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword",
@@ -2032,6 +2436,10 @@
     "label": "expectedForKeyword2",
     "kind": "interface",
     "detail": "expectedForKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedForKeyword2",
@@ -2049,6 +2457,10 @@
     "label": "expectedInKeyword",
     "kind": "interface",
     "detail": "expectedInKeyword",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword",
@@ -2066,6 +2478,10 @@
     "label": "expectedInKeyword2",
     "kind": "interface",
     "detail": "expectedInKeyword2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword2",
@@ -2083,6 +2499,10 @@
     "label": "expectedInKeyword3",
     "kind": "interface",
     "detail": "expectedInKeyword3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword3",
@@ -2100,6 +2520,10 @@
     "label": "expectedInKeyword4",
     "kind": "interface",
     "detail": "expectedInKeyword4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedInKeyword4",
@@ -2117,6 +2541,10 @@
     "label": "expectedLoopBody",
     "kind": "interface",
     "detail": "expectedLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody",
@@ -2134,6 +2562,10 @@
     "label": "expectedLoopBody2",
     "kind": "interface",
     "detail": "expectedLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopBody2",
@@ -2151,6 +2583,10 @@
     "label": "expectedLoopFilterOpenParen",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen",
@@ -2168,6 +2604,10 @@
     "label": "expectedLoopFilterOpenParen2",
     "kind": "interface",
     "detail": "expectedLoopFilterOpenParen2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterOpenParen2",
@@ -2185,6 +2625,10 @@
     "label": "expectedLoopFilterPredicateAndBody",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody",
@@ -2202,6 +2646,10 @@
     "label": "expectedLoopFilterPredicateAndBody2",
     "kind": "interface",
     "detail": "expectedLoopFilterPredicateAndBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopFilterPredicateAndBody2",
@@ -2219,6 +2667,10 @@
     "label": "expectedLoopIndexName",
     "kind": "interface",
     "detail": "expectedLoopIndexName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopIndexName",
@@ -2236,6 +2688,10 @@
     "label": "expectedLoopItemName",
     "kind": "interface",
     "detail": "expectedLoopItemName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName",
@@ -2253,6 +2709,10 @@
     "label": "expectedLoopItemName2",
     "kind": "interface",
     "detail": "expectedLoopItemName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopItemName2",
@@ -2270,6 +2730,10 @@
     "label": "expectedLoopVar",
     "kind": "interface",
     "detail": "expectedLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expectedLoopVar",
@@ -2287,6 +2751,10 @@
     "label": "expressionInPropertyLoopVar",
     "kind": "variable",
     "detail": "expressionInPropertyLoopVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInPropertyLoopVar",
@@ -2301,6 +2769,10 @@
     "label": "expressionsInPropertyLoopName",
     "kind": "interface",
     "detail": "expressionsInPropertyLoopName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionsInPropertyLoopName",
@@ -2319,7 +2791,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2340,7 +2812,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2361,7 +2833,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2382,7 +2854,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2402,6 +2874,10 @@
     "label": "fo",
     "kind": "interface",
     "detail": "fo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fo",
@@ -2419,6 +2895,10 @@
     "label": "foo",
     "kind": "interface",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -2437,7 +2917,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2458,7 +2938,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2492,6 +2972,10 @@
     "label": "incorrectPropertiesKey",
     "kind": "interface",
     "detail": "incorrectPropertiesKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey",
@@ -2509,6 +2993,10 @@
     "label": "incorrectPropertiesKey2",
     "kind": "interface",
     "detail": "incorrectPropertiesKey2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incorrectPropertiesKey2",
@@ -2527,7 +3015,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2548,7 +3036,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2568,6 +3056,10 @@
     "label": "interpVal",
     "kind": "variable",
     "detail": "interpVal",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpVal",
@@ -2583,7 +3075,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2603,6 +3095,10 @@
     "label": "invalidDecorator",
     "kind": "interface",
     "detail": "invalidDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDecorator",
@@ -2620,6 +3116,10 @@
     "label": "invalidDuplicateName1",
     "kind": "interface",
     "detail": "invalidDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName1",
@@ -2637,6 +3137,10 @@
     "label": "invalidDuplicateName2",
     "kind": "interface",
     "detail": "invalidDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName2",
@@ -2654,6 +3158,10 @@
     "label": "invalidDuplicateName3",
     "kind": "interface",
     "detail": "invalidDuplicateName3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDuplicateName3",
@@ -2671,6 +3179,10 @@
     "label": "invalidExistingLocationRef",
     "kind": "interface",
     "detail": "invalidExistingLocationRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExistingLocationRef",
@@ -2688,6 +3200,10 @@
     "label": "invalidExtensionResourceDuplicateName1",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName1",
@@ -2705,6 +3221,10 @@
     "label": "invalidExtensionResourceDuplicateName2",
     "kind": "interface",
     "detail": "invalidExtensionResourceDuplicateName2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidExtensionResourceDuplicateName2",
@@ -2722,6 +3242,10 @@
     "label": "invalidScope",
     "kind": "interface",
     "detail": "invalidScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope",
@@ -2739,6 +3263,10 @@
     "label": "invalidScope2",
     "kind": "interface",
     "detail": "invalidScope2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope2",
@@ -2756,6 +3284,10 @@
     "label": "invalidScope3",
     "kind": "interface",
     "detail": "invalidScope3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidScope3",
@@ -2773,6 +3305,10 @@
     "label": "issue3000LogicApp1",
     "kind": "interface",
     "detail": "issue3000LogicApp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp1",
@@ -2790,6 +3326,10 @@
     "label": "issue3000LogicApp2",
     "kind": "interface",
     "detail": "issue3000LogicApp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000LogicApp2",
@@ -2807,6 +3347,10 @@
     "label": "issue3000stg",
     "kind": "interface",
     "detail": "issue3000stg",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stg",
@@ -2824,6 +3368,10 @@
     "label": "issue3000stgMadeUpProperty",
     "kind": "variable",
     "detail": "issue3000stgMadeUpProperty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgMadeUpProperty",
@@ -2838,6 +3386,10 @@
     "label": "issue3000stgManagedBy",
     "kind": "variable",
     "detail": "issue3000stgManagedBy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedBy",
@@ -2852,6 +3404,10 @@
     "label": "issue3000stgManagedByExtended",
     "kind": "variable",
     "detail": "issue3000stgManagedByExtended",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue3000stgManagedByExtended",
@@ -2868,7 +3424,7 @@
     "detail": "issue4668_identity",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+      "value": "Type: `object`  \nThe identity that will be used to execute the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2886,7 +3442,7 @@
     "detail": "issue4668_kind",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2902,6 +3458,10 @@
     "label": "issue4668_mainResource",
     "kind": "interface",
     "detail": "issue4668_mainResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_mainResource",
@@ -2921,7 +3481,7 @@
     "detail": "issue4668_properties",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \nThe properties of the Deployment Script."
+      "value": "Type: `object`  \nThe properties of the Deployment Script.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2937,6 +3497,10 @@
     "label": "itemAndIndexSameName",
     "kind": "interface",
     "detail": "itemAndIndexSameName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_itemAndIndexSameName",
@@ -2955,7 +3519,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2976,7 +3540,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2997,7 +3561,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3018,7 +3582,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3039,7 +3603,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3060,7 +3624,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3080,6 +3644,10 @@
     "label": "letsAccessTheDashes",
     "kind": "variable",
     "detail": "letsAccessTheDashes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes",
@@ -3094,6 +3662,10 @@
     "label": "letsAccessTheDashes2",
     "kind": "variable",
     "detail": "letsAccessTheDashes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_letsAccessTheDashes2",
@@ -3109,7 +3681,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3130,7 +3702,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3151,7 +3723,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3172,7 +3744,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3192,6 +3764,10 @@
     "label": "logAnalyticsWorkspaces",
     "kind": "interface",
     "detail": "logAnalyticsWorkspaces",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_logAnalyticsWorkspaces",
@@ -3209,6 +3785,10 @@
     "label": "loopForRuntimeCheck",
     "kind": "interface",
     "detail": "loopForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck",
@@ -3226,6 +3806,10 @@
     "label": "loopForRuntimeCheck2",
     "kind": "interface",
     "detail": "loopForRuntimeCheck2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck2",
@@ -3243,6 +3827,10 @@
     "label": "loopForRuntimeCheck3",
     "kind": "interface",
     "detail": "loopForRuntimeCheck3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck3",
@@ -3260,6 +3848,10 @@
     "label": "loopForRuntimeCheck4",
     "kind": "interface",
     "detail": "loopForRuntimeCheck4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopForRuntimeCheck4",
@@ -3277,6 +3869,10 @@
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString1",
@@ -3291,6 +3887,10 @@
     "label": "magicString2",
     "kind": "variable",
     "detail": "magicString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_magicString2",
@@ -3306,7 +3906,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3327,7 +3927,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3348,7 +3948,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3369,7 +3969,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3390,7 +3990,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3410,6 +4010,10 @@
     "label": "missingFewerRequiredProperties",
     "kind": "interface",
     "detail": "missingFewerRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingFewerRequiredProperties",
@@ -3427,6 +4031,10 @@
     "label": "missingRequiredProperties",
     "kind": "interface",
     "detail": "missingRequiredProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties",
@@ -3444,6 +4052,10 @@
     "label": "missingRequiredProperties2",
     "kind": "interface",
     "detail": "missingRequiredProperties2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingRequiredProperties2",
@@ -3461,6 +4073,10 @@
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelProperties",
@@ -3478,6 +4094,10 @@
     "label": "missingTopLevelPropertiesExceptName",
     "kind": "interface",
     "detail": "missingTopLevelPropertiesExceptName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTopLevelPropertiesExceptName",
@@ -3495,6 +4115,10 @@
     "label": "missingType",
     "kind": "interface",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -3512,6 +4136,10 @@
     "label": "mock",
     "kind": "variable",
     "detail": "mock",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mock",
@@ -3526,6 +4154,10 @@
     "label": "nestedDiscriminator",
     "kind": "interface",
     "detail": "nestedDiscriminator",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator",
@@ -3543,6 +4175,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
@@ -3557,6 +4193,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
@@ -3571,6 +4211,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for_if",
@@ -3585,6 +4229,10 @@
     "label": "nestedDiscriminatorArrayIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
@@ -3599,6 +4247,10 @@
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions",
@@ -3613,6 +4265,10 @@
     "label": "nestedDiscriminatorCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2",
@@ -3627,6 +4283,10 @@
     "label": "nestedDiscriminatorCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for",
@@ -3641,6 +4301,10 @@
     "label": "nestedDiscriminatorCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_for_if",
@@ -3655,6 +4319,10 @@
     "label": "nestedDiscriminatorCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions2_if",
@@ -3669,6 +4337,10 @@
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3",
@@ -3683,6 +4355,10 @@
     "label": "nestedDiscriminatorCompletions3_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for",
@@ -3697,6 +4373,10 @@
     "label": "nestedDiscriminatorCompletions3_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_for_if",
@@ -3711,6 +4391,10 @@
     "label": "nestedDiscriminatorCompletions3_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions3_if",
@@ -3725,6 +4409,10 @@
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4",
@@ -3739,6 +4427,10 @@
     "label": "nestedDiscriminatorCompletions4_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for",
@@ -3753,6 +4445,10 @@
     "label": "nestedDiscriminatorCompletions4_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_for_if",
@@ -3767,6 +4463,10 @@
     "label": "nestedDiscriminatorCompletions4_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions4_if",
@@ -3781,6 +4481,10 @@
     "label": "nestedDiscriminatorCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for",
@@ -3795,6 +4499,10 @@
     "label": "nestedDiscriminatorCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_for_if",
@@ -3809,6 +4517,10 @@
     "label": "nestedDiscriminatorCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorCompletions_if",
@@ -3823,6 +4535,10 @@
     "label": "nestedDiscriminatorMissingKey",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey",
@@ -3840,6 +4556,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
@@ -3854,6 +4574,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
@@ -3868,6 +4592,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
@@ -3882,6 +4610,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for_if",
@@ -3896,6 +4628,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions2_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
@@ -3910,6 +4646,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
@@ -3924,6 +4664,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for_if",
@@ -3938,6 +4682,10 @@
     "label": "nestedDiscriminatorMissingKeyCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
@@ -3952,6 +4700,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
@@ -3966,6 +4718,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
@@ -3980,6 +4736,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for_if",
@@ -3994,6 +4754,10 @@
     "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
@@ -4008,6 +4772,10 @@
     "label": "nestedDiscriminatorMissingKey_for",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for",
@@ -4025,6 +4793,10 @@
     "label": "nestedDiscriminatorMissingKey_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_for_if",
@@ -4042,6 +4814,10 @@
     "label": "nestedDiscriminatorMissingKey_if",
     "kind": "interface",
     "detail": "nestedDiscriminatorMissingKey_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminatorMissingKey_if",
@@ -4059,6 +4835,10 @@
     "label": "nestedDiscriminator_for",
     "kind": "interface",
     "detail": "nestedDiscriminator_for",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for",
@@ -4076,6 +4856,10 @@
     "label": "nestedDiscriminator_for_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_for_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_for_if",
@@ -4093,6 +4877,10 @@
     "label": "nestedDiscriminator_if",
     "kind": "interface",
     "detail": "nestedDiscriminator_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedDiscriminator_if",
@@ -4110,6 +4898,10 @@
     "label": "nestedPropertyAccessOnConditional",
     "kind": "interface",
     "detail": "nestedPropertyAccessOnConditional",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedPropertyAccessOnConditional",
@@ -4127,6 +4919,10 @@
     "label": "noCompletionsBeforeColon",
     "kind": "interface",
     "detail": "noCompletionsBeforeColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsBeforeColon",
@@ -4144,6 +4940,10 @@
     "label": "noCompletionsWithoutColon",
     "kind": "interface",
     "detail": "noCompletionsWithoutColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noCompletionsWithoutColon",
@@ -4161,6 +4961,10 @@
     "label": "nonObjectResourceLoopBody",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody",
@@ -4178,6 +4982,10 @@
     "label": "nonObjectResourceLoopBody2",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody2",
@@ -4195,6 +5003,10 @@
     "label": "nonObjectResourceLoopBody3",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody3",
@@ -4212,6 +5024,10 @@
     "label": "nonObjectResourceLoopBody4",
     "kind": "interface",
     "detail": "nonObjectResourceLoopBody4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonObjectResourceLoopBody4",
@@ -4229,6 +5045,10 @@
     "label": "nonexistentArrays",
     "kind": "interface",
     "detail": "nonexistentArrays",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonexistentArrays",
@@ -4246,6 +5066,10 @@
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAResource",
@@ -4260,6 +5084,10 @@
     "label": "notAnArray",
     "kind": "variable",
     "detail": "notAnArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notAnArray",
@@ -4274,6 +5102,10 @@
     "label": "p1_child1",
     "kind": "interface",
     "detail": "p1_child1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_child1",
@@ -4291,6 +5123,10 @@
     "label": "p1_res1",
     "kind": "interface",
     "detail": "p1_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p1_res1",
@@ -4308,6 +5144,10 @@
     "label": "p2_res1",
     "kind": "interface",
     "detail": "p2_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res1",
@@ -4325,6 +5165,10 @@
     "label": "p2_res2",
     "kind": "interface",
     "detail": "p2_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2",
@@ -4342,6 +5186,10 @@
     "label": "p2_res2child",
     "kind": "interface",
     "detail": "p2_res2child",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p2_res2child",
@@ -4359,6 +5207,10 @@
     "label": "p3_vmExt",
     "kind": "interface",
     "detail": "p3_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p3_vmExt",
@@ -4376,6 +5228,10 @@
     "label": "p4_vm",
     "kind": "interface",
     "detail": "p4_vm",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vm",
@@ -4393,6 +5249,10 @@
     "label": "p4_vmExt",
     "kind": "interface",
     "detail": "p4_vmExt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p4_vmExt",
@@ -4410,6 +5270,10 @@
     "label": "p5_res1",
     "kind": "interface",
     "detail": "p5_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res1",
@@ -4427,6 +5291,10 @@
     "label": "p5_res2",
     "kind": "interface",
     "detail": "p5_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p5_res2",
@@ -4444,6 +5312,10 @@
     "label": "p6_res1",
     "kind": "interface",
     "detail": "p6_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res1",
@@ -4461,6 +5333,10 @@
     "label": "p6_res2",
     "kind": "interface",
     "detail": "p6_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p6_res2",
@@ -4478,6 +5354,10 @@
     "label": "p7_res1",
     "kind": "interface",
     "detail": "p7_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res1",
@@ -4495,6 +5375,10 @@
     "label": "p7_res2",
     "kind": "interface",
     "detail": "p7_res2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res2",
@@ -4512,6 +5396,10 @@
     "label": "p7_res3",
     "kind": "interface",
     "detail": "p7_res3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p7_res3",
@@ -4529,6 +5417,10 @@
     "label": "p8_res1",
     "kind": "interface",
     "detail": "p8_res1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_p8_res1",
@@ -4547,7 +5439,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4568,7 +5460,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4589,7 +5481,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4609,6 +5501,10 @@
     "label": "premiumStorages",
     "kind": "interface",
     "detail": "premiumStorages",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_premiumStorages",
@@ -4626,6 +5522,10 @@
     "label": "propertyLoopsCannotNest",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest",
@@ -4643,6 +5543,10 @@
     "label": "propertyLoopsCannotNest2",
     "kind": "interface",
     "detail": "propertyLoopsCannotNest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyLoopsCannotNest2",
@@ -4661,7 +5565,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4682,7 +5586,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4702,6 +5606,10 @@
     "label": "readOnlyPropertyAssignment",
     "kind": "interface",
     "detail": "readOnlyPropertyAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_readOnlyPropertyAssignment",
@@ -4720,7 +5628,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4741,7 +5649,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4762,7 +5670,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4783,7 +5691,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4804,7 +5712,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4824,6 +5732,10 @@
     "label": "resourceListIsNotSingleResource",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource",
@@ -4838,6 +5750,10 @@
     "label": "resourceListIsNotSingleResource_if",
     "kind": "variable",
     "detail": "resourceListIsNotSingleResource_if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceListIsNotSingleResource_if",
@@ -4854,7 +5770,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string"
+      "value": "Type: `string`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -4870,6 +5786,10 @@
     "label": "resrefvar",
     "kind": "variable",
     "detail": "resrefvar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefvar",
@@ -4898,6 +5818,10 @@
     "label": "runtimeCheckVar",
     "kind": "variable",
     "detail": "runtimeCheckVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar",
@@ -4912,6 +5836,10 @@
     "label": "runtimeCheckVar2",
     "kind": "variable",
     "detail": "runtimeCheckVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeCheckVar2",
@@ -4926,6 +5854,10 @@
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalid",
@@ -4940,6 +5872,10 @@
     "label": "runtimeInvalidRes1",
     "kind": "interface",
     "detail": "runtimeInvalidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes1",
@@ -4957,6 +5893,10 @@
     "label": "runtimeInvalidRes10",
     "kind": "interface",
     "detail": "runtimeInvalidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes10",
@@ -4974,6 +5914,10 @@
     "label": "runtimeInvalidRes11",
     "kind": "interface",
     "detail": "runtimeInvalidRes11",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes11",
@@ -4991,6 +5935,10 @@
     "label": "runtimeInvalidRes12",
     "kind": "interface",
     "detail": "runtimeInvalidRes12",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes12",
@@ -5008,6 +5956,10 @@
     "label": "runtimeInvalidRes13",
     "kind": "interface",
     "detail": "runtimeInvalidRes13",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes13",
@@ -5025,6 +5977,10 @@
     "label": "runtimeInvalidRes14",
     "kind": "interface",
     "detail": "runtimeInvalidRes14",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes14",
@@ -5042,6 +5998,10 @@
     "label": "runtimeInvalidRes15",
     "kind": "interface",
     "detail": "runtimeInvalidRes15",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes15",
@@ -5059,6 +6019,10 @@
     "label": "runtimeInvalidRes16",
     "kind": "interface",
     "detail": "runtimeInvalidRes16",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes16",
@@ -5076,6 +6040,10 @@
     "label": "runtimeInvalidRes17",
     "kind": "interface",
     "detail": "runtimeInvalidRes17",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes17",
@@ -5093,6 +6061,10 @@
     "label": "runtimeInvalidRes18",
     "kind": "interface",
     "detail": "runtimeInvalidRes18",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes18",
@@ -5110,6 +6082,10 @@
     "label": "runtimeInvalidRes2",
     "kind": "interface",
     "detail": "runtimeInvalidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes2",
@@ -5127,6 +6103,10 @@
     "label": "runtimeInvalidRes3",
     "kind": "interface",
     "detail": "runtimeInvalidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes3",
@@ -5144,6 +6124,10 @@
     "label": "runtimeInvalidRes4",
     "kind": "interface",
     "detail": "runtimeInvalidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes4",
@@ -5161,6 +6145,10 @@
     "label": "runtimeInvalidRes5",
     "kind": "interface",
     "detail": "runtimeInvalidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes5",
@@ -5178,6 +6166,10 @@
     "label": "runtimeInvalidRes6",
     "kind": "interface",
     "detail": "runtimeInvalidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes6",
@@ -5195,6 +6187,10 @@
     "label": "runtimeInvalidRes7",
     "kind": "interface",
     "detail": "runtimeInvalidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes7",
@@ -5212,6 +6208,10 @@
     "label": "runtimeInvalidRes8",
     "kind": "interface",
     "detail": "runtimeInvalidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeInvalidRes8",
@@ -5229,6 +6229,10 @@
     "label": "runtimeValid",
     "kind": "variable",
     "detail": "runtimeValid",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValid",
@@ -5243,6 +6247,10 @@
     "label": "runtimeValidRes1",
     "kind": "interface",
     "detail": "runtimeValidRes1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes1",
@@ -5260,6 +6268,10 @@
     "label": "runtimeValidRes10",
     "kind": "interface",
     "detail": "runtimeValidRes10",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes10",
@@ -5277,6 +6289,10 @@
     "label": "runtimeValidRes2",
     "kind": "interface",
     "detail": "runtimeValidRes2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes2",
@@ -5294,6 +6310,10 @@
     "label": "runtimeValidRes3",
     "kind": "interface",
     "detail": "runtimeValidRes3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes3",
@@ -5311,6 +6331,10 @@
     "label": "runtimeValidRes4",
     "kind": "interface",
     "detail": "runtimeValidRes4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes4",
@@ -5328,6 +6352,10 @@
     "label": "runtimeValidRes5",
     "kind": "interface",
     "detail": "runtimeValidRes5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes5",
@@ -5345,6 +6373,10 @@
     "label": "runtimeValidRes6",
     "kind": "interface",
     "detail": "runtimeValidRes6",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes6",
@@ -5362,6 +6394,10 @@
     "label": "runtimeValidRes7",
     "kind": "interface",
     "detail": "runtimeValidRes7",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes7",
@@ -5379,6 +6415,10 @@
     "label": "runtimeValidRes8",
     "kind": "interface",
     "detail": "runtimeValidRes8",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes8",
@@ -5396,6 +6436,10 @@
     "label": "runtimeValidRes9",
     "kind": "interface",
     "detail": "runtimeValidRes9",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeValidRes9",
@@ -5413,6 +6457,10 @@
     "label": "runtimefoo1",
     "kind": "variable",
     "detail": "runtimefoo1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo1",
@@ -5427,6 +6475,10 @@
     "label": "runtimefoo2",
     "kind": "variable",
     "detail": "runtimefoo2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo2",
@@ -5441,6 +6493,10 @@
     "label": "runtimefoo3",
     "kind": "variable",
     "detail": "runtimefoo3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo3",
@@ -5455,6 +6511,10 @@
     "label": "runtimefoo4",
     "kind": "variable",
     "detail": "runtimefoo4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimefoo4",
@@ -5469,6 +6529,10 @@
     "label": "selfScope",
     "kind": "interface",
     "detail": "selfScope",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_selfScope",
@@ -5486,6 +6550,10 @@
     "label": "sigh",
     "kind": "variable",
     "detail": "sigh",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sigh",
@@ -5500,6 +6568,10 @@
     "label": "singleResourceForRuntimeCheck",
     "kind": "interface",
     "detail": "singleResourceForRuntimeCheck",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleResourceForRuntimeCheck",
@@ -5518,7 +6590,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5539,7 +6611,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5560,7 +6632,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5580,6 +6652,10 @@
     "label": "sqlServer1",
     "kind": "interface",
     "detail": "sqlServer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer1",
@@ -5597,6 +6673,10 @@
     "label": "sqlServer2",
     "kind": "interface",
     "detail": "sqlServer2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer2",
@@ -5614,6 +6694,10 @@
     "label": "sqlServer3",
     "kind": "interface",
     "detail": "sqlServer3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer3",
@@ -5631,6 +6715,10 @@
     "label": "sqlServer4",
     "kind": "interface",
     "detail": "sqlServer4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer4",
@@ -5648,6 +6736,10 @@
     "label": "sqlServer5",
     "kind": "interface",
     "detail": "sqlServer5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sqlServer5",
@@ -5665,6 +6757,10 @@
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithQuotes",
@@ -5682,6 +6778,10 @@
     "label": "startedTypingTypeWithoutQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithoutQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_startedTypingTypeWithoutQuotes",
@@ -5700,7 +6800,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5720,6 +6820,10 @@
     "label": "storage",
     "kind": "interface",
     "detail": "storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_storage",
@@ -5738,7 +6842,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5758,6 +6862,10 @@
     "label": "stuffs",
     "kind": "interface",
     "detail": "stuffs",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_stuffs",
@@ -5776,7 +6884,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5797,7 +6905,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5818,7 +6926,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5858,7 +6966,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object"
+      "value": "Type: `object`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5875,7 +6983,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5896,7 +7004,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5912,6 +7020,10 @@
     "label": "tenantLevelResourceBlocked",
     "kind": "interface",
     "detail": "tenantLevelResourceBlocked",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tenantLevelResourceBlocked",
@@ -5930,7 +7042,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5951,7 +7063,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5972,7 +7084,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -5993,7 +7105,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6013,6 +7125,10 @@
     "label": "trailingSpace",
     "kind": "interface",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -6031,7 +7147,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6051,6 +7167,10 @@
     "label": "unfinishedVnet",
     "kind": "interface",
     "detail": "unfinishedVnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unfinishedVnet",
@@ -6069,7 +7189,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6090,7 +7210,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6111,7 +7231,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6132,7 +7252,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6153,7 +7273,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -6173,6 +7293,10 @@
     "label": "validModule",
     "kind": "module",
     "detail": "validModule",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validModule",
@@ -6187,6 +7311,10 @@
     "label": "validResourceForInvalidExtensionResourceDuplicateName",
     "kind": "interface",
     "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
@@ -6204,6 +7332,10 @@
     "label": "varForRuntimeCheck4a",
     "kind": "variable",
     "detail": "varForRuntimeCheck4a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4a",
@@ -6218,6 +7350,10 @@
     "label": "varForRuntimeCheck4b",
     "kind": "variable",
     "detail": "varForRuntimeCheck4b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_varForRuntimeCheck4b",
@@ -6232,6 +7368,10 @@
     "label": "vnet",
     "kind": "interface",
     "detail": "vnet",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_vnet",
@@ -6249,6 +7389,10 @@
     "label": "wrongArrayType",
     "kind": "interface",
     "detail": "wrongArrayType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType",
@@ -6266,6 +7410,10 @@
     "label": "wrongArrayType2",
     "kind": "interface",
     "detail": "wrongArrayType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongArrayType2",
@@ -6283,6 +7431,10 @@
     "label": "wrongFilterExpressionType",
     "kind": "interface",
     "detail": "wrongFilterExpressionType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType",
@@ -6300,6 +7452,10 @@
     "label": "wrongFilterExpressionType2",
     "kind": "interface",
     "detail": "wrongFilterExpressionType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongFilterExpressionType2",
@@ -6317,6 +7473,10 @@
     "label": "wrongLoopBodyType",
     "kind": "interface",
     "detail": "wrongLoopBodyType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType",
@@ -6334,6 +7494,10 @@
     "label": "wrongLoopBodyType2",
     "kind": "interface",
     "detail": "wrongLoopBodyType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongLoopBodyType2",
@@ -6351,6 +7515,10 @@
     "label": "wrongPropertyInNestedLoop",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop",
@@ -6368,6 +7536,10 @@
     "label": "wrongPropertyInNestedLoop2",
     "kind": "interface",
     "detail": "wrongPropertyInNestedLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongPropertyInNestedLoop2",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/templateSpecsResourceTypes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/templateSpecsResourceTypes.json
@@ -4,7 +4,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Resources/templateSpecs`  \nAPI Version: `2019-06-01-preview`"
+      "value": "Type: `Microsoft.Resources/templateSpecs`  \nAPI Version: `2019-06-01-preview`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22,7 +22,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Resources/templateSpecs`  \nAPI Version: `2021-03-01-preview`"
+      "value": "Type: `Microsoft.Resources/templateSpecs`  \nAPI Version: `2021-03-01-preview`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40,7 +40,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Resources/templateSpecs`  \nAPI Version: `2021-05-01`"
+      "value": "Type: `Microsoft.Resources/templateSpecs`  \nAPI Version: `2021-05-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -58,7 +58,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Resources/templateSpecs`  \nAPI Version: `2022-02-01`"
+      "value": "Type: `Microsoft.Resources/templateSpecs`  \nAPI Version: `2022-02-01`  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/topLevelProperties.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/topLevelProperties.json
@@ -163,7 +163,7 @@
     "detail": "Nested resource with defaults",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  properties: {\n    \n  }\n}\n```"
+      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  properties: {\n    \n  }\n}\n```  \n"
     },
     "deprecated": false,
     "preselect": true,
@@ -193,7 +193,7 @@
     "detail": "Nested resource without defaults",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  \n}\n```"
+      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  \n}\n```  \n"
     },
     "deprecated": false,
     "preselect": true,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/topLevelPropertiesMinusName.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/topLevelPropertiesMinusName.json
@@ -145,7 +145,7 @@
     "detail": "Nested resource with defaults",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  properties: {\n    \n  }\n}\n```"
+      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  properties: {\n    \n  }\n}\n```  \n"
     },
     "deprecated": false,
     "preselect": true,
@@ -175,7 +175,7 @@
     "detail": "Nested resource without defaults",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  \n}\n```"
+      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  \n}\n```  \n"
     },
     "deprecated": false,
     "preselect": true,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/virtualNetworksResourceTypes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/virtualNetworksResourceTypes.json
@@ -4,7 +4,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualnetworks`  \nAPI Version: `2015-05-01-preview`"
+      "value": "Type: `Microsoft.Network/virtualnetworks`  \nAPI Version: `2015-05-01-preview`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -22,7 +22,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2015-06-15`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2015-06-15`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -40,7 +40,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2016-03-30`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2016-03-30`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -58,7 +58,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2016-06-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2016-06-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -76,7 +76,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2016-09-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2016-09-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -94,7 +94,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2016-12-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2016-12-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -112,7 +112,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2017-03-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2017-03-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -130,7 +130,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2017-03-30`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2017-03-30`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -148,7 +148,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2017-06-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2017-06-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -166,7 +166,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2017-08-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2017-08-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -184,7 +184,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2017-09-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2017-09-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -202,7 +202,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2017-10-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2017-10-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -220,7 +220,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2017-11-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2017-11-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -238,7 +238,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2018-01-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2018-01-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -256,7 +256,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2018-02-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2018-02-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -274,7 +274,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2018-04-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2018-04-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -292,7 +292,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2018-06-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2018-06-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -310,7 +310,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2018-07-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2018-07-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -328,7 +328,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2018-08-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2018-08-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -346,7 +346,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2018-10-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2018-10-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -364,7 +364,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2018-11-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2018-11-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -382,7 +382,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2018-12-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2018-12-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -400,7 +400,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2019-02-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2019-02-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -418,7 +418,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2019-04-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2019-04-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -436,7 +436,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2019-06-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2019-06-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -454,7 +454,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2019-07-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2019-07-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -472,7 +472,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2019-08-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2019-08-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -490,7 +490,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2019-09-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2019-09-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -508,7 +508,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2019-11-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2019-11-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -526,7 +526,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2019-12-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2019-12-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -544,7 +544,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2020-03-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2020-03-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -562,7 +562,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2020-04-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2020-04-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -580,7 +580,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2020-05-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2020-05-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -598,7 +598,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2020-06-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2020-06-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -616,7 +616,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2020-07-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2020-07-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -634,7 +634,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2020-08-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2020-08-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -652,7 +652,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2020-11-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2020-11-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -670,7 +670,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2021-02-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2021-02-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -688,7 +688,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2021-03-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2021-03-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -706,7 +706,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2021-05-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2021-05-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -724,7 +724,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2021-08-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2021-08-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -742,7 +742,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2022-01-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2022-01-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -760,7 +760,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2022-05-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2022-05-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -778,7 +778,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2022-07-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2022-07-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -796,7 +796,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2022-09-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2022-09-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -814,7 +814,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2022-11-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2022-11-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -832,7 +832,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2023-02-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2023-02-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -850,7 +850,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2023-04-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2023-04-01`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -868,7 +868,7 @@
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2023-05-01`"
+      "value": "Type: `Microsoft.Network/virtualNetworks`  \nAPI Version: `2023-05-01`  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/description.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/description.json
@@ -4,7 +4,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndescription(text: string): any\n\n```\n\n"
+      "value": "```bicep\ndescription(text: string): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
@@ -3,10 +3,6 @@
     "label": "a",
     "kind": "variable",
     "detail": "a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_a",
@@ -21,10 +17,6 @@
     "label": "anotherThing",
     "kind": "variable",
     "detail": "anotherThing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anotherThing",
@@ -141,10 +133,6 @@
     "label": "badEquals",
     "kind": "variable",
     "detail": "badEquals",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badEquals",
@@ -159,10 +147,6 @@
     "label": "badEquals2",
     "kind": "variable",
     "detail": "badEquals2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badEquals2",
@@ -177,10 +161,6 @@
     "label": "bar",
     "kind": "variable",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -258,10 +238,6 @@
     "label": "batchSizeMakesNoSenseHere",
     "kind": "variable",
     "detail": "batchSizeMakesNoSenseHere",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_batchSizeMakesNoSenseHere",
@@ -381,10 +357,6 @@
     "label": "copy",
     "kind": "variable",
     "detail": "copy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_copy",
@@ -521,10 +493,6 @@
     "label": "doubleString",
     "kind": "variable",
     "detail": "doubleString",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_doubleString",
@@ -598,10 +566,6 @@
     "label": "evenMoreIndirection",
     "kind": "variable",
     "detail": "evenMoreIndirection",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_evenMoreIndirection",
@@ -700,10 +664,6 @@
     "label": "foo",
     "kind": "variable",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -795,10 +755,6 @@
     "label": "indirection",
     "kind": "variable",
     "detail": "indirection",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_indirection",
@@ -813,10 +769,6 @@
     "label": "inlinedVariable",
     "kind": "variable",
     "detail": "inlinedVariable",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_inlinedVariable",
@@ -831,10 +783,6 @@
     "label": "innerPropertyLoop",
     "kind": "variable",
     "detail": "innerPropertyLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_innerPropertyLoop",
@@ -849,10 +797,6 @@
     "label": "innerPropertyLoop2",
     "kind": "variable",
     "detail": "innerPropertyLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_innerPropertyLoop2",
@@ -909,10 +853,6 @@
     "label": "invalidEnvAuthVar",
     "kind": "variable",
     "detail": "invalidEnvAuthVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidEnvAuthVar",
@@ -927,10 +867,6 @@
     "label": "invalidEnvironmentVar",
     "kind": "variable",
     "detail": "invalidEnvironmentVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidEnvironmentVar",
@@ -945,10 +881,6 @@
     "label": "invalidLocationVar",
     "kind": "variable",
     "detail": "invalidLocationVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidLocationVar",
@@ -963,10 +895,6 @@
     "label": "invalidNamespaceAssignment",
     "kind": "variable",
     "detail": "invalidNamespaceAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidNamespaceAssignment",
@@ -1044,10 +972,6 @@
     "label": "keyVaultSecretArrayInterpolatedVar",
     "kind": "variable",
     "detail": "keyVaultSecretArrayInterpolatedVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretArrayInterpolatedVar",
@@ -1062,10 +986,6 @@
     "label": "keyVaultSecretArrayVar",
     "kind": "variable",
     "detail": "keyVaultSecretArrayVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretArrayVar",
@@ -1080,10 +1000,6 @@
     "label": "keyVaultSecretInterpolatedVar",
     "kind": "variable",
     "detail": "keyVaultSecretInterpolatedVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretInterpolatedVar",
@@ -1098,10 +1014,6 @@
     "label": "keyVaultSecretObjectVar",
     "kind": "variable",
     "detail": "keyVaultSecretObjectVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretObjectVar",
@@ -1116,10 +1028,6 @@
     "label": "keyVaultSecretVar",
     "kind": "variable",
     "detail": "keyVaultSecretVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretVar",
@@ -1134,10 +1042,6 @@
     "label": "keys",
     "kind": "variable",
     "detail": "keys",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keys",
@@ -1152,10 +1056,6 @@
     "label": "kv",
     "kind": "interface",
     "detail": "kv",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_kv",
@@ -1236,10 +1136,6 @@
     "label": "listSecrets",
     "kind": "variable",
     "detail": "listSecrets",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_listSecrets",
@@ -1254,10 +1150,6 @@
     "label": "listSecretsVar",
     "kind": "variable",
     "detail": "listSecretsVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_listSecretsVar",
@@ -1356,10 +1248,6 @@
     "label": "loopExpression",
     "kind": "variable",
     "detail": "loopExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopExpression",
@@ -1479,10 +1367,6 @@
     "label": "missingArrayVariable",
     "kind": "variable",
     "detail": "missingArrayVariable",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingArrayVariable",
@@ -1497,10 +1381,6 @@
     "label": "missingValue",
     "kind": "variable",
     "detail": "missingValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingValue",
@@ -1515,10 +1395,6 @@
     "label": "mixedArrayTypeCompletions",
     "kind": "variable",
     "detail": "mixedArrayTypeCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mixedArrayTypeCompletions",
@@ -1533,10 +1409,6 @@
     "label": "mixedArrayTypeCompletions2",
     "kind": "variable",
     "detail": "mixedArrayTypeCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mixedArrayTypeCompletions2",
@@ -1551,10 +1423,6 @@
     "label": "moreIndirection",
     "kind": "variable",
     "detail": "moreIndirection",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moreIndirection",
@@ -1569,10 +1437,6 @@
     "label": "myConcat",
     "kind": "variable",
     "detail": "myConcat",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myConcat",
@@ -1587,10 +1451,6 @@
     "label": "myFloat",
     "kind": "variable",
     "detail": "myFloat",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myFloat",
@@ -1605,10 +1465,6 @@
     "label": "myRef",
     "kind": "variable",
     "detail": "myRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myRef",
@@ -1623,10 +1479,6 @@
     "label": "mySum",
     "kind": "variable",
     "detail": "mySum",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mySum",
@@ -1641,10 +1493,6 @@
     "label": "noFilteredLoopsInVariables",
     "kind": "variable",
     "detail": "noFilteredLoopsInVariables",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noFilteredLoopsInVariables",
@@ -1659,10 +1507,6 @@
     "label": "noNestedVariableLoopsEither",
     "kind": "variable",
     "detail": "noNestedVariableLoopsEither",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noNestedVariableLoopsEither",
@@ -1677,10 +1521,6 @@
     "label": "nonExistentIndex1",
     "kind": "variable",
     "detail": "nonExistentIndex1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentIndex1",
@@ -1695,10 +1535,6 @@
     "label": "nonExistentIndex2",
     "kind": "variable",
     "detail": "nonExistentIndex2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentIndex2",
@@ -1713,10 +1549,6 @@
     "label": "nonExistentIndex3",
     "kind": "variable",
     "detail": "nonExistentIndex3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentIndex3",
@@ -1731,10 +1563,6 @@
     "label": "nonTopLevelLoop",
     "kind": "variable",
     "detail": "nonTopLevelLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonTopLevelLoop",
@@ -1749,10 +1577,6 @@
     "label": "notRuntime",
     "kind": "variable",
     "detail": "notRuntime",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notRuntime",
@@ -1767,10 +1591,6 @@
     "label": "objWithInterp",
     "kind": "variable",
     "detail": "objWithInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objWithInterp",
@@ -1785,10 +1605,6 @@
     "label": "objectLiteralType",
     "kind": "variable",
     "detail": "objectLiteralType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objectLiteralType",
@@ -1803,10 +1619,6 @@
     "label": "objectVarTopLevelCompletions",
     "kind": "variable",
     "detail": "objectVarTopLevelCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objectVarTopLevelCompletions",
@@ -1821,10 +1633,6 @@
     "label": "objectVarTopLevelCompletions2",
     "kind": "variable",
     "detail": "objectVarTopLevelCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objectVarTopLevelCompletions2",
@@ -1839,10 +1647,6 @@
     "label": "oneArrayIndexCompletions",
     "kind": "variable",
     "detail": "oneArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_oneArrayIndexCompletions",
@@ -1857,10 +1661,6 @@
     "label": "oneArrayItemCompletions",
     "kind": "variable",
     "detail": "oneArrayItemCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_oneArrayItemCompletions",
@@ -1875,10 +1675,6 @@
     "label": "oneArrayItemCompletions2",
     "kind": "variable",
     "detail": "oneArrayItemCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_oneArrayItemCompletions2",
@@ -2061,10 +1857,6 @@
     "label": "resourceGroup",
     "kind": "variable",
     "detail": "resourceGroup",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceGroup",
@@ -2100,10 +1892,6 @@
     "label": "rgName",
     "kind": "variable",
     "detail": "rgName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_rgName",
@@ -2118,10 +1906,6 @@
     "label": "runtimeLoop",
     "kind": "variable",
     "detail": "runtimeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop",
@@ -2136,10 +1920,6 @@
     "label": "runtimeLoop2",
     "kind": "variable",
     "detail": "runtimeLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop2",
@@ -2154,10 +1934,6 @@
     "label": "runtimeLoop3",
     "kind": "variable",
     "detail": "runtimeLoop3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop3",
@@ -2172,10 +1948,6 @@
     "label": "runtimeLoop4",
     "kind": "variable",
     "detail": "runtimeLoop4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop4",
@@ -2190,10 +1962,6 @@
     "label": "runtimeLoop5",
     "kind": "variable",
     "detail": "runtimeLoop5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop5",
@@ -2229,10 +1997,6 @@
     "label": "something",
     "kind": "variable",
     "detail": "something",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_something",
@@ -2331,10 +2095,6 @@
     "label": "subName",
     "kind": "variable",
     "detail": "subName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_subName",
@@ -2349,10 +2109,6 @@
     "label": "subscription",
     "kind": "variable",
     "detail": "subscription",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_subscription",
@@ -2486,10 +2242,6 @@
     "label": "test",
     "kind": "variable",
     "detail": "test",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_test",
@@ -2504,10 +2256,6 @@
     "label": "test2",
     "kind": "variable",
     "detail": "test2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_test2",
@@ -2522,10 +2270,6 @@
     "label": "test3",
     "kind": "variable",
     "detail": "test3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_test3",
@@ -2540,10 +2284,6 @@
     "label": "testDupe",
     "kind": "variable",
     "detail": "testDupe",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_testDupe",
@@ -2747,10 +2487,6 @@
     "label": "x",
     "kind": "variable",
     "detail": "x",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_x",
@@ -2765,10 +2501,6 @@
     "label": "y",
     "kind": "variable",
     "detail": "y",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_y",
@@ -2783,10 +2515,6 @@
     "label": "zoneInput",
     "kind": "variable",
     "detail": "zoneInput",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_zoneInput",
@@ -2801,10 +2529,6 @@
     "label": "zones",
     "kind": "interface",
     "detail": "zones",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_zones",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
@@ -3,6 +3,10 @@
     "label": "a",
     "kind": "variable",
     "detail": "a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_a",
@@ -17,6 +21,10 @@
     "label": "anotherThing",
     "kind": "variable",
     "detail": "anotherThing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anotherThing",
@@ -32,7 +40,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53,7 +61,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -92,7 +100,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -113,7 +121,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -133,6 +141,10 @@
     "label": "badEquals",
     "kind": "variable",
     "detail": "badEquals",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badEquals",
@@ -147,6 +159,10 @@
     "label": "badEquals2",
     "kind": "variable",
     "detail": "badEquals2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badEquals2",
@@ -161,6 +177,10 @@
     "label": "bar",
     "kind": "variable",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -176,7 +196,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -197,7 +217,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -218,7 +238,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -238,6 +258,10 @@
     "label": "batchSizeMakesNoSenseHere",
     "kind": "variable",
     "detail": "batchSizeMakesNoSenseHere",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_batchSizeMakesNoSenseHere",
@@ -253,7 +277,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -274,7 +298,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -295,7 +319,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -316,7 +340,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -337,7 +361,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -357,6 +381,10 @@
     "label": "copy",
     "kind": "variable",
     "detail": "copy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_copy",
@@ -372,7 +400,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -393,7 +421,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -414,7 +442,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -435,7 +463,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -456,7 +484,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -477,7 +505,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -493,6 +521,10 @@
     "label": "doubleString",
     "kind": "variable",
     "detail": "doubleString",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_doubleString",
@@ -508,7 +540,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -529,7 +561,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -550,7 +582,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -566,6 +598,10 @@
     "label": "evenMoreIndirection",
     "kind": "variable",
     "detail": "evenMoreIndirection",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_evenMoreIndirection",
@@ -581,7 +617,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -602,7 +638,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -623,7 +659,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -644,7 +680,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -664,6 +700,10 @@
     "label": "foo",
     "kind": "variable",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -679,7 +719,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -700,7 +740,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -735,7 +775,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -755,6 +795,10 @@
     "label": "indirection",
     "kind": "variable",
     "detail": "indirection",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_indirection",
@@ -769,6 +813,10 @@
     "label": "inlinedVariable",
     "kind": "variable",
     "detail": "inlinedVariable",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_inlinedVariable",
@@ -783,6 +831,10 @@
     "label": "innerPropertyLoop",
     "kind": "variable",
     "detail": "innerPropertyLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_innerPropertyLoop",
@@ -797,6 +849,10 @@
     "label": "innerPropertyLoop2",
     "kind": "variable",
     "detail": "innerPropertyLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_innerPropertyLoop2",
@@ -812,7 +868,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -833,7 +889,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -853,6 +909,10 @@
     "label": "invalidEnvAuthVar",
     "kind": "variable",
     "detail": "invalidEnvAuthVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidEnvAuthVar",
@@ -867,6 +927,10 @@
     "label": "invalidEnvironmentVar",
     "kind": "variable",
     "detail": "invalidEnvironmentVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidEnvironmentVar",
@@ -881,6 +945,10 @@
     "label": "invalidLocationVar",
     "kind": "variable",
     "detail": "invalidLocationVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidLocationVar",
@@ -895,6 +963,10 @@
     "label": "invalidNamespaceAssignment",
     "kind": "variable",
     "detail": "invalidNamespaceAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidNamespaceAssignment",
@@ -910,7 +982,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -931,7 +1003,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -952,7 +1024,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -972,6 +1044,10 @@
     "label": "keyVaultSecretArrayInterpolatedVar",
     "kind": "variable",
     "detail": "keyVaultSecretArrayInterpolatedVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretArrayInterpolatedVar",
@@ -986,6 +1062,10 @@
     "label": "keyVaultSecretArrayVar",
     "kind": "variable",
     "detail": "keyVaultSecretArrayVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretArrayVar",
@@ -1000,6 +1080,10 @@
     "label": "keyVaultSecretInterpolatedVar",
     "kind": "variable",
     "detail": "keyVaultSecretInterpolatedVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretInterpolatedVar",
@@ -1014,6 +1098,10 @@
     "label": "keyVaultSecretObjectVar",
     "kind": "variable",
     "detail": "keyVaultSecretObjectVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretObjectVar",
@@ -1028,6 +1116,10 @@
     "label": "keyVaultSecretVar",
     "kind": "variable",
     "detail": "keyVaultSecretVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretVar",
@@ -1042,6 +1134,10 @@
     "label": "keys",
     "kind": "variable",
     "detail": "keys",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keys",
@@ -1056,6 +1152,10 @@
     "label": "kv",
     "kind": "interface",
     "detail": "kv",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_kv",
@@ -1074,7 +1174,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1095,7 +1195,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1116,7 +1216,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1136,6 +1236,10 @@
     "label": "listSecrets",
     "kind": "variable",
     "detail": "listSecrets",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_listSecrets",
@@ -1150,6 +1254,10 @@
     "label": "listSecretsVar",
     "kind": "variable",
     "detail": "listSecretsVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_listSecretsVar",
@@ -1165,7 +1273,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1186,7 +1294,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1207,7 +1315,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1228,7 +1336,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1248,6 +1356,10 @@
     "label": "loopExpression",
     "kind": "variable",
     "detail": "loopExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopExpression",
@@ -1263,7 +1375,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1284,7 +1396,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1305,7 +1417,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1326,7 +1438,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1347,7 +1459,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1367,6 +1479,10 @@
     "label": "missingArrayVariable",
     "kind": "variable",
     "detail": "missingArrayVariable",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingArrayVariable",
@@ -1381,6 +1497,10 @@
     "label": "missingValue",
     "kind": "variable",
     "detail": "missingValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingValue",
@@ -1395,6 +1515,10 @@
     "label": "mixedArrayTypeCompletions",
     "kind": "variable",
     "detail": "mixedArrayTypeCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mixedArrayTypeCompletions",
@@ -1409,6 +1533,10 @@
     "label": "mixedArrayTypeCompletions2",
     "kind": "variable",
     "detail": "mixedArrayTypeCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mixedArrayTypeCompletions2",
@@ -1423,6 +1551,10 @@
     "label": "moreIndirection",
     "kind": "variable",
     "detail": "moreIndirection",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moreIndirection",
@@ -1437,6 +1569,10 @@
     "label": "myConcat",
     "kind": "variable",
     "detail": "myConcat",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myConcat",
@@ -1451,6 +1587,10 @@
     "label": "myFloat",
     "kind": "variable",
     "detail": "myFloat",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myFloat",
@@ -1465,6 +1605,10 @@
     "label": "myRef",
     "kind": "variable",
     "detail": "myRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myRef",
@@ -1479,6 +1623,10 @@
     "label": "mySum",
     "kind": "variable",
     "detail": "mySum",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mySum",
@@ -1493,6 +1641,10 @@
     "label": "noFilteredLoopsInVariables",
     "kind": "variable",
     "detail": "noFilteredLoopsInVariables",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noFilteredLoopsInVariables",
@@ -1507,6 +1659,10 @@
     "label": "noNestedVariableLoopsEither",
     "kind": "variable",
     "detail": "noNestedVariableLoopsEither",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noNestedVariableLoopsEither",
@@ -1521,6 +1677,10 @@
     "label": "nonExistentIndex1",
     "kind": "variable",
     "detail": "nonExistentIndex1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentIndex1",
@@ -1535,6 +1695,10 @@
     "label": "nonExistentIndex2",
     "kind": "variable",
     "detail": "nonExistentIndex2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentIndex2",
@@ -1549,6 +1713,10 @@
     "label": "nonExistentIndex3",
     "kind": "variable",
     "detail": "nonExistentIndex3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentIndex3",
@@ -1563,6 +1731,10 @@
     "label": "nonTopLevelLoop",
     "kind": "variable",
     "detail": "nonTopLevelLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonTopLevelLoop",
@@ -1577,6 +1749,10 @@
     "label": "notRuntime",
     "kind": "variable",
     "detail": "notRuntime",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notRuntime",
@@ -1591,6 +1767,10 @@
     "label": "objWithInterp",
     "kind": "variable",
     "detail": "objWithInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objWithInterp",
@@ -1605,6 +1785,10 @@
     "label": "objectLiteralType",
     "kind": "variable",
     "detail": "objectLiteralType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objectLiteralType",
@@ -1619,6 +1803,10 @@
     "label": "objectVarTopLevelCompletions",
     "kind": "variable",
     "detail": "objectVarTopLevelCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objectVarTopLevelCompletions",
@@ -1633,6 +1821,10 @@
     "label": "objectVarTopLevelCompletions2",
     "kind": "variable",
     "detail": "objectVarTopLevelCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objectVarTopLevelCompletions2",
@@ -1647,6 +1839,10 @@
     "label": "oneArrayIndexCompletions",
     "kind": "variable",
     "detail": "oneArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_oneArrayIndexCompletions",
@@ -1661,6 +1857,10 @@
     "label": "oneArrayItemCompletions",
     "kind": "variable",
     "detail": "oneArrayItemCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_oneArrayItemCompletions",
@@ -1675,6 +1875,10 @@
     "label": "oneArrayItemCompletions2",
     "kind": "variable",
     "detail": "oneArrayItemCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_oneArrayItemCompletions2",
@@ -1690,7 +1894,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1711,7 +1915,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1732,7 +1936,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1753,7 +1957,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1774,7 +1978,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1795,7 +1999,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1816,7 +2020,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1837,7 +2041,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1857,6 +2061,10 @@
     "label": "resourceGroup",
     "kind": "variable",
     "detail": "resourceGroup",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceGroup",
@@ -1872,7 +2080,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1892,6 +2100,10 @@
     "label": "rgName",
     "kind": "variable",
     "detail": "rgName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_rgName",
@@ -1906,6 +2118,10 @@
     "label": "runtimeLoop",
     "kind": "variable",
     "detail": "runtimeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop",
@@ -1920,6 +2136,10 @@
     "label": "runtimeLoop2",
     "kind": "variable",
     "detail": "runtimeLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop2",
@@ -1934,6 +2154,10 @@
     "label": "runtimeLoop3",
     "kind": "variable",
     "detail": "runtimeLoop3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop3",
@@ -1948,6 +2172,10 @@
     "label": "runtimeLoop4",
     "kind": "variable",
     "detail": "runtimeLoop4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop4",
@@ -1962,6 +2190,10 @@
     "label": "runtimeLoop5",
     "kind": "variable",
     "detail": "runtimeLoop5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop5",
@@ -1977,7 +2209,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1997,6 +2229,10 @@
     "label": "something",
     "kind": "variable",
     "detail": "something",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_something",
@@ -2012,7 +2248,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2033,7 +2269,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2054,7 +2290,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2075,7 +2311,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2095,6 +2331,10 @@
     "label": "subName",
     "kind": "variable",
     "detail": "subName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_subName",
@@ -2109,6 +2349,10 @@
     "label": "subscription",
     "kind": "variable",
     "detail": "subscription",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_subscription",
@@ -2124,7 +2368,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2145,7 +2389,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2184,7 +2428,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2205,7 +2449,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2222,7 +2466,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2242,6 +2486,10 @@
     "label": "test",
     "kind": "variable",
     "detail": "test",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_test",
@@ -2256,6 +2504,10 @@
     "label": "test2",
     "kind": "variable",
     "detail": "test2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_test2",
@@ -2270,6 +2522,10 @@
     "label": "test3",
     "kind": "variable",
     "detail": "test3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_test3",
@@ -2284,6 +2540,10 @@
     "label": "testDupe",
     "kind": "variable",
     "detail": "testDupe",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_testDupe",
@@ -2299,7 +2559,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2320,7 +2580,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2341,7 +2601,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2362,7 +2622,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2383,7 +2643,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2404,7 +2664,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2425,7 +2685,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2446,7 +2706,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2467,7 +2727,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2487,6 +2747,10 @@
     "label": "x",
     "kind": "variable",
     "detail": "x",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_x",
@@ -2501,6 +2765,10 @@
     "label": "y",
     "kind": "variable",
     "detail": "y",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_y",
@@ -2515,6 +2783,10 @@
     "label": "zoneInput",
     "kind": "variable",
     "detail": "zoneInput",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_zoneInput",
@@ -2529,6 +2801,10 @@
     "label": "zones",
     "kind": "interface",
     "detail": "zones",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_zones",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/symbols.json
@@ -3,10 +3,6 @@
     "label": "a",
     "kind": "variable",
     "detail": "a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_a",
@@ -21,10 +17,6 @@
     "label": "anotherThing",
     "kind": "variable",
     "detail": "anotherThing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anotherThing",
@@ -141,10 +133,6 @@
     "label": "badEquals",
     "kind": "variable",
     "detail": "badEquals",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badEquals",
@@ -159,10 +147,6 @@
     "label": "badEquals2",
     "kind": "variable",
     "detail": "badEquals2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badEquals2",
@@ -177,10 +161,6 @@
     "label": "bar",
     "kind": "variable",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -258,10 +238,6 @@
     "label": "batchSizeMakesNoSenseHere",
     "kind": "variable",
     "detail": "batchSizeMakesNoSenseHere",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_batchSizeMakesNoSenseHere",
@@ -381,10 +357,6 @@
     "label": "copy",
     "kind": "variable",
     "detail": "copy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_copy",
@@ -521,10 +493,6 @@
     "label": "doubleString",
     "kind": "variable",
     "detail": "doubleString",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_doubleString",
@@ -598,10 +566,6 @@
     "label": "evenMoreIndirection",
     "kind": "variable",
     "detail": "evenMoreIndirection",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_evenMoreIndirection",
@@ -700,10 +664,6 @@
     "label": "foo",
     "kind": "variable",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -831,10 +791,6 @@
     "label": "indirection",
     "kind": "variable",
     "detail": "indirection",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_indirection",
@@ -849,10 +805,6 @@
     "label": "inlinedVariable",
     "kind": "variable",
     "detail": "inlinedVariable",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_inlinedVariable",
@@ -867,10 +819,6 @@
     "label": "innerPropertyLoop",
     "kind": "variable",
     "detail": "innerPropertyLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_innerPropertyLoop",
@@ -885,10 +833,6 @@
     "label": "innerPropertyLoop2",
     "kind": "variable",
     "detail": "innerPropertyLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_innerPropertyLoop2",
@@ -945,10 +889,6 @@
     "label": "invalidEnvAuthVar",
     "kind": "variable",
     "detail": "invalidEnvAuthVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidEnvAuthVar",
@@ -963,10 +903,6 @@
     "label": "invalidEnvironmentVar",
     "kind": "variable",
     "detail": "invalidEnvironmentVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidEnvironmentVar",
@@ -981,10 +917,6 @@
     "label": "invalidLocationVar",
     "kind": "variable",
     "detail": "invalidLocationVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidLocationVar",
@@ -999,10 +931,6 @@
     "label": "invalidNamespaceAssignment",
     "kind": "variable",
     "detail": "invalidNamespaceAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidNamespaceAssignment",
@@ -1080,10 +1008,6 @@
     "label": "keyVaultSecretArrayInterpolatedVar",
     "kind": "variable",
     "detail": "keyVaultSecretArrayInterpolatedVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretArrayInterpolatedVar",
@@ -1098,10 +1022,6 @@
     "label": "keyVaultSecretArrayVar",
     "kind": "variable",
     "detail": "keyVaultSecretArrayVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretArrayVar",
@@ -1116,10 +1036,6 @@
     "label": "keyVaultSecretInterpolatedVar",
     "kind": "variable",
     "detail": "keyVaultSecretInterpolatedVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretInterpolatedVar",
@@ -1134,10 +1050,6 @@
     "label": "keyVaultSecretObjectVar",
     "kind": "variable",
     "detail": "keyVaultSecretObjectVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretObjectVar",
@@ -1152,10 +1064,6 @@
     "label": "keyVaultSecretVar",
     "kind": "variable",
     "detail": "keyVaultSecretVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretVar",
@@ -1170,10 +1078,6 @@
     "label": "keys",
     "kind": "variable",
     "detail": "keys",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keys",
@@ -1188,10 +1092,6 @@
     "label": "kv",
     "kind": "interface",
     "detail": "kv",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_kv",
@@ -1272,10 +1172,6 @@
     "label": "listSecrets",
     "kind": "variable",
     "detail": "listSecrets",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_listSecrets",
@@ -1290,10 +1186,6 @@
     "label": "listSecretsVar",
     "kind": "variable",
     "detail": "listSecretsVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_listSecretsVar",
@@ -1392,10 +1284,6 @@
     "label": "loopExpression",
     "kind": "variable",
     "detail": "loopExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopExpression",
@@ -1515,10 +1403,6 @@
     "label": "missingArrayVariable",
     "kind": "variable",
     "detail": "missingArrayVariable",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingArrayVariable",
@@ -1533,10 +1417,6 @@
     "label": "mixedArrayTypeCompletions",
     "kind": "variable",
     "detail": "mixedArrayTypeCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mixedArrayTypeCompletions",
@@ -1551,10 +1431,6 @@
     "label": "mixedArrayTypeCompletions2",
     "kind": "variable",
     "detail": "mixedArrayTypeCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mixedArrayTypeCompletions2",
@@ -1569,10 +1445,6 @@
     "label": "moreIndirection",
     "kind": "variable",
     "detail": "moreIndirection",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moreIndirection",
@@ -1587,10 +1459,6 @@
     "label": "myConcat",
     "kind": "variable",
     "detail": "myConcat",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myConcat",
@@ -1605,10 +1473,6 @@
     "label": "myFloat",
     "kind": "variable",
     "detail": "myFloat",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myFloat",
@@ -1623,10 +1487,6 @@
     "label": "myRef",
     "kind": "variable",
     "detail": "myRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myRef",
@@ -1641,10 +1501,6 @@
     "label": "mySum",
     "kind": "variable",
     "detail": "mySum",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mySum",
@@ -1659,10 +1515,6 @@
     "label": "noFilteredLoopsInVariables",
     "kind": "variable",
     "detail": "noFilteredLoopsInVariables",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noFilteredLoopsInVariables",
@@ -1677,10 +1529,6 @@
     "label": "noNestedVariableLoopsEither",
     "kind": "variable",
     "detail": "noNestedVariableLoopsEither",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noNestedVariableLoopsEither",
@@ -1695,10 +1543,6 @@
     "label": "nonExistentIndex1",
     "kind": "variable",
     "detail": "nonExistentIndex1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentIndex1",
@@ -1713,10 +1557,6 @@
     "label": "nonExistentIndex2",
     "kind": "variable",
     "detail": "nonExistentIndex2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentIndex2",
@@ -1731,10 +1571,6 @@
     "label": "nonExistentIndex3",
     "kind": "variable",
     "detail": "nonExistentIndex3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentIndex3",
@@ -1749,10 +1585,6 @@
     "label": "nonTopLevelLoop",
     "kind": "variable",
     "detail": "nonTopLevelLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonTopLevelLoop",
@@ -1767,10 +1599,6 @@
     "label": "notRuntime",
     "kind": "variable",
     "detail": "notRuntime",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notRuntime",
@@ -1785,10 +1613,6 @@
     "label": "objWithInterp",
     "kind": "variable",
     "detail": "objWithInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objWithInterp",
@@ -1803,10 +1627,6 @@
     "label": "objectLiteralType",
     "kind": "variable",
     "detail": "objectLiteralType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objectLiteralType",
@@ -1821,10 +1641,6 @@
     "label": "objectVarTopLevelArrayIndexCompletions",
     "kind": "variable",
     "detail": "objectVarTopLevelArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objectVarTopLevelArrayIndexCompletions",
@@ -1839,10 +1655,6 @@
     "label": "objectVarTopLevelCompletions",
     "kind": "variable",
     "detail": "objectVarTopLevelCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objectVarTopLevelCompletions",
@@ -1857,10 +1669,6 @@
     "label": "objectVarTopLevelCompletions2",
     "kind": "variable",
     "detail": "objectVarTopLevelCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objectVarTopLevelCompletions2",
@@ -1875,10 +1683,6 @@
     "label": "oneArrayIndexCompletions",
     "kind": "variable",
     "detail": "oneArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_oneArrayIndexCompletions",
@@ -1893,10 +1697,6 @@
     "label": "oneArrayItemCompletions",
     "kind": "variable",
     "detail": "oneArrayItemCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_oneArrayItemCompletions",
@@ -1911,10 +1711,6 @@
     "label": "oneArrayItemCompletions2",
     "kind": "variable",
     "detail": "oneArrayItemCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_oneArrayItemCompletions2",
@@ -2097,10 +1893,6 @@
     "label": "resourceGroup",
     "kind": "variable",
     "detail": "resourceGroup",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceGroup",
@@ -2136,10 +1928,6 @@
     "label": "rgName",
     "kind": "variable",
     "detail": "rgName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_rgName",
@@ -2154,10 +1942,6 @@
     "label": "runtimeLoop",
     "kind": "variable",
     "detail": "runtimeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop",
@@ -2172,10 +1956,6 @@
     "label": "runtimeLoop2",
     "kind": "variable",
     "detail": "runtimeLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop2",
@@ -2190,10 +1970,6 @@
     "label": "runtimeLoop3",
     "kind": "variable",
     "detail": "runtimeLoop3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop3",
@@ -2208,10 +1984,6 @@
     "label": "runtimeLoop4",
     "kind": "variable",
     "detail": "runtimeLoop4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop4",
@@ -2226,10 +1998,6 @@
     "label": "runtimeLoop5",
     "kind": "variable",
     "detail": "runtimeLoop5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop5",
@@ -2265,10 +2033,6 @@
     "label": "something",
     "kind": "variable",
     "detail": "something",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_something",
@@ -2367,10 +2131,6 @@
     "label": "subName",
     "kind": "variable",
     "detail": "subName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_subName",
@@ -2385,10 +2145,6 @@
     "label": "subscription",
     "kind": "variable",
     "detail": "subscription",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_subscription",
@@ -2522,10 +2278,6 @@
     "label": "test",
     "kind": "variable",
     "detail": "test",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_test",
@@ -2540,10 +2292,6 @@
     "label": "test2",
     "kind": "variable",
     "detail": "test2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_test2",
@@ -2558,10 +2306,6 @@
     "label": "test3",
     "kind": "variable",
     "detail": "test3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_test3",
@@ -2576,10 +2320,6 @@
     "label": "testDupe",
     "kind": "variable",
     "detail": "testDupe",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_testDupe",
@@ -2783,10 +2523,6 @@
     "label": "x",
     "kind": "variable",
     "detail": "x",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_x",
@@ -2801,10 +2537,6 @@
     "label": "y",
     "kind": "variable",
     "detail": "y",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_y",
@@ -2819,10 +2551,6 @@
     "label": "zoneInput",
     "kind": "variable",
     "detail": "zoneInput",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_zoneInput",
@@ -2837,10 +2565,6 @@
     "label": "zones",
     "kind": "interface",
     "detail": "zones",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_zones",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/symbols.json
@@ -3,6 +3,10 @@
     "label": "a",
     "kind": "variable",
     "detail": "a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_a",
@@ -17,6 +21,10 @@
     "label": "anotherThing",
     "kind": "variable",
     "detail": "anotherThing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anotherThing",
@@ -32,7 +40,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -53,7 +61,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -92,7 +100,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -113,7 +121,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -133,6 +141,10 @@
     "label": "badEquals",
     "kind": "variable",
     "detail": "badEquals",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badEquals",
@@ -147,6 +159,10 @@
     "label": "badEquals2",
     "kind": "variable",
     "detail": "badEquals2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badEquals2",
@@ -161,6 +177,10 @@
     "label": "bar",
     "kind": "variable",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -176,7 +196,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -197,7 +217,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -218,7 +238,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -238,6 +258,10 @@
     "label": "batchSizeMakesNoSenseHere",
     "kind": "variable",
     "detail": "batchSizeMakesNoSenseHere",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_batchSizeMakesNoSenseHere",
@@ -253,7 +277,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -274,7 +298,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -295,7 +319,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -316,7 +340,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -337,7 +361,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -357,6 +381,10 @@
     "label": "copy",
     "kind": "variable",
     "detail": "copy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_copy",
@@ -372,7 +400,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -393,7 +421,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -414,7 +442,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -435,7 +463,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -456,7 +484,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -477,7 +505,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -493,6 +521,10 @@
     "label": "doubleString",
     "kind": "variable",
     "detail": "doubleString",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_doubleString",
@@ -508,7 +540,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -529,7 +561,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -550,7 +582,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -566,6 +598,10 @@
     "label": "evenMoreIndirection",
     "kind": "variable",
     "detail": "evenMoreIndirection",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_evenMoreIndirection",
@@ -581,7 +617,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -602,7 +638,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -623,7 +659,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -644,7 +680,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -664,6 +700,10 @@
     "label": "foo",
     "kind": "variable",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -680,7 +720,7 @@
     "detail": "for",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n[for item in list: ]\n```"
+      "value": "```bicep\n[for item in list: ]\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -698,7 +738,7 @@
     "detail": "for-indexed",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n[for (item, index) in list: ]\n```"
+      "value": "```bicep\n[for (item, index) in list: ]\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -715,7 +755,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -736,7 +776,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -771,7 +811,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -791,6 +831,10 @@
     "label": "indirection",
     "kind": "variable",
     "detail": "indirection",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_indirection",
@@ -805,6 +849,10 @@
     "label": "inlinedVariable",
     "kind": "variable",
     "detail": "inlinedVariable",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_inlinedVariable",
@@ -819,6 +867,10 @@
     "label": "innerPropertyLoop",
     "kind": "variable",
     "detail": "innerPropertyLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_innerPropertyLoop",
@@ -833,6 +885,10 @@
     "label": "innerPropertyLoop2",
     "kind": "variable",
     "detail": "innerPropertyLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_innerPropertyLoop2",
@@ -848,7 +904,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -869,7 +925,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -889,6 +945,10 @@
     "label": "invalidEnvAuthVar",
     "kind": "variable",
     "detail": "invalidEnvAuthVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidEnvAuthVar",
@@ -903,6 +963,10 @@
     "label": "invalidEnvironmentVar",
     "kind": "variable",
     "detail": "invalidEnvironmentVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidEnvironmentVar",
@@ -917,6 +981,10 @@
     "label": "invalidLocationVar",
     "kind": "variable",
     "detail": "invalidLocationVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidLocationVar",
@@ -931,6 +999,10 @@
     "label": "invalidNamespaceAssignment",
     "kind": "variable",
     "detail": "invalidNamespaceAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidNamespaceAssignment",
@@ -946,7 +1018,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -967,7 +1039,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -988,7 +1060,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1008,6 +1080,10 @@
     "label": "keyVaultSecretArrayInterpolatedVar",
     "kind": "variable",
     "detail": "keyVaultSecretArrayInterpolatedVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretArrayInterpolatedVar",
@@ -1022,6 +1098,10 @@
     "label": "keyVaultSecretArrayVar",
     "kind": "variable",
     "detail": "keyVaultSecretArrayVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretArrayVar",
@@ -1036,6 +1116,10 @@
     "label": "keyVaultSecretInterpolatedVar",
     "kind": "variable",
     "detail": "keyVaultSecretInterpolatedVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretInterpolatedVar",
@@ -1050,6 +1134,10 @@
     "label": "keyVaultSecretObjectVar",
     "kind": "variable",
     "detail": "keyVaultSecretObjectVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretObjectVar",
@@ -1064,6 +1152,10 @@
     "label": "keyVaultSecretVar",
     "kind": "variable",
     "detail": "keyVaultSecretVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretVar",
@@ -1078,6 +1170,10 @@
     "label": "keys",
     "kind": "variable",
     "detail": "keys",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keys",
@@ -1092,6 +1188,10 @@
     "label": "kv",
     "kind": "interface",
     "detail": "kv",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_kv",
@@ -1110,7 +1210,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1131,7 +1231,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1152,7 +1252,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1172,6 +1272,10 @@
     "label": "listSecrets",
     "kind": "variable",
     "detail": "listSecrets",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_listSecrets",
@@ -1186,6 +1290,10 @@
     "label": "listSecretsVar",
     "kind": "variable",
     "detail": "listSecretsVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_listSecretsVar",
@@ -1201,7 +1309,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1222,7 +1330,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1243,7 +1351,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1264,7 +1372,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1284,6 +1392,10 @@
     "label": "loopExpression",
     "kind": "variable",
     "detail": "loopExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopExpression",
@@ -1299,7 +1411,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1320,7 +1432,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1341,7 +1453,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1362,7 +1474,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1383,7 +1495,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1403,6 +1515,10 @@
     "label": "missingArrayVariable",
     "kind": "variable",
     "detail": "missingArrayVariable",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingArrayVariable",
@@ -1417,6 +1533,10 @@
     "label": "mixedArrayTypeCompletions",
     "kind": "variable",
     "detail": "mixedArrayTypeCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mixedArrayTypeCompletions",
@@ -1431,6 +1551,10 @@
     "label": "mixedArrayTypeCompletions2",
     "kind": "variable",
     "detail": "mixedArrayTypeCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mixedArrayTypeCompletions2",
@@ -1445,6 +1569,10 @@
     "label": "moreIndirection",
     "kind": "variable",
     "detail": "moreIndirection",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moreIndirection",
@@ -1459,6 +1587,10 @@
     "label": "myConcat",
     "kind": "variable",
     "detail": "myConcat",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myConcat",
@@ -1473,6 +1605,10 @@
     "label": "myFloat",
     "kind": "variable",
     "detail": "myFloat",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myFloat",
@@ -1487,6 +1623,10 @@
     "label": "myRef",
     "kind": "variable",
     "detail": "myRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myRef",
@@ -1501,6 +1641,10 @@
     "label": "mySum",
     "kind": "variable",
     "detail": "mySum",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mySum",
@@ -1515,6 +1659,10 @@
     "label": "noFilteredLoopsInVariables",
     "kind": "variable",
     "detail": "noFilteredLoopsInVariables",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noFilteredLoopsInVariables",
@@ -1529,6 +1677,10 @@
     "label": "noNestedVariableLoopsEither",
     "kind": "variable",
     "detail": "noNestedVariableLoopsEither",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noNestedVariableLoopsEither",
@@ -1543,6 +1695,10 @@
     "label": "nonExistentIndex1",
     "kind": "variable",
     "detail": "nonExistentIndex1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentIndex1",
@@ -1557,6 +1713,10 @@
     "label": "nonExistentIndex2",
     "kind": "variable",
     "detail": "nonExistentIndex2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentIndex2",
@@ -1571,6 +1731,10 @@
     "label": "nonExistentIndex3",
     "kind": "variable",
     "detail": "nonExistentIndex3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentIndex3",
@@ -1585,6 +1749,10 @@
     "label": "nonTopLevelLoop",
     "kind": "variable",
     "detail": "nonTopLevelLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonTopLevelLoop",
@@ -1599,6 +1767,10 @@
     "label": "notRuntime",
     "kind": "variable",
     "detail": "notRuntime",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notRuntime",
@@ -1613,6 +1785,10 @@
     "label": "objWithInterp",
     "kind": "variable",
     "detail": "objWithInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objWithInterp",
@@ -1627,6 +1803,10 @@
     "label": "objectLiteralType",
     "kind": "variable",
     "detail": "objectLiteralType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objectLiteralType",
@@ -1641,6 +1821,10 @@
     "label": "objectVarTopLevelArrayIndexCompletions",
     "kind": "variable",
     "detail": "objectVarTopLevelArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objectVarTopLevelArrayIndexCompletions",
@@ -1655,6 +1839,10 @@
     "label": "objectVarTopLevelCompletions",
     "kind": "variable",
     "detail": "objectVarTopLevelCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objectVarTopLevelCompletions",
@@ -1669,6 +1857,10 @@
     "label": "objectVarTopLevelCompletions2",
     "kind": "variable",
     "detail": "objectVarTopLevelCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objectVarTopLevelCompletions2",
@@ -1683,6 +1875,10 @@
     "label": "oneArrayIndexCompletions",
     "kind": "variable",
     "detail": "oneArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_oneArrayIndexCompletions",
@@ -1697,6 +1893,10 @@
     "label": "oneArrayItemCompletions",
     "kind": "variable",
     "detail": "oneArrayItemCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_oneArrayItemCompletions",
@@ -1711,6 +1911,10 @@
     "label": "oneArrayItemCompletions2",
     "kind": "variable",
     "detail": "oneArrayItemCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_oneArrayItemCompletions2",
@@ -1726,7 +1930,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1747,7 +1951,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1768,7 +1972,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1789,7 +1993,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1810,7 +2014,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1831,7 +2035,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1852,7 +2056,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1873,7 +2077,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1893,6 +2097,10 @@
     "label": "resourceGroup",
     "kind": "variable",
     "detail": "resourceGroup",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceGroup",
@@ -1908,7 +2116,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1928,6 +2136,10 @@
     "label": "rgName",
     "kind": "variable",
     "detail": "rgName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_rgName",
@@ -1942,6 +2154,10 @@
     "label": "runtimeLoop",
     "kind": "variable",
     "detail": "runtimeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop",
@@ -1956,6 +2172,10 @@
     "label": "runtimeLoop2",
     "kind": "variable",
     "detail": "runtimeLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop2",
@@ -1970,6 +2190,10 @@
     "label": "runtimeLoop3",
     "kind": "variable",
     "detail": "runtimeLoop3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop3",
@@ -1984,6 +2208,10 @@
     "label": "runtimeLoop4",
     "kind": "variable",
     "detail": "runtimeLoop4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop4",
@@ -1998,6 +2226,10 @@
     "label": "runtimeLoop5",
     "kind": "variable",
     "detail": "runtimeLoop5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop5",
@@ -2013,7 +2245,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2033,6 +2265,10 @@
     "label": "something",
     "kind": "variable",
     "detail": "something",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_something",
@@ -2048,7 +2284,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2069,7 +2305,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2090,7 +2326,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2111,7 +2347,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2131,6 +2367,10 @@
     "label": "subName",
     "kind": "variable",
     "detail": "subName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_subName",
@@ -2145,6 +2385,10 @@
     "label": "subscription",
     "kind": "variable",
     "detail": "subscription",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_subscription",
@@ -2160,7 +2404,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2181,7 +2425,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2220,7 +2464,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2241,7 +2485,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2258,7 +2502,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2278,6 +2522,10 @@
     "label": "test",
     "kind": "variable",
     "detail": "test",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_test",
@@ -2292,6 +2540,10 @@
     "label": "test2",
     "kind": "variable",
     "detail": "test2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_test2",
@@ -2306,6 +2558,10 @@
     "label": "test3",
     "kind": "variable",
     "detail": "test3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_test3",
@@ -2320,6 +2576,10 @@
     "label": "testDupe",
     "kind": "variable",
     "detail": "testDupe",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_testDupe",
@@ -2335,7 +2595,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2356,7 +2616,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2377,7 +2637,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2398,7 +2658,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2419,7 +2679,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2440,7 +2700,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2461,7 +2721,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2482,7 +2742,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2503,7 +2763,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2523,6 +2783,10 @@
     "label": "x",
     "kind": "variable",
     "detail": "x",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_x",
@@ -2537,6 +2801,10 @@
     "label": "y",
     "kind": "variable",
     "detail": "y",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_y",
@@ -2551,6 +2819,10 @@
     "label": "zoneInput",
     "kind": "variable",
     "detail": "zoneInput",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_zoneInput",
@@ -2565,6 +2837,10 @@
     "label": "zones",
     "kind": "interface",
     "detail": "zones",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_zones",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/sysAndDescription.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/sysAndDescription.json
@@ -4,7 +4,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndescription(text: string): any\n\n```\n\n"
+      "value": "```bicep\ndescription(text: string): any\n\n```  \n  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
@@ -21,6 +21,10 @@
     "label": "a",
     "kind": "variable",
     "detail": "a",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_a",
@@ -35,6 +39,10 @@
     "label": "anotherThing",
     "kind": "variable",
     "detail": "anotherThing",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anotherThing",
@@ -50,7 +58,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -71,7 +79,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -110,7 +118,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -131,7 +139,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -151,6 +159,10 @@
     "label": "badEquals",
     "kind": "variable",
     "detail": "badEquals",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badEquals",
@@ -165,6 +177,10 @@
     "label": "badEquals2",
     "kind": "variable",
     "detail": "badEquals2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badEquals2",
@@ -179,6 +195,10 @@
     "label": "bar",
     "kind": "variable",
     "detail": "bar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -194,7 +214,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -215,7 +235,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -236,7 +256,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -256,6 +276,10 @@
     "label": "batchSizeMakesNoSenseHere",
     "kind": "variable",
     "detail": "batchSizeMakesNoSenseHere",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_batchSizeMakesNoSenseHere",
@@ -271,7 +295,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -292,7 +316,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -313,7 +337,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -334,7 +358,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -355,7 +379,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -375,6 +399,10 @@
     "label": "copy",
     "kind": "variable",
     "detail": "copy",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_copy",
@@ -390,7 +418,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -411,7 +439,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -432,7 +460,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -453,7 +481,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -474,7 +502,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -495,7 +523,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -511,6 +539,10 @@
     "label": "doubleString",
     "kind": "variable",
     "detail": "doubleString",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_doubleString",
@@ -526,7 +558,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -547,7 +579,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -568,7 +600,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -584,6 +616,10 @@
     "label": "evenMoreIndirection",
     "kind": "variable",
     "detail": "evenMoreIndirection",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_evenMoreIndirection",
@@ -599,7 +635,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -620,7 +656,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -641,7 +677,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -662,7 +698,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -682,6 +718,10 @@
     "label": "foo",
     "kind": "variable",
     "detail": "foo",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -697,7 +737,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -718,7 +758,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -753,7 +793,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -773,6 +813,10 @@
     "label": "indirection",
     "kind": "variable",
     "detail": "indirection",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_indirection",
@@ -787,6 +831,10 @@
     "label": "inlinedVariable",
     "kind": "variable",
     "detail": "inlinedVariable",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_inlinedVariable",
@@ -801,6 +849,10 @@
     "label": "innerPropertyLoop",
     "kind": "variable",
     "detail": "innerPropertyLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_innerPropertyLoop",
@@ -815,6 +867,10 @@
     "label": "innerPropertyLoop2",
     "kind": "variable",
     "detail": "innerPropertyLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_innerPropertyLoop2",
@@ -830,7 +886,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -851,7 +907,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -871,6 +927,10 @@
     "label": "invalidEnvAuthVar",
     "kind": "variable",
     "detail": "invalidEnvAuthVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidEnvAuthVar",
@@ -885,6 +945,10 @@
     "label": "invalidEnvironmentVar",
     "kind": "variable",
     "detail": "invalidEnvironmentVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidEnvironmentVar",
@@ -899,6 +963,10 @@
     "label": "invalidLocationVar",
     "kind": "variable",
     "detail": "invalidLocationVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidLocationVar",
@@ -913,6 +981,10 @@
     "label": "invalidNamespaceAssignment",
     "kind": "variable",
     "detail": "invalidNamespaceAssignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidNamespaceAssignment",
@@ -928,7 +1000,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -949,7 +1021,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -970,7 +1042,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -990,6 +1062,10 @@
     "label": "keyVaultSecretArrayInterpolatedVar",
     "kind": "variable",
     "detail": "keyVaultSecretArrayInterpolatedVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretArrayInterpolatedVar",
@@ -1004,6 +1080,10 @@
     "label": "keyVaultSecretArrayVar",
     "kind": "variable",
     "detail": "keyVaultSecretArrayVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretArrayVar",
@@ -1018,6 +1098,10 @@
     "label": "keyVaultSecretInterpolatedVar",
     "kind": "variable",
     "detail": "keyVaultSecretInterpolatedVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretInterpolatedVar",
@@ -1032,6 +1116,10 @@
     "label": "keyVaultSecretObjectVar",
     "kind": "variable",
     "detail": "keyVaultSecretObjectVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretObjectVar",
@@ -1046,6 +1134,10 @@
     "label": "keyVaultSecretVar",
     "kind": "variable",
     "detail": "keyVaultSecretVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretVar",
@@ -1060,6 +1152,10 @@
     "label": "keys",
     "kind": "variable",
     "detail": "keys",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keys",
@@ -1074,6 +1170,10 @@
     "label": "kv",
     "kind": "interface",
     "detail": "kv",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_kv",
@@ -1092,7 +1192,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1113,7 +1213,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1134,7 +1234,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1154,6 +1254,10 @@
     "label": "listSecrets",
     "kind": "variable",
     "detail": "listSecrets",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_listSecrets",
@@ -1168,6 +1272,10 @@
     "label": "listSecretsVar",
     "kind": "variable",
     "detail": "listSecretsVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_listSecretsVar",
@@ -1183,7 +1291,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1204,7 +1312,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1225,7 +1333,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1246,7 +1354,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1266,6 +1374,10 @@
     "label": "loopExpression",
     "kind": "variable",
     "detail": "loopExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopExpression",
@@ -1281,7 +1393,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1302,7 +1414,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1323,7 +1435,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1344,7 +1456,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1365,7 +1477,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1385,6 +1497,10 @@
     "label": "missingArrayVariable",
     "kind": "variable",
     "detail": "missingArrayVariable",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingArrayVariable",
@@ -1399,6 +1515,10 @@
     "label": "missingValue",
     "kind": "variable",
     "detail": "missingValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingValue",
@@ -1413,6 +1533,10 @@
     "label": "mixedArrayTypeCompletions",
     "kind": "variable",
     "detail": "mixedArrayTypeCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mixedArrayTypeCompletions",
@@ -1427,6 +1551,10 @@
     "label": "mixedArrayTypeCompletions2",
     "kind": "variable",
     "detail": "mixedArrayTypeCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mixedArrayTypeCompletions2",
@@ -1441,6 +1569,10 @@
     "label": "moreIndirection",
     "kind": "variable",
     "detail": "moreIndirection",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moreIndirection",
@@ -1455,6 +1587,10 @@
     "label": "myConcat",
     "kind": "variable",
     "detail": "myConcat",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myConcat",
@@ -1469,6 +1605,10 @@
     "label": "myFloat",
     "kind": "variable",
     "detail": "myFloat",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myFloat",
@@ -1483,6 +1623,10 @@
     "label": "myRef",
     "kind": "variable",
     "detail": "myRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myRef",
@@ -1497,6 +1641,10 @@
     "label": "mySum",
     "kind": "variable",
     "detail": "mySum",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mySum",
@@ -1511,6 +1659,10 @@
     "label": "noFilteredLoopsInVariables",
     "kind": "variable",
     "detail": "noFilteredLoopsInVariables",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noFilteredLoopsInVariables",
@@ -1525,6 +1677,10 @@
     "label": "noNestedVariableLoopsEither",
     "kind": "variable",
     "detail": "noNestedVariableLoopsEither",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noNestedVariableLoopsEither",
@@ -1539,6 +1695,10 @@
     "label": "nonExistentIndex1",
     "kind": "variable",
     "detail": "nonExistentIndex1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentIndex1",
@@ -1553,6 +1713,10 @@
     "label": "nonExistentIndex2",
     "kind": "variable",
     "detail": "nonExistentIndex2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentIndex2",
@@ -1567,6 +1731,10 @@
     "label": "nonExistentIndex3",
     "kind": "variable",
     "detail": "nonExistentIndex3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentIndex3",
@@ -1581,6 +1749,10 @@
     "label": "nonTopLevelLoop",
     "kind": "variable",
     "detail": "nonTopLevelLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonTopLevelLoop",
@@ -1595,6 +1767,10 @@
     "label": "notRuntime",
     "kind": "variable",
     "detail": "notRuntime",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notRuntime",
@@ -1609,6 +1785,10 @@
     "label": "objWithInterp",
     "kind": "variable",
     "detail": "objWithInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objWithInterp",
@@ -1623,6 +1803,10 @@
     "label": "objectLiteralType",
     "kind": "variable",
     "detail": "objectLiteralType",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objectLiteralType",
@@ -1637,6 +1821,10 @@
     "label": "objectVarTopLevelArrayIndexCompletions",
     "kind": "variable",
     "detail": "objectVarTopLevelArrayIndexCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objectVarTopLevelArrayIndexCompletions",
@@ -1651,6 +1839,10 @@
     "label": "objectVarTopLevelCompletions",
     "kind": "variable",
     "detail": "objectVarTopLevelCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objectVarTopLevelCompletions",
@@ -1665,6 +1857,10 @@
     "label": "objectVarTopLevelCompletions2",
     "kind": "variable",
     "detail": "objectVarTopLevelCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objectVarTopLevelCompletions2",
@@ -1679,6 +1875,10 @@
     "label": "oneArrayItemCompletions",
     "kind": "variable",
     "detail": "oneArrayItemCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_oneArrayItemCompletions",
@@ -1693,6 +1893,10 @@
     "label": "oneArrayItemCompletions2",
     "kind": "variable",
     "detail": "oneArrayItemCompletions2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_oneArrayItemCompletions2",
@@ -1708,7 +1912,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1729,7 +1933,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1750,7 +1954,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1771,7 +1975,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1792,7 +1996,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1813,7 +2017,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1834,7 +2038,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1855,7 +2059,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1875,6 +2079,10 @@
     "label": "resourceGroup",
     "kind": "variable",
     "detail": "resourceGroup",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceGroup",
@@ -1890,7 +2098,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1910,6 +2118,10 @@
     "label": "rgName",
     "kind": "variable",
     "detail": "rgName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_rgName",
@@ -1924,6 +2136,10 @@
     "label": "runtimeLoop",
     "kind": "variable",
     "detail": "runtimeLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop",
@@ -1938,6 +2154,10 @@
     "label": "runtimeLoop2",
     "kind": "variable",
     "detail": "runtimeLoop2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop2",
@@ -1952,6 +2172,10 @@
     "label": "runtimeLoop3",
     "kind": "variable",
     "detail": "runtimeLoop3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop3",
@@ -1966,6 +2190,10 @@
     "label": "runtimeLoop4",
     "kind": "variable",
     "detail": "runtimeLoop4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop4",
@@ -1980,6 +2208,10 @@
     "label": "runtimeLoop5",
     "kind": "variable",
     "detail": "runtimeLoop5",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop5",
@@ -1995,7 +2227,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2015,6 +2247,10 @@
     "label": "something",
     "kind": "variable",
     "detail": "something",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_something",
@@ -2030,7 +2266,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2051,7 +2287,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2072,7 +2308,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2093,7 +2329,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2113,6 +2349,10 @@
     "label": "subName",
     "kind": "variable",
     "detail": "subName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_subName",
@@ -2127,6 +2367,10 @@
     "label": "subscription",
     "kind": "variable",
     "detail": "subscription",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_subscription",
@@ -2142,7 +2386,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2163,7 +2407,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2202,7 +2446,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2223,7 +2467,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2240,7 +2484,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2260,6 +2504,10 @@
     "label": "test",
     "kind": "variable",
     "detail": "test",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_test",
@@ -2274,6 +2522,10 @@
     "label": "test2",
     "kind": "variable",
     "detail": "test2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_test2",
@@ -2288,6 +2540,10 @@
     "label": "test3",
     "kind": "variable",
     "detail": "test3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_test3",
@@ -2302,6 +2558,10 @@
     "label": "testDupe",
     "kind": "variable",
     "detail": "testDupe",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_testDupe",
@@ -2317,7 +2577,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2338,7 +2598,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2359,7 +2619,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2380,7 +2640,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2401,7 +2661,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2422,7 +2682,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2443,7 +2703,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2464,7 +2724,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2485,7 +2745,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2505,6 +2765,10 @@
     "label": "x",
     "kind": "variable",
     "detail": "x",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_x",
@@ -2519,6 +2783,10 @@
     "label": "y",
     "kind": "variable",
     "detail": "y",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_y",
@@ -2533,6 +2801,10 @@
     "label": "zoneInput",
     "kind": "variable",
     "detail": "zoneInput",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_zoneInput",
@@ -2547,6 +2819,10 @@
     "label": "zones",
     "kind": "interface",
     "detail": "zones",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_zones",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
@@ -21,10 +21,6 @@
     "label": "a",
     "kind": "variable",
     "detail": "a",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_a",
@@ -39,10 +35,6 @@
     "label": "anotherThing",
     "kind": "variable",
     "detail": "anotherThing",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anotherThing",
@@ -159,10 +151,6 @@
     "label": "badEquals",
     "kind": "variable",
     "detail": "badEquals",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badEquals",
@@ -177,10 +165,6 @@
     "label": "badEquals2",
     "kind": "variable",
     "detail": "badEquals2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badEquals2",
@@ -195,10 +179,6 @@
     "label": "bar",
     "kind": "variable",
     "detail": "bar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bar",
@@ -276,10 +256,6 @@
     "label": "batchSizeMakesNoSenseHere",
     "kind": "variable",
     "detail": "batchSizeMakesNoSenseHere",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_batchSizeMakesNoSenseHere",
@@ -399,10 +375,6 @@
     "label": "copy",
     "kind": "variable",
     "detail": "copy",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_copy",
@@ -539,10 +511,6 @@
     "label": "doubleString",
     "kind": "variable",
     "detail": "doubleString",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_doubleString",
@@ -616,10 +584,6 @@
     "label": "evenMoreIndirection",
     "kind": "variable",
     "detail": "evenMoreIndirection",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_evenMoreIndirection",
@@ -718,10 +682,6 @@
     "label": "foo",
     "kind": "variable",
     "detail": "foo",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_foo",
@@ -813,10 +773,6 @@
     "label": "indirection",
     "kind": "variable",
     "detail": "indirection",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_indirection",
@@ -831,10 +787,6 @@
     "label": "inlinedVariable",
     "kind": "variable",
     "detail": "inlinedVariable",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_inlinedVariable",
@@ -849,10 +801,6 @@
     "label": "innerPropertyLoop",
     "kind": "variable",
     "detail": "innerPropertyLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_innerPropertyLoop",
@@ -867,10 +815,6 @@
     "label": "innerPropertyLoop2",
     "kind": "variable",
     "detail": "innerPropertyLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_innerPropertyLoop2",
@@ -927,10 +871,6 @@
     "label": "invalidEnvAuthVar",
     "kind": "variable",
     "detail": "invalidEnvAuthVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidEnvAuthVar",
@@ -945,10 +885,6 @@
     "label": "invalidEnvironmentVar",
     "kind": "variable",
     "detail": "invalidEnvironmentVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidEnvironmentVar",
@@ -963,10 +899,6 @@
     "label": "invalidLocationVar",
     "kind": "variable",
     "detail": "invalidLocationVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidLocationVar",
@@ -981,10 +913,6 @@
     "label": "invalidNamespaceAssignment",
     "kind": "variable",
     "detail": "invalidNamespaceAssignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidNamespaceAssignment",
@@ -1062,10 +990,6 @@
     "label": "keyVaultSecretArrayInterpolatedVar",
     "kind": "variable",
     "detail": "keyVaultSecretArrayInterpolatedVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretArrayInterpolatedVar",
@@ -1080,10 +1004,6 @@
     "label": "keyVaultSecretArrayVar",
     "kind": "variable",
     "detail": "keyVaultSecretArrayVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretArrayVar",
@@ -1098,10 +1018,6 @@
     "label": "keyVaultSecretInterpolatedVar",
     "kind": "variable",
     "detail": "keyVaultSecretInterpolatedVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretInterpolatedVar",
@@ -1116,10 +1032,6 @@
     "label": "keyVaultSecretObjectVar",
     "kind": "variable",
     "detail": "keyVaultSecretObjectVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretObjectVar",
@@ -1134,10 +1046,6 @@
     "label": "keyVaultSecretVar",
     "kind": "variable",
     "detail": "keyVaultSecretVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keyVaultSecretVar",
@@ -1152,10 +1060,6 @@
     "label": "keys",
     "kind": "variable",
     "detail": "keys",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_keys",
@@ -1170,10 +1074,6 @@
     "label": "kv",
     "kind": "interface",
     "detail": "kv",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_kv",
@@ -1254,10 +1154,6 @@
     "label": "listSecrets",
     "kind": "variable",
     "detail": "listSecrets",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_listSecrets",
@@ -1272,10 +1168,6 @@
     "label": "listSecretsVar",
     "kind": "variable",
     "detail": "listSecretsVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_listSecretsVar",
@@ -1374,10 +1266,6 @@
     "label": "loopExpression",
     "kind": "variable",
     "detail": "loopExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopExpression",
@@ -1497,10 +1385,6 @@
     "label": "missingArrayVariable",
     "kind": "variable",
     "detail": "missingArrayVariable",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingArrayVariable",
@@ -1515,10 +1399,6 @@
     "label": "missingValue",
     "kind": "variable",
     "detail": "missingValue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingValue",
@@ -1533,10 +1413,6 @@
     "label": "mixedArrayTypeCompletions",
     "kind": "variable",
     "detail": "mixedArrayTypeCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mixedArrayTypeCompletions",
@@ -1551,10 +1427,6 @@
     "label": "mixedArrayTypeCompletions2",
     "kind": "variable",
     "detail": "mixedArrayTypeCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mixedArrayTypeCompletions2",
@@ -1569,10 +1441,6 @@
     "label": "moreIndirection",
     "kind": "variable",
     "detail": "moreIndirection",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_moreIndirection",
@@ -1587,10 +1455,6 @@
     "label": "myConcat",
     "kind": "variable",
     "detail": "myConcat",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myConcat",
@@ -1605,10 +1469,6 @@
     "label": "myFloat",
     "kind": "variable",
     "detail": "myFloat",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myFloat",
@@ -1623,10 +1483,6 @@
     "label": "myRef",
     "kind": "variable",
     "detail": "myRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myRef",
@@ -1641,10 +1497,6 @@
     "label": "mySum",
     "kind": "variable",
     "detail": "mySum",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mySum",
@@ -1659,10 +1511,6 @@
     "label": "noFilteredLoopsInVariables",
     "kind": "variable",
     "detail": "noFilteredLoopsInVariables",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noFilteredLoopsInVariables",
@@ -1677,10 +1525,6 @@
     "label": "noNestedVariableLoopsEither",
     "kind": "variable",
     "detail": "noNestedVariableLoopsEither",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noNestedVariableLoopsEither",
@@ -1695,10 +1539,6 @@
     "label": "nonExistentIndex1",
     "kind": "variable",
     "detail": "nonExistentIndex1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentIndex1",
@@ -1713,10 +1553,6 @@
     "label": "nonExistentIndex2",
     "kind": "variable",
     "detail": "nonExistentIndex2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentIndex2",
@@ -1731,10 +1567,6 @@
     "label": "nonExistentIndex3",
     "kind": "variable",
     "detail": "nonExistentIndex3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonExistentIndex3",
@@ -1749,10 +1581,6 @@
     "label": "nonTopLevelLoop",
     "kind": "variable",
     "detail": "nonTopLevelLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonTopLevelLoop",
@@ -1767,10 +1595,6 @@
     "label": "notRuntime",
     "kind": "variable",
     "detail": "notRuntime",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_notRuntime",
@@ -1785,10 +1609,6 @@
     "label": "objWithInterp",
     "kind": "variable",
     "detail": "objWithInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objWithInterp",
@@ -1803,10 +1623,6 @@
     "label": "objectLiteralType",
     "kind": "variable",
     "detail": "objectLiteralType",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objectLiteralType",
@@ -1821,10 +1637,6 @@
     "label": "objectVarTopLevelArrayIndexCompletions",
     "kind": "variable",
     "detail": "objectVarTopLevelArrayIndexCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objectVarTopLevelArrayIndexCompletions",
@@ -1839,10 +1651,6 @@
     "label": "objectVarTopLevelCompletions",
     "kind": "variable",
     "detail": "objectVarTopLevelCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objectVarTopLevelCompletions",
@@ -1857,10 +1665,6 @@
     "label": "objectVarTopLevelCompletions2",
     "kind": "variable",
     "detail": "objectVarTopLevelCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objectVarTopLevelCompletions2",
@@ -1875,10 +1679,6 @@
     "label": "oneArrayItemCompletions",
     "kind": "variable",
     "detail": "oneArrayItemCompletions",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_oneArrayItemCompletions",
@@ -1893,10 +1693,6 @@
     "label": "oneArrayItemCompletions2",
     "kind": "variable",
     "detail": "oneArrayItemCompletions2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_oneArrayItemCompletions2",
@@ -2079,10 +1875,6 @@
     "label": "resourceGroup",
     "kind": "variable",
     "detail": "resourceGroup",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceGroup",
@@ -2118,10 +1910,6 @@
     "label": "rgName",
     "kind": "variable",
     "detail": "rgName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_rgName",
@@ -2136,10 +1924,6 @@
     "label": "runtimeLoop",
     "kind": "variable",
     "detail": "runtimeLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop",
@@ -2154,10 +1938,6 @@
     "label": "runtimeLoop2",
     "kind": "variable",
     "detail": "runtimeLoop2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop2",
@@ -2172,10 +1952,6 @@
     "label": "runtimeLoop3",
     "kind": "variable",
     "detail": "runtimeLoop3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop3",
@@ -2190,10 +1966,6 @@
     "label": "runtimeLoop4",
     "kind": "variable",
     "detail": "runtimeLoop4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop4",
@@ -2208,10 +1980,6 @@
     "label": "runtimeLoop5",
     "kind": "variable",
     "detail": "runtimeLoop5",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_runtimeLoop5",
@@ -2247,10 +2015,6 @@
     "label": "something",
     "kind": "variable",
     "detail": "something",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_something",
@@ -2349,10 +2113,6 @@
     "label": "subName",
     "kind": "variable",
     "detail": "subName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_subName",
@@ -2367,10 +2127,6 @@
     "label": "subscription",
     "kind": "variable",
     "detail": "subscription",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_subscription",
@@ -2504,10 +2260,6 @@
     "label": "test",
     "kind": "variable",
     "detail": "test",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_test",
@@ -2522,10 +2274,6 @@
     "label": "test2",
     "kind": "variable",
     "detail": "test2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_test2",
@@ -2540,10 +2288,6 @@
     "label": "test3",
     "kind": "variable",
     "detail": "test3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_test3",
@@ -2558,10 +2302,6 @@
     "label": "testDupe",
     "kind": "variable",
     "detail": "testDupe",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_testDupe",
@@ -2765,10 +2505,6 @@
     "label": "x",
     "kind": "variable",
     "detail": "x",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_x",
@@ -2783,10 +2519,6 @@
     "label": "y",
     "kind": "variable",
     "detail": "y",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_y",
@@ -2801,10 +2533,6 @@
     "label": "zoneInput",
     "kind": "variable",
     "detail": "zoneInput",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_zoneInput",
@@ -2819,10 +2547,6 @@
     "label": "zones",
     "kind": "interface",
     "detail": "zones",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_zones",

--- a/src/Bicep.Core.Samples/Files/baselines/NestedResources_LF/Completions/childResources.json
+++ b/src/Bicep.Core.Samples/Files/baselines/NestedResources_LF/Completions/childResources.json
@@ -3,6 +3,10 @@
     "label": "basicChild",
     "kind": "interface",
     "detail": "basicChild",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_basicChild",
@@ -20,6 +24,10 @@
     "label": "basicSibling",
     "kind": "interface",
     "detail": "basicSibling",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_basicSibling",

--- a/src/Bicep.Core.Samples/Files/baselines/NestedResources_LF/Completions/childResources.json
+++ b/src/Bicep.Core.Samples/Files/baselines/NestedResources_LF/Completions/childResources.json
@@ -3,10 +3,6 @@
     "label": "basicChild",
     "kind": "interface",
     "detail": "basicChild",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_basicChild",
@@ -24,10 +20,6 @@
     "label": "basicSibling",
     "kind": "interface",
     "detail": "basicSibling",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_basicSibling",

--- a/src/Bicep.Core.Samples/Files/baselines/NestedResources_LF/Completions/grandChildResources.json
+++ b/src/Bicep.Core.Samples/Files/baselines/NestedResources_LF/Completions/grandChildResources.json
@@ -3,6 +3,10 @@
     "label": "basicGrandchild",
     "kind": "interface",
     "detail": "basicGrandchild",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_basicGrandchild",

--- a/src/Bicep.Core.Samples/Files/baselines/NestedResources_LF/Completions/grandChildResources.json
+++ b/src/Bicep.Core.Samples/Files/baselines/NestedResources_LF/Completions/grandChildResources.json
@@ -3,10 +3,6 @@
     "label": "basicGrandchild",
     "kind": "interface",
     "detail": "basicGrandchild",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_basicGrandchild",

--- a/src/Bicep.Core.Samples/Files/baselines/Variables_LF/Completions/symbolsPlusTypes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Variables_LF/Completions/symbolsPlusTypes.json
@@ -3,6 +3,10 @@
     "label": "I_WANT_IT_ALL",
     "kind": "variable",
     "detail": "I_WANT_IT_ALL",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_I_WANT_IT_ALL",
@@ -17,6 +21,10 @@
     "label": "_",
     "kind": "variable",
     "detail": "_",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2__",
@@ -31,6 +39,10 @@
     "label": "_0a_1b",
     "kind": "variable",
     "detail": "_0a_1b",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2__0a_1b",
@@ -45,6 +57,10 @@
     "label": "_1_",
     "kind": "variable",
     "detail": "_1_",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2__1_",
@@ -59,6 +75,10 @@
     "label": "__",
     "kind": "variable",
     "detail": "__",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2___",
@@ -73,6 +93,10 @@
     "label": "add",
     "kind": "variable",
     "detail": "add",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_add",
@@ -87,6 +111,10 @@
     "label": "and",
     "kind": "variable",
     "detail": "and",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_and",
@@ -102,7 +130,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nany(value: any): any\n\n```\nConverts the specified value to the `any` type.\n"
+      "value": "```bicep\nany(value: any): any\n\n```  \nConverts the specified value to the `any` type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -122,6 +150,10 @@
     "label": "anyIndexOnAny",
     "kind": "variable",
     "detail": "anyIndexOnAny",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyIndexOnAny",
@@ -137,7 +169,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\narray(valueToConvert: any): array\n\n```\nConverts the value to an array.\n"
+      "value": "```bicep\narray(valueToConvert: any): array\n\n```  \nConverts the value to an array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -157,6 +189,10 @@
     "label": "arrayOfArraysViaLoop",
     "kind": "variable",
     "detail": "arrayOfArraysViaLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayOfArraysViaLoop",
@@ -171,6 +207,10 @@
     "label": "arrayOfBooleans",
     "kind": "variable",
     "detail": "arrayOfBooleans",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayOfBooleans",
@@ -185,6 +225,10 @@
     "label": "arrayOfHardCodedBools",
     "kind": "variable",
     "detail": "arrayOfHardCodedBools",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayOfHardCodedBools",
@@ -199,6 +243,10 @@
     "label": "arrayOfHardCodedNumbers",
     "kind": "variable",
     "detail": "arrayOfHardCodedNumbers",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayOfHardCodedNumbers",
@@ -213,6 +261,10 @@
     "label": "arrayOfHardCodedStrings",
     "kind": "variable",
     "detail": "arrayOfHardCodedStrings",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayOfHardCodedStrings",
@@ -227,6 +279,10 @@
     "label": "arrayOfNonRuntimeFunctionCalls",
     "kind": "variable",
     "detail": "arrayOfNonRuntimeFunctionCalls",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayOfNonRuntimeFunctionCalls",
@@ -241,6 +297,10 @@
     "label": "arrayOfObjectsViaLoop",
     "kind": "variable",
     "detail": "arrayOfObjectsViaLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayOfObjectsViaLoop",
@@ -255,6 +315,10 @@
     "label": "arrayOfStringsViaLoop",
     "kind": "variable",
     "detail": "arrayOfStringsViaLoop",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayOfStringsViaLoop",
@@ -288,7 +352,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```\nReturns a resource group scope.\n"
+      "value": "```bicep\nresourceGroup(): resourceGroup\nresourceGroup(resourceGroupName: string): resourceGroup\nresourceGroup(subscriptionId: string, resourceGroupName: string): resourceGroup\n\n```  \nReturns a resource group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -309,7 +373,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64(inputString: string): string\n\n```\nReturns the base64 representation of the input string.\n"
+      "value": "```bicep\nbase64(inputString: string): string\n\n```  \nReturns the base64 representation of the input string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -330,7 +394,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```\nConverts a base64 representation to a JSON object.\n"
+      "value": "```bicep\nbase64ToJson(base64Value: string): any\n\n```  \nConverts a base64 representation to a JSON object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -351,7 +415,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```\nConverts a base64 representation to a string.\n"
+      "value": "```bicep\nbase64ToString(base64Value: string): string\n\n```  \nConverts a base64 representation to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -372,7 +436,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nbool(value: any): bool\n\n```\nConverts the parameter to a boolean.\n"
+      "value": "```bicep\nbool(value: any): bool\n\n```  \nConverts the parameter to a boolean.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -392,6 +456,10 @@
     "label": "bracketAtBeginning",
     "kind": "variable",
     "detail": "bracketAtBeginning",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bracketAtBeginning",
@@ -406,6 +474,10 @@
     "label": "bracketInTheMiddle",
     "kind": "variable",
     "detail": "bracketInTheMiddle",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bracketInTheMiddle",
@@ -420,6 +492,10 @@
     "label": "bracketStringInExpression",
     "kind": "variable",
     "detail": "bracketStringInExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bracketStringInExpression",
@@ -435,7 +511,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```\nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.\n"
+      "value": "```bicep\ncidrHost(network: string, hostIndex: int): string\n\n```  \nCalculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -456,7 +532,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```\nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.\n"
+      "value": "```bicep\ncidrSubnet(network: string, cidr: int, subnetIndex: int): string\n\n```  \nSplits the specified IP address range in CIDR notation into subnets with a new CIDR value and returns the IP address range of the subnet with the specified index.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -477,7 +553,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```\nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.\n"
+      "value": "```bicep\nconcat(... : array): array\nconcat(... : bool | int | string): string\n\n```  \nCombines multiple arrays and returns the concatenated array, or combines multiple string values and returns the concatenated string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -498,7 +574,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```\nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.\n"
+      "value": "```bicep\ncontains(object: object, propertyName: string): bool\ncontains(array: array, itemToFind: any): bool\ncontains(string: string, itemToFind: string): bool\n\n```  \nChecks whether an array contains a value, an object contains a key, or a string contains a substring. The string comparison is case-sensitive. However, when testing if an object contains a key, the comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -518,6 +594,10 @@
     "label": "copyBlockInObject",
     "kind": "variable",
     "detail": "copyBlockInObject",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_copyBlockInObject",
@@ -532,6 +612,10 @@
     "label": "createArray",
     "kind": "variable",
     "detail": "createArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_createArray",
@@ -546,6 +630,10 @@
     "label": "createObject",
     "kind": "variable",
     "detail": "createObject",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_createObject",
@@ -560,6 +648,10 @@
     "label": "curliesInInterp",
     "kind": "variable",
     "detail": "curliesInInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_curliesInInterp",
@@ -574,6 +666,10 @@
     "label": "curliesWithNoInterp",
     "kind": "variable",
     "detail": "curliesWithNoInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_curliesWithNoInterp",
@@ -589,7 +685,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```\nConverts a value to a data URI.\n"
+      "value": "```bicep\ndataUri(valueToConvert: any): string\n\n```  \nConverts a value to a data URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -610,7 +706,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```\nConverts a data URI formatted value to a string.\n"
+      "value": "```bicep\ndataUriToString(dataUriToConvert: string): string\n\n```  \nConverts a data URI formatted value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -631,7 +727,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```\nAdds a time duration to a base value. ISO 8601 format is expected.\n"
+      "value": "```bicep\ndateTimeAdd(base: string, duration: string, [format: string]): string\n\n```  \nAdds a time duration to a base value. ISO 8601 format is expected.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -652,7 +748,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```\nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.\n"
+      "value": "```bicep\ndateTimeFromEpoch([epochTime: int]): string\n\n```  \nConverts an epoch time integer value to an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -673,7 +769,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```\nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.\n"
+      "value": "```bicep\ndateTimeToEpoch([dateTime: string]): int\n\n```  \nConverts an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) dateTime string to an epoch time integer value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -694,7 +790,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployment(): deployment\n\n```\nReturns information about the current deployment operation.\n"
+      "value": "```bicep\ndeployment(): deployment\n\n```  \nReturns information about the current deployment operation.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -710,6 +806,10 @@
     "label": "deploymentName",
     "kind": "variable",
     "detail": "deploymentName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_deploymentName",
@@ -724,6 +824,10 @@
     "label": "div",
     "kind": "variable",
     "detail": "div",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_div",
@@ -738,6 +842,10 @@
     "label": "doubleInterp",
     "kind": "variable",
     "detail": "doubleInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_doubleInterp",
@@ -753,7 +861,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```\nDetermines if an array, object, or string is empty.\n"
+      "value": "```bicep\nempty(itemToTest: array | null | object | string): bool\n\n```  \nDetermines if an array, object, or string is empty.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -773,6 +881,10 @@
     "label": "emptyJsonArray",
     "kind": "variable",
     "detail": "emptyJsonArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyJsonArray",
@@ -788,7 +900,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string ends with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nendsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string ends with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -809,7 +921,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nenvironment(): environment\n\n```\nReturns information about the Azure environment used for deployment.\n"
+      "value": "```bicep\nenvironment(): environment\n\n```  \nReturns information about the Azure environment used for deployment.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -827,7 +939,7 @@
     "detail": "equals",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool"
+      "value": "Type: `bool`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -843,6 +955,10 @@
     "label": "expressionIndexOnAny",
     "kind": "variable",
     "detail": "expressionIndexOnAny",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionIndexOnAny",
@@ -858,7 +974,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```\nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.\n"
+      "value": "```bicep\nextensionResourceId(resourceId: string, resourceType: string, ... : string): string\n\n```  \nReturns the resource ID for an [extension](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/extension-resource-types) resource, which is a resource type that is applied to another resource to add to its capabilities.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -879,7 +995,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```\nFilters an array with a custom filtering function.\n"
+      "value": "```bicep\nfilter(array: array, predicate: any => bool): array\n\n```  \nFilters an array with a custom filtering function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -900,7 +1016,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```\nReturns the first element of the array, or first character of the string.\n"
+      "value": "```bicep\nfirst(array: array): any\nfirst(string: string): string\n\n```  \nReturns the first element of the array, or first character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -921,7 +1037,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nflatten(array: array[]): array\n\n```\nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.\n"
+      "value": "```bicep\nflatten(array: array[]): array\n\n```  \nTakes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -943,7 +1059,7 @@
     "detail": "for",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n[for item in list: ]\n```"
+      "value": "```bicep\n[for item in list: ]\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -961,7 +1077,7 @@
     "detail": "for-indexed",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\n[for (item, index) in list: ]\n```"
+      "value": "```bicep\n[for (item, index) in list: ]\n```  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -977,6 +1093,10 @@
     "label": "forceLineBreaks1",
     "kind": "variable",
     "detail": "forceLineBreaks1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_forceLineBreaks1",
@@ -991,6 +1111,10 @@
     "label": "forceLineBreaks2",
     "kind": "variable",
     "detail": "forceLineBreaks2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_forceLineBreaks2",
@@ -1005,6 +1129,10 @@
     "label": "forceLineBreaks3",
     "kind": "variable",
     "detail": "forceLineBreaks3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_forceLineBreaks3",
@@ -1020,7 +1148,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```\nCreates a formatted string from input values.\n"
+      "value": "```bicep\nformat(formatString: string, ... : any): string\n\n```  \nCreates a formatted string from input values.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1040,6 +1168,10 @@
     "label": "functionOnIndexer1",
     "kind": "variable",
     "detail": "functionOnIndexer1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_functionOnIndexer1",
@@ -1054,6 +1186,10 @@
     "label": "greater",
     "kind": "variable",
     "detail": "greater",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_greater",
@@ -1068,6 +1204,10 @@
     "label": "greaterOrEquals",
     "kind": "variable",
     "detail": "greaterOrEquals",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_greaterOrEquals",
@@ -1083,7 +1223,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nguid(... : string): string\n\n```\nCreates a value in the format of a globally unique identifier based on the values provided as parameters.\n"
+      "value": "```bicep\nguid(... : string): string\n\n```  \nCreates a value in the format of a globally unique identifier based on the values provided as parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1103,6 +1243,10 @@
     "label": "if",
     "kind": "variable",
     "detail": "if",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_if",
@@ -1131,6 +1275,10 @@
     "label": "incrementingNumbers",
     "kind": "variable",
     "detail": "incrementingNumbers",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incrementingNumbers",
@@ -1146,7 +1294,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```\nReturns the first position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nindexOf(stringToSearch: string, stringToFind: string): int\nindexOf(array: array, itemToFind: any): int\n\n```  \nReturns the first position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1167,7 +1315,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```\nConverts the specified value to an integer.\n"
+      "value": "```bicep\nint(valueToConvert: int | string): int\n\n```  \nConverts the specified value to an integer.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1187,6 +1335,10 @@
     "label": "intIndexer",
     "kind": "variable",
     "detail": "intIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_intIndexer",
@@ -1201,6 +1353,10 @@
     "label": "interp1",
     "kind": "variable",
     "detail": "interp1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interp1",
@@ -1215,6 +1371,10 @@
     "label": "interp2",
     "kind": "variable",
     "detail": "interp2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interp2",
@@ -1229,6 +1389,10 @@
     "label": "interp3",
     "kind": "variable",
     "detail": "interp3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interp3",
@@ -1243,6 +1407,10 @@
     "label": "interp4",
     "kind": "variable",
     "detail": "interp4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interp4",
@@ -1257,6 +1425,10 @@
     "label": "interpolatedBrackets",
     "kind": "variable",
     "detail": "interpolatedBrackets",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpolatedBrackets",
@@ -1272,7 +1444,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```\nReturns a single array or object with the common elements from the parameters.\n"
+      "value": "```bicep\nintersection(... : object): object\nintersection(... : array): array\n\n```  \nReturns a single array or object with the common elements from the parameters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1292,6 +1464,10 @@
     "label": "isFalse",
     "kind": "variable",
     "detail": "isFalse",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_isFalse",
@@ -1306,6 +1482,10 @@
     "label": "isPrefixed",
     "kind": "variable",
     "detail": "isPrefixed",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_isPrefixed",
@@ -1320,6 +1500,10 @@
     "label": "isTrue",
     "kind": "variable",
     "detail": "isTrue",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_isTrue",
@@ -1334,6 +1518,10 @@
     "label": "issue1332",
     "kind": "variable",
     "detail": "issue1332",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue1332",
@@ -1348,6 +1536,10 @@
     "label": "issue1332_propname",
     "kind": "variable",
     "detail": "issue1332_propname",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue1332_propname",
@@ -1363,7 +1555,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nitems(object: object): object[]\n\n```\nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.\n"
+      "value": "```bicep\nitems(object: object): object[]\n\n```  \nReturns an array of keys and values for an object. Elements are consistently ordered alphabetically by key.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1384,7 +1576,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```\nJoins multiple strings into a single string, separated using a delimiter.\n"
+      "value": "```bicep\njoin(inputArray: (bool | int | string)[], delimiter: string): string\n\n```  \nJoins multiple strings into a single string, separated using a delimiter.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1404,6 +1596,10 @@
     "label": "joinedString",
     "kind": "variable",
     "detail": "joinedString",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_joinedString",
@@ -1419,7 +1615,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\njson(json: string): any\n\n```\nConverts a valid JSON string into a JSON data type.\n"
+      "value": "```bicep\njson(json: string): any\n\n```  \nConverts a valid JSON string into a JSON data type.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1440,7 +1636,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```\nReturns the last element of the array, or last character of the string.\n"
+      "value": "```bicep\nlast(array: array): any\nlast(string: string): string\n\n```  \nReturns the last element of the array, or last character of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1461,7 +1657,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```\nReturns the last position of a value within a string. The comparison is case-insensitive.\n"
+      "value": "```bicep\nlastIndexOf(stringToSearch: string, stringToFind: string): int\nlastIndexOf(array: array, itemToFind: any): int\n\n```  \nReturns the last position of a value within a string. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1482,7 +1678,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```\nReturns the number of characters in a string, elements in an array, or root-level properties in an object.\n"
+      "value": "```bicep\nlength(arg: object | string): int\nlength(arg: array): int\n\n```  \nReturns the number of characters in a string, elements in an array, or root-level properties in an object.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1502,6 +1698,10 @@
     "label": "less",
     "kind": "variable",
     "detail": "less",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_less",
@@ -1516,6 +1716,10 @@
     "label": "lessOrEquals",
     "kind": "variable",
     "detail": "lessOrEquals",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_lessOrEquals",
@@ -1531,7 +1735,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```\nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.\n"
+      "value": "```bicep\nloadFileAsBase64(filePath: string): string\n\n```  \nLoads the specified file as base64 string. File loading occurs during compilation, not at runtime. The maximum allowed size is 96 Kb.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1552,7 +1756,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadJsonContent(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified JSON file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1573,7 +1777,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```\nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).\n"
+      "value": "```bicep\nloadTextContent(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string\n\n```  \nLoads the content of the specified file into a string. Content loading occurs during compilation, not at runtime. The maximum allowed content size is 131072 characters (including line endings).  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1594,7 +1798,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```\nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.\n"
+      "value": "```bicep\nloadYamlContent(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any\n\n```  \nLoads the specified YAML file as bicep object. File loading occurs during compilation, not at runtime.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1614,6 +1818,10 @@
     "label": "loginEndpoint",
     "kind": "variable",
     "detail": "loginEndpoint",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loginEndpoint",
@@ -1628,6 +1836,10 @@
     "label": "loopInput",
     "kind": "variable",
     "detail": "loopInput",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopInput",
@@ -1643,7 +1855,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```\nReturns a management group scope.\n"
+      "value": "```bicep\nmanagementGroup(name: string): managementGroup\n\n```  \nReturns a management group scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1664,7 +1876,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the management group level.\n"
+      "value": "```bicep\nmanagementGroupResourceId(resourceType: string, ... : string): string\nmanagementGroupResourceId(managementGroupId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the management group level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1685,7 +1897,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```\nApplies a custom mapping function to each element of an array and returns the result array.\n"
+      "value": "```bicep\nmap(array: array, predicate: any => any): array\n\n```  \nApplies a custom mapping function to each element of an array and returns the result array.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1706,7 +1918,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```\nReturns the maximum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmax(... : int): int\nmax(intArray: int[]): int\n\n```  \nReturns the maximum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1727,7 +1939,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```\nReturns the minimum value from an array of integers or a comma-separated list of integers.\n"
+      "value": "```bicep\nmin(... : int): int\nmin(intArray: int[]): int\n\n```  \nReturns the minimum value from an array of integers or a comma-separated list of integers.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1749,7 +1961,7 @@
     "detail": "mod",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool"
+      "value": "Type: `bool`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -1765,6 +1977,10 @@
     "label": "mul",
     "kind": "variable",
     "detail": "mul",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mul",
@@ -1779,6 +1995,10 @@
     "label": "multilineEmpty",
     "kind": "variable",
     "detail": "multilineEmpty",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_multilineEmpty",
@@ -1793,6 +2013,10 @@
     "label": "multilineEmptyNewline",
     "kind": "variable",
     "detail": "multilineEmptyNewline",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_multilineEmptyNewline",
@@ -1807,6 +2031,10 @@
     "label": "multilineExtraQuotes",
     "kind": "variable",
     "detail": "multilineExtraQuotes",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_multilineExtraQuotes",
@@ -1821,6 +2049,10 @@
     "label": "multilineExtraQuotesNewlines",
     "kind": "variable",
     "detail": "multilineExtraQuotesNewlines",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_multilineExtraQuotesNewlines",
@@ -1835,6 +2067,10 @@
     "label": "multilineFormatted",
     "kind": "variable",
     "detail": "multilineFormatted",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_multilineFormatted",
@@ -1849,6 +2085,10 @@
     "label": "multilineJavaScript",
     "kind": "variable",
     "detail": "multilineJavaScript",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_multilineJavaScript",
@@ -1863,6 +2103,10 @@
     "label": "multilineSingleLine",
     "kind": "variable",
     "detail": "multilineSingleLine",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_multilineSingleLine",
@@ -1877,6 +2121,10 @@
     "label": "multilineString",
     "kind": "variable",
     "detail": "multilineString",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_multilineString",
@@ -1891,6 +2139,10 @@
     "label": "myArr",
     "kind": "variable",
     "detail": "myArr",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myArr",
@@ -1905,6 +2157,10 @@
     "label": "myArrWithObjects",
     "kind": "variable",
     "detail": "myArrWithObjects",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myArrWithObjects",
@@ -1919,6 +2175,10 @@
     "label": "myBigInt",
     "kind": "variable",
     "detail": "myBigInt",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myBigInt",
@@ -1933,6 +2193,10 @@
     "label": "myBigIntExpression",
     "kind": "variable",
     "detail": "myBigIntExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myBigIntExpression",
@@ -1947,6 +2211,10 @@
     "label": "myBigIntExpression2",
     "kind": "variable",
     "detail": "myBigIntExpression2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myBigIntExpression2",
@@ -1961,6 +2229,10 @@
     "label": "myEmptyArray",
     "kind": "variable",
     "detail": "myEmptyArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myEmptyArray",
@@ -1975,6 +2247,10 @@
     "label": "myEmptyObj",
     "kind": "variable",
     "detail": "myEmptyObj",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myEmptyObj",
@@ -1989,6 +2265,10 @@
     "label": "myFalsehood",
     "kind": "variable",
     "detail": "myFalsehood",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myFalsehood",
@@ -2005,7 +2285,7 @@
     "detail": "myInt",
     "documentation": {
       "kind": "markdown",
-      "value": "an int variable"
+      "value": "an int variable  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2021,6 +2301,10 @@
     "label": "myIntExpression",
     "kind": "variable",
     "detail": "myIntExpression",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myIntExpression",
@@ -2037,7 +2321,7 @@
     "detail": "myObj",
     "documentation": {
       "kind": "markdown",
-      "value": "a object variable"
+      "value": "a object variable  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2053,6 +2337,10 @@
     "label": "myPropertyName",
     "kind": "variable",
     "detail": "myPropertyName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myPropertyName",
@@ -2069,7 +2357,7 @@
     "detail": "myStr",
     "documentation": {
       "kind": "markdown",
-      "value": "a string variable"
+      "value": "a string variable  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2087,7 +2375,7 @@
     "detail": "myTruth",
     "documentation": {
       "kind": "markdown",
-      "value": "a bool variable"
+      "value": "a bool variable  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2103,6 +2391,10 @@
     "label": "myVar",
     "kind": "variable",
     "detail": "myVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myVar",
@@ -2117,6 +2409,10 @@
     "label": "myVar2",
     "kind": "variable",
     "detail": "myVar2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myVar2",
@@ -2131,6 +2427,10 @@
     "label": "myVar3",
     "kind": "variable",
     "detail": "myVar3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myVar3",
@@ -2145,6 +2445,10 @@
     "label": "myVar4",
     "kind": "variable",
     "detail": "myVar4",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myVar4",
@@ -2159,6 +2463,10 @@
     "label": "namedPropertyIndexer",
     "kind": "variable",
     "detail": "namedPropertyIndexer",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_namedPropertyIndexer",
@@ -2173,6 +2481,10 @@
     "label": "nestedBrackets",
     "kind": "variable",
     "detail": "nestedBrackets",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedBrackets",
@@ -2187,6 +2499,10 @@
     "label": "nestedInterpolatedBrackets",
     "kind": "variable",
     "detail": "nestedInterpolatedBrackets",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedInterpolatedBrackets",
@@ -2201,6 +2517,10 @@
     "label": "not",
     "kind": "variable",
     "detail": "not",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_not",
@@ -2217,7 +2537,7 @@
     "detail": "objWithInterp",
     "documentation": {
       "kind": "markdown",
-      "value": "a object with interp"
+      "value": "a object with interp  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2233,6 +2553,10 @@
     "label": "or",
     "kind": "variable",
     "detail": "or",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_or",
@@ -2248,7 +2572,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```\nReturns a right-aligned string by adding characters to the left until reaching the total specified length.\n"
+      "value": "```bicep\npadLeft(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string\n\n```  \nReturns a right-aligned string by adding characters to the left until reaching the total specified length.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2270,7 +2594,7 @@
     "detail": "parameters",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool"
+      "value": "Type: `bool`  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2287,7 +2611,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```\nParses an IP address range in CIDR notation to get various properties of the address range.\n"
+      "value": "```bicep\nparseCidr(network: string): parseCidr\n\n```  \nParses an IP address range in CIDR notation to get various properties of the address range.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2308,7 +2632,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```\nDetermines whether a resource type supports zones for a region.\n"
+      "value": "```bicep\npickZones(providerNamespace: string, resourceType: string, location: string, [numberOfZones: int], [offset: int]): array\n\n```  \nDetermines whether a resource type supports zones for a region.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2328,6 +2652,10 @@
     "label": "portalEndpoint",
     "kind": "variable",
     "detail": "portalEndpoint",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_portalEndpoint",
@@ -2342,6 +2670,10 @@
     "label": "prefix",
     "kind": "variable",
     "detail": "prefix",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_prefix",
@@ -2356,6 +2688,10 @@
     "label": "previousEmitLimit",
     "kind": "variable",
     "detail": "previousEmitLimit",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_previousEmitLimit",
@@ -2370,6 +2706,10 @@
     "label": "previousEmitLimit2",
     "kind": "variable",
     "detail": "previousEmitLimit2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_previousEmitLimit2",
@@ -2384,6 +2724,10 @@
     "label": "previousEmitLimit3",
     "kind": "variable",
     "detail": "previousEmitLimit3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_previousEmitLimit3",
@@ -2398,6 +2742,10 @@
     "label": "printToSingleLine1",
     "kind": "variable",
     "detail": "printToSingleLine1",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_printToSingleLine1",
@@ -2412,6 +2760,10 @@
     "label": "printToSingleLine2",
     "kind": "variable",
     "detail": "printToSingleLine2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_printToSingleLine2",
@@ -2426,6 +2778,10 @@
     "label": "printToSingleLine3",
     "kind": "variable",
     "detail": "printToSingleLine3",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_printToSingleLine3",
@@ -2440,6 +2796,10 @@
     "label": "propertyAccessFromObject",
     "kind": "variable",
     "detail": "propertyAccessFromObject",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyAccessFromObject",
@@ -2455,7 +2815,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```\nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.\n"
+      "value": "```bicep\nproviders(providerNamespace: string): Provider\nproviders(providerNamespace: string, resourceType: string): ProviderResource\n\n```  \nReturns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2475,6 +2835,10 @@
     "label": "providersTest",
     "kind": "variable",
     "detail": "providersTest",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_providersTest",
@@ -2489,6 +2853,10 @@
     "label": "providersTest2",
     "kind": "variable",
     "detail": "providersTest2",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_providersTest2",
@@ -2504,7 +2872,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```\nCreates an array of integers from a starting integer and containing a number of items.\n"
+      "value": "```bicep\nrange(startIndex: int, count: int): int[]\n\n```  \nCreates an array of integers from a starting integer and containing a number of items.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2525,7 +2893,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```\nReduces an array with a custom reduce function.\n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2546,7 +2914,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```\nReturns an object representing a resource's runtime state.\n"
+      "value": "```bicep\nreference(resourceNameOrIdentifier: string, [apiVersion: string], [full: string]): object\n\n```  \nReturns an object representing a resource's runtime state.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2567,7 +2935,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```\nReturns a new string with all instances of one string replaced by another string.\n"
+      "value": "```bicep\nreplace(originalString: string, oldString: string, newString: string): string\n\n```  \nReturns a new string with all instances of one string replaced by another string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2587,6 +2955,10 @@
     "label": "resourceGroup",
     "kind": "variable",
     "detail": "resourceGroup",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceGroup",
@@ -2601,6 +2973,10 @@
     "label": "resourceGroupName",
     "kind": "variable",
     "detail": "resourceGroupName",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceGroupName",
@@ -2615,6 +2991,10 @@
     "label": "resourceGroupObject",
     "kind": "variable",
     "detail": "resourceGroupObject",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceGroupObject",
@@ -2630,7 +3010,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.\n"
+      "value": "```bicep\nresourceId(resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceType: string, ... : string): string\nresourceId(resourceGroupName: string, resourceType: string, ... : string): string\nresourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2650,6 +3030,10 @@
     "label": "scopesWithArmRepresentation",
     "kind": "variable",
     "detail": "scopesWithArmRepresentation",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_scopesWithArmRepresentation",
@@ -2664,6 +3048,10 @@
     "label": "scopesWithoutArmRepresentation",
     "kind": "variable",
     "detail": "scopesWithoutArmRepresentation",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_scopesWithoutArmRepresentation",
@@ -2678,6 +3066,10 @@
     "label": "singleQuote",
     "kind": "variable",
     "detail": "singleQuote",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleQuote",
@@ -2693,7 +3085,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```\nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.\n"
+      "value": "```bicep\nskip(originalValue: array, numberToSkip: int): array\nskip(originalValue: string, numberToSkip: int): string\n\n```  \nReturns a string with all the characters after the specified number of characters, or an array with all the elements after the specified number of elements.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2713,6 +3105,10 @@
     "label": "someText",
     "kind": "variable",
     "detail": "someText",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_someText",
@@ -2728,7 +3124,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```\nSorts an array with a custom sort function.\n"
+      "value": "```bicep\nsort(array: array, predicate: (any, any) => bool): array\n\n```  \nSorts an array with a custom sort function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2749,7 +3145,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```\nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.\n"
+      "value": "```bicep\nsplit(inputString: string, delimiter: array | string): string[]\n\n```  \nReturns an array of strings that contains the substrings of the input string that are delimited by the specified delimiters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2770,7 +3166,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```\nDetermines whether a string starts with a value. The comparison is case-insensitive.\n"
+      "value": "```bicep\nstartsWith(stringToSearch: string, stringToFind: string): bool\n\n```  \nDetermines whether a string starts with a value. The comparison is case-insensitive.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2791,7 +3187,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nstring(valueToConvert: any): string\n\n```\nConverts the specified value to a string.\n"
+      "value": "```bicep\nstring(valueToConvert: any): string\n\n```  \nConverts the specified value to a string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2811,6 +3207,10 @@
     "label": "sub",
     "kind": "variable",
     "detail": "sub",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sub",
@@ -2826,7 +3226,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```\nReturns a subscription scope.\n"
+      "value": "```bicep\nsubscription(): subscription\nsubscription(subscriptionId: string): subscription\n\n```  \nReturns a subscription scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2847,7 +3247,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the subscription level.\n"
+      "value": "```bicep\nsubscriptionResourceId(resourceType: string, ... : string): string\nsubscriptionResourceId(subscriptionId: string, resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the subscription level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2868,7 +3268,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```\nReturns a substring that starts at the specified character position and contains the specified number of characters.\n"
+      "value": "```bicep\nsubstring(stringToParse: string, startIndex: int, [length: int]): string\n\n```  \nReturns a substring that starts at the specified character position and contains the specified number of characters.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2907,7 +3307,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```\nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.\n"
+      "value": "```bicep\ntake(originalValue: array, numberToTake: int): array\ntake(originalValue: string, numberToTake: int): string\n\n```  \nReturns an array or string. An array has the specified number of elements from the start of the array. A string has the specified number of characters from the start of the string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2927,6 +3327,10 @@
     "label": "templateContentVersion",
     "kind": "variable",
     "detail": "templateContentVersion",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_templateContentVersion",
@@ -2941,6 +3345,10 @@
     "label": "templateLinkId",
     "kind": "variable",
     "detail": "templateLinkId",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_templateLinkId",
@@ -2955,6 +3363,10 @@
     "label": "templateLinkUri",
     "kind": "variable",
     "detail": "templateLinkUri",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_templateLinkUri",
@@ -2970,7 +3382,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenant(): tenant\n\n```\nReturns the current tenant scope.\n"
+      "value": "```bicep\ntenant(): tenant\n\n```  \nReturns the current tenant scope.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -2987,7 +3399,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```\nReturns the unique identifier for a resource deployed at the tenant level.\n"
+      "value": "```bicep\ntenantResourceId(resourceType: string, ... : string): string\n\n```  \nReturns the unique identifier for a resource deployed at the tenant level.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3008,7 +3420,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```\nConverts the specified string to lower case.\n"
+      "value": "```bicep\ntoLower(stringToChange: string): string\n\n```  \nConverts the specified string to lower case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3029,7 +3441,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```\nConverts an array to an object with a custom key function and optional custom value function.\n"
+      "value": "```bicep\ntoObject(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object\n\n```  \nConverts an array to an object with a custom key function and optional custom value function.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3050,7 +3462,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```\nConverts the specified string to upper case.\n"
+      "value": "```bicep\ntoUpper(stringToChange: string): string\n\n```  \nConverts the specified string to upper case.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3071,7 +3483,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```\nRemoves all leading and trailing white-space characters from the specified string.\n"
+      "value": "```bicep\ntrim(stringToTrim: string): string\n\n```  \nRemoves all leading and trailing white-space characters from the specified string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3092,7 +3504,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```\nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.\n"
+      "value": "```bicep\nunion(... : object): object\nunion(... : array): array\n\n```  \nReturns a single array or object with all elements from the parameters. Duplicate values or keys are only included once.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3113,7 +3525,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuniqueString(... : string): string\n\n```\nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.\n"
+      "value": "```bicep\nuniqueString(... : string): string\n\n```  \nCreates a deterministic hash string based on the values provided as parameters. The returned value is 13 characters long.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3133,6 +3545,10 @@
     "label": "unusedIntermediate",
     "kind": "variable",
     "detail": "unusedIntermediate",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unusedIntermediate",
@@ -3147,6 +3563,10 @@
     "label": "unusedIntermediateRef",
     "kind": "variable",
     "detail": "unusedIntermediateRef",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unusedIntermediateRef",
@@ -3162,7 +3582,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```\nCreates an absolute URI by combining the baseUri and the relativeUri string.\n"
+      "value": "```bicep\nuri(baseUri: string, relativeUri: string): string\n\n```  \nCreates an absolute URI by combining the baseUri and the relativeUri string.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3183,7 +3603,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```\nEncodes a URI.\n"
+      "value": "```bicep\nuriComponent(stringToEncode: string): string\n\n```  \nEncodes a URI.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3204,7 +3624,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```\nReturns a string of a URI encoded value.\n"
+      "value": "```bicep\nuriComponentToString(uriEncodedString: string): string\n\n```  \nReturns a string of a URI encoded value.  \n"
     },
     "deprecated": false,
     "preselect": false,
@@ -3224,6 +3644,10 @@
     "label": "variables",
     "kind": "variable",
     "detail": "variables",
+    "documentation": {
+      "kind": "markdown",
+      "value": ""
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_variables",

--- a/src/Bicep.Core.Samples/Files/baselines/Variables_LF/Completions/symbolsPlusTypes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Variables_LF/Completions/symbolsPlusTypes.json
@@ -3,10 +3,6 @@
     "label": "I_WANT_IT_ALL",
     "kind": "variable",
     "detail": "I_WANT_IT_ALL",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_I_WANT_IT_ALL",
@@ -21,10 +17,6 @@
     "label": "_",
     "kind": "variable",
     "detail": "_",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2__",
@@ -39,10 +31,6 @@
     "label": "_0a_1b",
     "kind": "variable",
     "detail": "_0a_1b",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2__0a_1b",
@@ -57,10 +45,6 @@
     "label": "_1_",
     "kind": "variable",
     "detail": "_1_",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2__1_",
@@ -75,10 +59,6 @@
     "label": "__",
     "kind": "variable",
     "detail": "__",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2___",
@@ -93,10 +73,6 @@
     "label": "add",
     "kind": "variable",
     "detail": "add",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_add",
@@ -111,10 +87,6 @@
     "label": "and",
     "kind": "variable",
     "detail": "and",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_and",
@@ -150,10 +122,6 @@
     "label": "anyIndexOnAny",
     "kind": "variable",
     "detail": "anyIndexOnAny",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_anyIndexOnAny",
@@ -189,10 +157,6 @@
     "label": "arrayOfArraysViaLoop",
     "kind": "variable",
     "detail": "arrayOfArraysViaLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayOfArraysViaLoop",
@@ -207,10 +171,6 @@
     "label": "arrayOfBooleans",
     "kind": "variable",
     "detail": "arrayOfBooleans",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayOfBooleans",
@@ -225,10 +185,6 @@
     "label": "arrayOfHardCodedBools",
     "kind": "variable",
     "detail": "arrayOfHardCodedBools",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayOfHardCodedBools",
@@ -243,10 +199,6 @@
     "label": "arrayOfHardCodedNumbers",
     "kind": "variable",
     "detail": "arrayOfHardCodedNumbers",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayOfHardCodedNumbers",
@@ -261,10 +213,6 @@
     "label": "arrayOfHardCodedStrings",
     "kind": "variable",
     "detail": "arrayOfHardCodedStrings",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayOfHardCodedStrings",
@@ -279,10 +227,6 @@
     "label": "arrayOfNonRuntimeFunctionCalls",
     "kind": "variable",
     "detail": "arrayOfNonRuntimeFunctionCalls",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayOfNonRuntimeFunctionCalls",
@@ -297,10 +241,6 @@
     "label": "arrayOfObjectsViaLoop",
     "kind": "variable",
     "detail": "arrayOfObjectsViaLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayOfObjectsViaLoop",
@@ -315,10 +255,6 @@
     "label": "arrayOfStringsViaLoop",
     "kind": "variable",
     "detail": "arrayOfStringsViaLoop",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayOfStringsViaLoop",
@@ -456,10 +392,6 @@
     "label": "bracketAtBeginning",
     "kind": "variable",
     "detail": "bracketAtBeginning",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bracketAtBeginning",
@@ -474,10 +406,6 @@
     "label": "bracketInTheMiddle",
     "kind": "variable",
     "detail": "bracketInTheMiddle",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bracketInTheMiddle",
@@ -492,10 +420,6 @@
     "label": "bracketStringInExpression",
     "kind": "variable",
     "detail": "bracketStringInExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_bracketStringInExpression",
@@ -594,10 +518,6 @@
     "label": "copyBlockInObject",
     "kind": "variable",
     "detail": "copyBlockInObject",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_copyBlockInObject",
@@ -612,10 +532,6 @@
     "label": "createArray",
     "kind": "variable",
     "detail": "createArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_createArray",
@@ -630,10 +546,6 @@
     "label": "createObject",
     "kind": "variable",
     "detail": "createObject",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_createObject",
@@ -648,10 +560,6 @@
     "label": "curliesInInterp",
     "kind": "variable",
     "detail": "curliesInInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_curliesInInterp",
@@ -666,10 +574,6 @@
     "label": "curliesWithNoInterp",
     "kind": "variable",
     "detail": "curliesWithNoInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_curliesWithNoInterp",
@@ -806,10 +710,6 @@
     "label": "deploymentName",
     "kind": "variable",
     "detail": "deploymentName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_deploymentName",
@@ -824,10 +724,6 @@
     "label": "div",
     "kind": "variable",
     "detail": "div",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_div",
@@ -842,10 +738,6 @@
     "label": "doubleInterp",
     "kind": "variable",
     "detail": "doubleInterp",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_doubleInterp",
@@ -881,10 +773,6 @@
     "label": "emptyJsonArray",
     "kind": "variable",
     "detail": "emptyJsonArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyJsonArray",
@@ -955,10 +843,6 @@
     "label": "expressionIndexOnAny",
     "kind": "variable",
     "detail": "expressionIndexOnAny",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionIndexOnAny",
@@ -1093,10 +977,6 @@
     "label": "forceLineBreaks1",
     "kind": "variable",
     "detail": "forceLineBreaks1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_forceLineBreaks1",
@@ -1111,10 +991,6 @@
     "label": "forceLineBreaks2",
     "kind": "variable",
     "detail": "forceLineBreaks2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_forceLineBreaks2",
@@ -1129,10 +1005,6 @@
     "label": "forceLineBreaks3",
     "kind": "variable",
     "detail": "forceLineBreaks3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_forceLineBreaks3",
@@ -1168,10 +1040,6 @@
     "label": "functionOnIndexer1",
     "kind": "variable",
     "detail": "functionOnIndexer1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_functionOnIndexer1",
@@ -1186,10 +1054,6 @@
     "label": "greater",
     "kind": "variable",
     "detail": "greater",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_greater",
@@ -1204,10 +1068,6 @@
     "label": "greaterOrEquals",
     "kind": "variable",
     "detail": "greaterOrEquals",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_greaterOrEquals",
@@ -1243,10 +1103,6 @@
     "label": "if",
     "kind": "variable",
     "detail": "if",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_if",
@@ -1275,10 +1131,6 @@
     "label": "incrementingNumbers",
     "kind": "variable",
     "detail": "incrementingNumbers",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incrementingNumbers",
@@ -1335,10 +1187,6 @@
     "label": "intIndexer",
     "kind": "variable",
     "detail": "intIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_intIndexer",
@@ -1353,10 +1201,6 @@
     "label": "interp1",
     "kind": "variable",
     "detail": "interp1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interp1",
@@ -1371,10 +1215,6 @@
     "label": "interp2",
     "kind": "variable",
     "detail": "interp2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interp2",
@@ -1389,10 +1229,6 @@
     "label": "interp3",
     "kind": "variable",
     "detail": "interp3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interp3",
@@ -1407,10 +1243,6 @@
     "label": "interp4",
     "kind": "variable",
     "detail": "interp4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interp4",
@@ -1425,10 +1257,6 @@
     "label": "interpolatedBrackets",
     "kind": "variable",
     "detail": "interpolatedBrackets",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_interpolatedBrackets",
@@ -1464,10 +1292,6 @@
     "label": "isFalse",
     "kind": "variable",
     "detail": "isFalse",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_isFalse",
@@ -1482,10 +1306,6 @@
     "label": "isPrefixed",
     "kind": "variable",
     "detail": "isPrefixed",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_isPrefixed",
@@ -1500,10 +1320,6 @@
     "label": "isTrue",
     "kind": "variable",
     "detail": "isTrue",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_isTrue",
@@ -1518,10 +1334,6 @@
     "label": "issue1332",
     "kind": "variable",
     "detail": "issue1332",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue1332",
@@ -1536,10 +1348,6 @@
     "label": "issue1332_propname",
     "kind": "variable",
     "detail": "issue1332_propname",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue1332_propname",
@@ -1596,10 +1404,6 @@
     "label": "joinedString",
     "kind": "variable",
     "detail": "joinedString",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_joinedString",
@@ -1698,10 +1502,6 @@
     "label": "less",
     "kind": "variable",
     "detail": "less",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_less",
@@ -1716,10 +1516,6 @@
     "label": "lessOrEquals",
     "kind": "variable",
     "detail": "lessOrEquals",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_lessOrEquals",
@@ -1818,10 +1614,6 @@
     "label": "loginEndpoint",
     "kind": "variable",
     "detail": "loginEndpoint",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loginEndpoint",
@@ -1836,10 +1628,6 @@
     "label": "loopInput",
     "kind": "variable",
     "detail": "loopInput",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_loopInput",
@@ -1977,10 +1765,6 @@
     "label": "mul",
     "kind": "variable",
     "detail": "mul",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mul",
@@ -1995,10 +1779,6 @@
     "label": "multilineEmpty",
     "kind": "variable",
     "detail": "multilineEmpty",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_multilineEmpty",
@@ -2013,10 +1793,6 @@
     "label": "multilineEmptyNewline",
     "kind": "variable",
     "detail": "multilineEmptyNewline",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_multilineEmptyNewline",
@@ -2031,10 +1807,6 @@
     "label": "multilineExtraQuotes",
     "kind": "variable",
     "detail": "multilineExtraQuotes",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_multilineExtraQuotes",
@@ -2049,10 +1821,6 @@
     "label": "multilineExtraQuotesNewlines",
     "kind": "variable",
     "detail": "multilineExtraQuotesNewlines",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_multilineExtraQuotesNewlines",
@@ -2067,10 +1835,6 @@
     "label": "multilineFormatted",
     "kind": "variable",
     "detail": "multilineFormatted",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_multilineFormatted",
@@ -2085,10 +1849,6 @@
     "label": "multilineJavaScript",
     "kind": "variable",
     "detail": "multilineJavaScript",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_multilineJavaScript",
@@ -2103,10 +1863,6 @@
     "label": "multilineSingleLine",
     "kind": "variable",
     "detail": "multilineSingleLine",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_multilineSingleLine",
@@ -2121,10 +1877,6 @@
     "label": "multilineString",
     "kind": "variable",
     "detail": "multilineString",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_multilineString",
@@ -2139,10 +1891,6 @@
     "label": "myArr",
     "kind": "variable",
     "detail": "myArr",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myArr",
@@ -2157,10 +1905,6 @@
     "label": "myArrWithObjects",
     "kind": "variable",
     "detail": "myArrWithObjects",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myArrWithObjects",
@@ -2175,10 +1919,6 @@
     "label": "myBigInt",
     "kind": "variable",
     "detail": "myBigInt",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myBigInt",
@@ -2193,10 +1933,6 @@
     "label": "myBigIntExpression",
     "kind": "variable",
     "detail": "myBigIntExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myBigIntExpression",
@@ -2211,10 +1947,6 @@
     "label": "myBigIntExpression2",
     "kind": "variable",
     "detail": "myBigIntExpression2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myBigIntExpression2",
@@ -2229,10 +1961,6 @@
     "label": "myEmptyArray",
     "kind": "variable",
     "detail": "myEmptyArray",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myEmptyArray",
@@ -2247,10 +1975,6 @@
     "label": "myEmptyObj",
     "kind": "variable",
     "detail": "myEmptyObj",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myEmptyObj",
@@ -2265,10 +1989,6 @@
     "label": "myFalsehood",
     "kind": "variable",
     "detail": "myFalsehood",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myFalsehood",
@@ -2301,10 +2021,6 @@
     "label": "myIntExpression",
     "kind": "variable",
     "detail": "myIntExpression",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myIntExpression",
@@ -2337,10 +2053,6 @@
     "label": "myPropertyName",
     "kind": "variable",
     "detail": "myPropertyName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myPropertyName",
@@ -2391,10 +2103,6 @@
     "label": "myVar",
     "kind": "variable",
     "detail": "myVar",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myVar",
@@ -2409,10 +2117,6 @@
     "label": "myVar2",
     "kind": "variable",
     "detail": "myVar2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myVar2",
@@ -2427,10 +2131,6 @@
     "label": "myVar3",
     "kind": "variable",
     "detail": "myVar3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myVar3",
@@ -2445,10 +2145,6 @@
     "label": "myVar4",
     "kind": "variable",
     "detail": "myVar4",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myVar4",
@@ -2463,10 +2159,6 @@
     "label": "namedPropertyIndexer",
     "kind": "variable",
     "detail": "namedPropertyIndexer",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_namedPropertyIndexer",
@@ -2481,10 +2173,6 @@
     "label": "nestedBrackets",
     "kind": "variable",
     "detail": "nestedBrackets",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedBrackets",
@@ -2499,10 +2187,6 @@
     "label": "nestedInterpolatedBrackets",
     "kind": "variable",
     "detail": "nestedInterpolatedBrackets",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nestedInterpolatedBrackets",
@@ -2517,10 +2201,6 @@
     "label": "not",
     "kind": "variable",
     "detail": "not",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_not",
@@ -2553,10 +2233,6 @@
     "label": "or",
     "kind": "variable",
     "detail": "or",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_or",
@@ -2652,10 +2328,6 @@
     "label": "portalEndpoint",
     "kind": "variable",
     "detail": "portalEndpoint",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_portalEndpoint",
@@ -2670,10 +2342,6 @@
     "label": "prefix",
     "kind": "variable",
     "detail": "prefix",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_prefix",
@@ -2688,10 +2356,6 @@
     "label": "previousEmitLimit",
     "kind": "variable",
     "detail": "previousEmitLimit",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_previousEmitLimit",
@@ -2706,10 +2370,6 @@
     "label": "previousEmitLimit2",
     "kind": "variable",
     "detail": "previousEmitLimit2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_previousEmitLimit2",
@@ -2724,10 +2384,6 @@
     "label": "previousEmitLimit3",
     "kind": "variable",
     "detail": "previousEmitLimit3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_previousEmitLimit3",
@@ -2742,10 +2398,6 @@
     "label": "printToSingleLine1",
     "kind": "variable",
     "detail": "printToSingleLine1",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_printToSingleLine1",
@@ -2760,10 +2412,6 @@
     "label": "printToSingleLine2",
     "kind": "variable",
     "detail": "printToSingleLine2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_printToSingleLine2",
@@ -2778,10 +2426,6 @@
     "label": "printToSingleLine3",
     "kind": "variable",
     "detail": "printToSingleLine3",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_printToSingleLine3",
@@ -2796,10 +2440,6 @@
     "label": "propertyAccessFromObject",
     "kind": "variable",
     "detail": "propertyAccessFromObject",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_propertyAccessFromObject",
@@ -2835,10 +2475,6 @@
     "label": "providersTest",
     "kind": "variable",
     "detail": "providersTest",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_providersTest",
@@ -2853,10 +2489,6 @@
     "label": "providersTest2",
     "kind": "variable",
     "detail": "providersTest2",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_providersTest2",
@@ -2955,10 +2587,6 @@
     "label": "resourceGroup",
     "kind": "variable",
     "detail": "resourceGroup",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceGroup",
@@ -2973,10 +2601,6 @@
     "label": "resourceGroupName",
     "kind": "variable",
     "detail": "resourceGroupName",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceGroupName",
@@ -2991,10 +2615,6 @@
     "label": "resourceGroupObject",
     "kind": "variable",
     "detail": "resourceGroupObject",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resourceGroupObject",
@@ -3030,10 +2650,6 @@
     "label": "scopesWithArmRepresentation",
     "kind": "variable",
     "detail": "scopesWithArmRepresentation",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_scopesWithArmRepresentation",
@@ -3048,10 +2664,6 @@
     "label": "scopesWithoutArmRepresentation",
     "kind": "variable",
     "detail": "scopesWithoutArmRepresentation",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_scopesWithoutArmRepresentation",
@@ -3066,10 +2678,6 @@
     "label": "singleQuote",
     "kind": "variable",
     "detail": "singleQuote",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_singleQuote",
@@ -3105,10 +2713,6 @@
     "label": "someText",
     "kind": "variable",
     "detail": "someText",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_someText",
@@ -3207,10 +2811,6 @@
     "label": "sub",
     "kind": "variable",
     "detail": "sub",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_sub",
@@ -3327,10 +2927,6 @@
     "label": "templateContentVersion",
     "kind": "variable",
     "detail": "templateContentVersion",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_templateContentVersion",
@@ -3345,10 +2941,6 @@
     "label": "templateLinkId",
     "kind": "variable",
     "detail": "templateLinkId",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_templateLinkId",
@@ -3363,10 +2955,6 @@
     "label": "templateLinkUri",
     "kind": "variable",
     "detail": "templateLinkUri",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_templateLinkUri",
@@ -3545,10 +3133,6 @@
     "label": "unusedIntermediate",
     "kind": "variable",
     "detail": "unusedIntermediate",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unusedIntermediate",
@@ -3563,10 +3147,6 @@
     "label": "unusedIntermediateRef",
     "kind": "variable",
     "detail": "unusedIntermediateRef",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unusedIntermediateRef",
@@ -3644,10 +3224,6 @@
     "label": "variables",
     "kind": "variable",
     "detail": "variables",
-    "documentation": {
-      "kind": "markdown",
-      "value": ""
-    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_variables",

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -403,43 +403,43 @@ resource service 'Microsoft.Storage/storageAccounts/fileServices@2021-02-01' = {
               {
                   x.Label.Should().Be("myInt");
                   x.Kind.Should().Be(CompletionItemKind.Field);
-                  x.Documentation!.MarkupContent!.Value.Should().Be("Type: 0 | 1  \nthis is an int value");
+                  x.Documentation!.MarkupContent!.Value.Should().Be("Type: `0 | 1`  \nthis is an int value  \n");
               },
               x =>
               {
                   x.Label.Should().Be("myStr");
                   x.Kind.Should().Be(CompletionItemKind.Field);
-                  x.Documentation!.MarkupContent!.Value.Should().Be("Type: 'value1' | 'value2'  \nthis is a string value");
+                  x.Documentation!.MarkupContent!.Value.Should().Be("Type: `'value1' | 'value2'`  \nthis is a string value  \n");
               },
               x =>
               {
                   x.Label.Should().Be("myBool");
                   x.Kind.Should().Be(CompletionItemKind.Field);
-                  x.Documentation!.MarkupContent!.Value.Should().Be("Type: bool  \nthis is a bool value");
+                  x.Documentation!.MarkupContent!.Value.Should().Be("Type: `bool`  \nthis is a bool value  \n");
               },
               x =>
               {
                   x.Label.Should().Be("myArray");
                   x.Kind.Should().Be(CompletionItemKind.Field);
-                  x.Documentation!.MarkupContent!.Value.Should().Be("Type: array");
+                  x.Documentation!.MarkupContent!.Value.Should().Be("Type: `array`  \n");
               },
               x =>
               {
                   x.Label.Should().Be("myVar");
                   x.Kind.Should().Be(CompletionItemKind.Variable);
-                  x.Documentation!.MarkupContent!.Value.Should().Be("this is a variable");
+                  x.Documentation!.MarkupContent!.Value.Should().Be("this is a variable  \n");
               },
               x =>
               {
                   x.Label.Should().Be("storageAct");
                   x.Kind.Should().Be(CompletionItemKind.Interface);
-                  x.Documentation!.MarkupContent!.Value.Should().Be("this is a storage account resource");
+                  x.Documentation!.MarkupContent!.Value.Should().Be("this is a storage account resource  \n");
               },
               x =>
               {
                   x.Label.Should().Be("myMod");
                   x.Kind.Should().Be(CompletionItemKind.Module);
-                  x.Documentation!.MarkupContent!.Value.Should().Be("this is a bicep module");
+                  x.Documentation!.MarkupContent!.Value.Should().Be("this is a bicep module  \n");
               }
             );
         }
@@ -3083,16 +3083,16 @@ var foo = resourceI|
                 ServerWithBuiltInTypes,
                 fileWithCursors,
                 completionLists => completionLists.Should().SatisfyRespectively(
-                    completions => completions!.Where(x => x.Label == "resourceId").First().Documentation!.MarkupContent!.Value.Should().EqualIgnoringNewlines(@"```bicep
+                    completions => completions!.Where(x => x.Label == "resourceId").First().Documentation!.MarkupContent!.Value.Should().EqualIgnoringNewlines(
+                      @"```bicep
 resourceId(resourceType: string, ... : string): string
 resourceId(subscriptionId: string, resourceType: string, ... : string): string
 resourceId(resourceGroupName: string, resourceType: string, ... : string): string
 resourceId(subscriptionId: string, resourceGroupName: string, resourceType: string, ... : string): string
 
-```
-Returns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.
-")),
-                '|');
+```  " + @"
+Returns the unique identifier of a resource. You use this function when the resource name is ambiguous or not provisioned within the same template. The format of the returned identifier varies based on whether the deployment happens at the scope of a resource group, subscription, management group, or tenant.  " + @"
+")));
         }
 
         [TestMethod]
@@ -3494,7 +3494,7 @@ module foo 'Microsoft.Storage/storageAccounts@2022-09-01' = {
             return await file.RequestCompletion(offset);
         }
 
-        private static async Task RunCompletionScenarioTest(TestContext testContext, SharedLanguageHelperManager server, string fileWithCursors, Action<IEnumerable<CompletionList>> assertAction, char cursor)
+        private static async Task RunCompletionScenarioTest(TestContext testContext, SharedLanguageHelperManager server, string fileWithCursors, Action<IEnumerable<CompletionList>> assertAction, char cursor = '|')
         {
             var (fileText, cursors) = ParserHelper.GetFileWithCursors(fileWithCursors, cursor);
             var file = await new ServerRequestHelper(testContext, server).OpenFile(fileText);
@@ -4567,10 +4567,11 @@ param foo1 foo = {
             var completions = await file.RequestCompletion(cursor);
             completions.Single(x => x.Label == "sourcePortRanges").Documentation!.MarkupContent!.Value
                 .Should().BeEquivalentToIgnoringNewlines(
-                    "Type: `string[]`  \n" +
-                    "Source port ranges.\n" +
-                    "    Can be a single valid port number, a range in the form of \\<start\\>-\\<end\\>, or a * for any ports.\n" +
-                    "    When a wildcard is used, that needs to be the only value.  \n");
+                    @"Type: `string[]`  " + @"
+Source port ranges.
+    Can be a single valid port number, a range in the form of \<start\>-\<end\>, or a * for any ports.
+    When a wildcard is used, that needs to be the only value.  " + @"
+");
         }
     }
 }

--- a/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -224,13 +225,13 @@ output string test = testRes.prop|erties.rea|donly
             var hovers = await RequestHovers(helper.Client, bicepFile, cursors);
 
             hovers.Should().SatisfyRespectively(
-                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nname: string\n```\nThe resource name\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nproperties: Properties\n```\nproperties property\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nreadwrite: string\n```\nThis is a property which supports reading AND writing!\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nwriteonly: string\n```\nThis is a property which only supports writing.\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nrequired: string\n```\nThis is a property which is required.\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nproperties: Properties\n```\nproperties property\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nreadonly: string\n```\nThis is a property which only supports reading.\n"));
+                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nname: string\n```  \nThe resource name  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nproperties: Properties\n```  \nproperties property  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nreadwrite: string\n```  \nThis is a property which supports reading AND writing!  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nwriteonly: string\n```  \nThis is a property which only supports writing.  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nrequired: string\n```  \nThis is a property which is required.  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nproperties: Properties\n```  \nproperties property  \n"  ),
+                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nreadonly: string\n```  \nThis is a property which only supports reading.  \n"));
         }
 
 
@@ -259,13 +260,13 @@ output string test = testRes[3].prop|erties.rea|donly
             var hovers = await RequestHovers(helper.Client, bicepFile, cursors);
 
             hovers.Should().SatisfyRespectively(
-                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nname: string\n```\nThe resource name\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nproperties: Properties\n```\nproperties property\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nreadwrite: string\n```\nThis is a property which supports reading AND writing!\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nwriteonly: string\n```\nThis is a property which only supports writing.\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nrequired: string\n```\nThis is a property which is required.\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nproperties: Properties\n```\nproperties property\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nreadonly: string\n```\nThis is a property which only supports reading.\n"));
+                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nname: string\n```  \nThe resource name  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nproperties: Properties\n```  \nproperties property  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nreadwrite: string\n```  \nThis is a property which supports reading AND writing!  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nwriteonly: string\n```  \nThis is a property which only supports writing.  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nrequired: string\n```  \nThis is a property which is required.  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nproperties: Properties\n```  \nproperties property  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nreadonly: string\n```  \nThis is a property which only supports reading.  \n"));
         }
 
         [TestMethod]
@@ -293,13 +294,13 @@ output string test = testRes.prop|erties.rea|donly
             var hovers = await RequestHovers(helper.Client, bicepFile, cursors);
 
             hovers.Should().SatisfyRespectively(
-                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nname: string\n```\nThe resource name\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nproperties: Properties\n```\nproperties property\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nreadwrite: string\n```\nThis is a property which supports reading AND writing!\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nwriteonly: string\n```\nThis is a property which only supports writing.\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nrequired: string\n```\nThis is a property which is required.\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nproperties: Properties\n```\nproperties property\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nreadonly: string\n```\nThis is a property which only supports reading.\n"));
+                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nname: string\n```  \nThe resource name  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nproperties: Properties\n```  \nproperties property  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nreadwrite: string\n```  \nThis is a property which supports reading AND writing!  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nwriteonly: string\n```  \nThis is a property which only supports writing.  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nrequired: string\n```  \nThis is a property which is required.  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nproperties: Properties\n```  \nproperties property  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nreadonly: string\n```  \nThis is a property which only supports reading.  \n"));
         }
 
         [TestMethod]
@@ -335,11 +336,11 @@ resource test|Output string = 'str'
             var hovers = await RequestHovers(helper.Client, bicepFile, cursors);
 
             hovers.Should().SatisfyRespectively(
-                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```\nthis is my module\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```\nthis is my param\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```\nthis is my var\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```\nthis is my  \nmultiline  \nresource  \n[View Documentation](https://learn.microsoft.com/azure/templates/test.rp/discriminatortests?pivots=deployment-language-bicep)\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```\nthis is my output  \n\n"));
+                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```  \nthis is my module  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```  \nthis is my param  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```  \nthis is my var  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```  \nthis is my\nmultiline\nresource  \n[View Documentation](https://learn.microsoft.com/azure/templates/test.rp/discriminatortests?pivots=deployment-language-bicep)  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```  \nthis is my output  \n  \n"));
         }
 
         [TestMethod]
@@ -361,7 +362,7 @@ param constrainedSe|cureString string
             var hovers = await RequestHovers(helper.Client, bicepFile, cursors);
 
             hovers.Should().SatisfyRespectively(
-                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\n@minLength(1)\n@maxLength(128)\n@secure()\nparam constrainedSecureString: string\n```\n"));
+                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\n@minLength(1)\n@maxLength(128)\n@secure()\nparam constrainedSecureString: string\n```  \n"));
         }
 
         [TestMethod]
@@ -410,11 +411,11 @@ output moduleOutput string = '${var|1}-${mod1.outputs.o|ut2}'
             var hovers = await RequestHovers(client, bicepFile, cursors);
 
             hovers.Should().SatisfyRespectively(
-                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```\nthis is mod1\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```\nthis is param1\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```\nthis is out1\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```\nthis is var1\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```\nthis  \nis  \nout2\n"));
+                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```  \nthis is mod1  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```  \nthis is param1  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```  \nthis is out1  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```  \nthis is var1  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```  \nthis\nis\nout2  \n"));
         }
 
         [TestMethod]
@@ -452,7 +453,7 @@ output o1 string = mod|1.name
 
             var hovers = await RequestHovers(client, bicepFile, cursors);
 
-            var expectedHover = "```bicep\nmodule mod1 './mod.bicep'\n```\nthis is mod1  \n  \nthis  \nis  \na description\n";
+            var expectedHover = "```bicep\nmodule mod1 './mod.bicep'\n```  \nthis is mod1  \nthis\nis\na description  \n";
             hovers.Should().SatisfyRespectively(
                 h => h!.Contents.MarkupContent!.Value.Should().Be(expectedHover),
                 h => h!.Contents.MarkupContent!.Value.Should().Be(expectedHover)
@@ -500,7 +501,7 @@ output o1 string = mod|1.name
 
             var hovers = await RequestHovers(client, bicepFile, cursors);
 
-            var expectedHover = $"```bicep\nmodule mod1 './mod.{extension}'\n```\nthis is mod1  \n  \nthis  \nis  \na description\n";
+            var expectedHover = $"```bicep\nmodule mod1 './mod.{extension}'\n```  \nthis is mod1  \nthis\nis\na description  \n";
             hovers.Should().SatisfyRespectively(
                 h => h!.Contents.MarkupContent!.Value.Should().Be(expectedHover),
                 h => h!.Contents.MarkupContent!.Value.Should().Be(expectedHover)
@@ -520,10 +521,10 @@ var nsConcatFunc = sys.c|oncat('abc', 'def')
                 '|');
 
             hovers.Should().SatisfyRespectively(
-                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nfunction resourceGroup(): resourceGroup\n```\nReturns the current resource group scope.\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nfunction resourceGroup(): resourceGroup\n```\nReturns the current resource group scope.\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nfunction concat(... : bool | int | string): string\n```\nCombines multiple string, integer, or boolean values and returns them as a concatenated string.\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nfunction concat(... : bool | int | string): string\n```\nCombines multiple string, integer, or boolean values and returns them as a concatenated string.\n"));
+                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nfunction resourceGroup(): resourceGroup\n```  \nReturns the current resource group scope.  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nfunction resourceGroup(): resourceGroup\n```  \nReturns the current resource group scope.  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nfunction concat(... : bool | int | string): string\n```  \nCombines multiple string, integer, or boolean values and returns them as a concatenated string.  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nfunction concat(... : bool | int | string): string\n```  \nCombines multiple string, integer, or boolean values and returns them as a concatenated string.  \n"));
         }
 
         [TestMethod]
@@ -542,18 +543,19 @@ resource m|adeUp 'Test.MadeUp/nonExistentResourceType@2020-01-01' = {}
             hovers.Should().SatisfyRespectively(
                 h => h!.Contents.MarkupContent!.Value.Should().BeEquivalentToIgnoringNewlines(@"```bicep
 resource foo 'Test.Rp/basicTests@2020-01-01'
-```
-[View Documentation](https://learn.microsoft.com/azure/templates/test.rp/basictests?pivots=deployment-language-bicep)
+```  " + @"
+[View Documentation](https://learn.microsoft.com/azure/templates/test.rp/basictests?pivots=deployment-language-bicep)  " + @"
 "),
                 h => h!.Contents.MarkupContent!.Value.Should().BeEquivalentToIgnoringNewlines(@"```bicep
 resource bar 'Test.Rp/basicTests@2020-01-01'
-```
+```  " + @"
 This resource also has a description!  " + @"
-[View Documentation](https://learn.microsoft.com/azure/templates/test.rp/basictests?pivots=deployment-language-bicep)
+[View Documentation](https://learn.microsoft.com/azure/templates/test.rp/basictests?pivots=deployment-language-bicep)  " +@"
 "),
                 h => h!.Contents.MarkupContent!.Value.Should().BeEquivalentToIgnoringNewlines(@"```bicep
 resource madeUp 'Test.MadeUp/nonExistentResourceType@2020-01-01'
-```
+```  " + @"
+  " + @"
 "));
         }
 
@@ -570,11 +572,11 @@ var nsConcatFunc = sys.conc|at(any('hello'))
 
             hovers.Should().SatisfyRespectively(
                 h => h!.Contents.MarkedStrings.Should().ContainInOrder(
-                    "```bicep\nfunction concat(... : array): array\n```\nCombines multiple arrays and returns the concatenated array.\n",
-                    "```bicep\nfunction concat(... : bool | int | string): string\n```\nCombines multiple string, integer, or boolean values and returns them as a concatenated string.\n"),
+                    "```bicep\nfunction concat(... : array): array\n```  \nCombines multiple arrays and returns the concatenated array.  \n",
+                    "```bicep\nfunction concat(... : bool | int | string): string\n```  \nCombines multiple string, integer, or boolean values and returns them as a concatenated string.  \n"),
                 h => h!.Contents.MarkedStrings.Should().ContainInOrder(
-                    "```bicep\nfunction concat(... : array): array\n```\nCombines multiple arrays and returns the concatenated array.\n",
-                    "```bicep\nfunction concat(... : bool | int | string): string\n```\nCombines multiple string, integer, or boolean values and returns them as a concatenated string.\n"));
+                    "```bicep\nfunction concat(... : array): array\n```  \nCombines multiple arrays and returns the concatenated array.  \n",
+                    "```bicep\nfunction concat(... : bool | int | string): string\n```  \nCombines multiple string, integer, or boolean values and returns them as a concatenated string.  \n"));
         }
 
         [TestMethod]
@@ -633,12 +635,12 @@ output moduleOutput string = '${va|r1}-${mod1.outputs.ou|t2}'
             var hovers = await RequestHovers(client, bicepFile, cursors);
 
             hovers.Should().SatisfyRespectively(
-                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```\nthis is mod1\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```\nthis is param1\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```\nthis is param2\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```\nthis is out1\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```\nthis is var1\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```\nthis  \nis  \nout2\n"));
+                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```  \nthis is mod1  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```  \nthis is param1  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```  \nthis is param2  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```  \nthis is out1  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```  \nthis is var1  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```  \nthis\nis\nout2  \n"));
         }
 
         [TestMethod]
@@ -698,7 +700,7 @@ resource testRes 'Test.Rp/discriminatorTests@2020-01-01' = {
             var hovers = await RequestHovers(helper.Client, bicepFile, cursors);
 
             hovers.Should().SatisfyRespectively(
-                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nkind: 'BodyA' | 'BodyB'\n```\n"));
+                h => h!.Contents.MarkupContent!.Value.Should().Be("```bicep\nkind: 'BodyA' | 'BodyB'\n```  \n"));
         }
 
         [DataTestMethod]
@@ -715,7 +717,7 @@ resource testRes 'Test.Rp/discriminatorTests@2020-01-01' = {
             null, // description
 
              // documentationUri passed in, use it
-             "```bicep\nmodule test 'br:test.azurecr.io/bicep/modules/storage:sha:12345'\n```\n[View Documentation](http://test.com)\n")]
+             "```bicep\nmodule test 'br:test.azurecr.io/bicep/modules/storage:sha:12345'\n```  \n[View Documentation](http://test.com)  \n")]
         [DataRow(
             "http://test.com",
             "br:mcr.microsoft.com/bicep/modules/storage:1.0.1",
@@ -726,7 +728,7 @@ resource testRes 'Test.Rp/discriminatorTests@2020-01-01' = {
             null, // description
 
             // documentationUri was passed in (overrides MCR location)
-            "```bicep\nmodule test 'br:mcr.microsoft.com/bicep/modules/storage:1.0.1'\n```\n[View Documentation](http://test.com)\n")]
+            "```bicep\nmodule test 'br:mcr.microsoft.com/bicep/modules/storage:1.0.1'\n```  \n[View Documentation](http://test.com)  \n")]
         [DataRow(
             null,
             "br:mcr.microsoft.com/bicep/app/dapr-containerapps-environment:1.0.1",
@@ -737,7 +739,7 @@ resource testRes 'Test.Rp/discriminatorTests@2020-01-01' = {
             null, // description
 
              // documentationUri calculated from MCR location
-             "```bicep\nmodule test 'br:mcr.microsoft.com/bicep/app/dapr-containerapps-environment:1.0.1'\n```\n[View Documentation](https://github.com/Azure/bicep-registry-modules/tree/app/dapr-containerapps-environment/1.0.1/modules/app/dapr-containerapps-environment/README.md)\n")]
+             "```bicep\nmodule test 'br:mcr.microsoft.com/bicep/app/dapr-containerapps-environment:1.0.1'\n```  \n[View Documentation](https://github.com/Azure/bicep-registry-modules/tree/app/dapr-containerapps-environment/1.0.1/modules/app/dapr-containerapps-environment/README.md)  \n")]
         [DataRow(
             null,
             "br:mcr.microsoft.com/bicep/app/dapr-containerapps-environment:1.0.2",
@@ -748,7 +750,7 @@ resource testRes 'Test.Rp/discriminatorTests@2020-01-01' = {
             null, // description
 
              // documentationUri calculated from MCR location
-             "```bicep\nmodule test 'br:mcr.microsoft.com/bicep/app/dapr-containerapps-environment:1.0.2'\n```\n[View Documentation](https://github.com/Azure/bicep-registry-modules/tree/app/dapr-containerapps-environment/1.0.2/modules/app/dapr-containerapps-environment/README.md)\n")]
+             "```bicep\nmodule test 'br:mcr.microsoft.com/bicep/app/dapr-containerapps-environment:1.0.2'\n```  \n[View Documentation](https://github.com/Azure/bicep-registry-modules/tree/app/dapr-containerapps-environment/1.0.2/modules/app/dapr-containerapps-environment/README.md)  \n")]
         //
         // Description only, no documentationUri
         //
@@ -761,7 +763,7 @@ resource testRes 'Test.Rp/discriminatorTests@2020-01-01' = {
             null,
             "my description", // description
 
-             "```bicep\nmodule test 'br:test.azurecr.io/bicep/modules/storage:sha:12345'\n```\nmy description\n")]
+             "```bicep\nmodule test 'br:test.azurecr.io/bicep/modules/storage:sha:12345'\n```  \nmy description  \n")]
         [DataRow(
             null,
             "br:test.azurecr.io/bicep/modules/storage:sha:12345",
@@ -771,7 +773,7 @@ resource testRes 'Test.Rp/discriminatorTests@2020-01-01' = {
             null,
             "my \\\"description\\\"", // description
 
-             "```bicep\nmodule test 'br:test.azurecr.io/bicep/modules/storage:sha:12345'\n```\nmy \"description\"\n")]
+             "```bicep\nmodule test 'br:test.azurecr.io/bicep/modules/storage:sha:12345'\n```  \nmy \"description\"  \n")]
         [DataRow(
             null,
             "br:test.azurecr.io/bicep/modules/storage:sha:12345",
@@ -781,7 +783,7 @@ resource testRes 'Test.Rp/discriminatorTests@2020-01-01' = {
             null,
             "my [description", // description
 
-             "```bicep\nmodule test 'br:test.azurecr.io/bicep/modules/storage:sha:12345'\n```\nmy [description\n")]
+             "```bicep\nmodule test 'br:test.azurecr.io/bicep/modules/storage:sha:12345'\n```  \nmy [description  \n")]
         //
         // Neither documentationUri nor description
         [DataRow(
@@ -793,7 +795,7 @@ resource testRes 'Test.Rp/discriminatorTests@2020-01-01' = {
             null,
             null, // description
 
-            "```bicep\nmodule test 'br:test.azurecr.io/bicep/modules/storage:sha:12345'\n```\n")]
+            "```bicep\nmodule test 'br:test.azurecr.io/bicep/modules/storage:sha:12345'\n```  \n  \n")]
         //
         // Both documentationUri and description
         //
@@ -805,7 +807,7 @@ resource testRes 'Test.Rp/discriminatorTests@2020-01-01' = {
             "sha:12345",
             null,
             "my description", // description
-             "```bicep\nmodule test 'br:test.azurecr.io/bicep/modules/storage:sha:12345'\n```\nmy description  \n  \n[View Documentation](http://test.com)\n")]
+             "```bicep\nmodule test 'br:test.azurecr.io/bicep/modules/storage:sha:12345'\n```  \nmy description  \n[View Documentation](http://test.com)  \n")]
         public async Task Verify_Hover_ContainerRegistry(string? documentationUri, string repositoryAndTag, string registry, string repository, string? digest, string? tag, string? description, string expectedHoverContent)
         {
             string manifestFileContents = GetManifestFileContents(documentationUri, description);
@@ -831,7 +833,7 @@ resource testRes 'Test.Rp/discriminatorTests@2020-01-01' = {
             var bicepFile = SourceFileFactory.CreateBicepFile(parentModuleUri, bicepFileContents);
             var hovers = await RequestHovers(client, bicepFile, cursors);
 
-            hovers.Should().SatisfyRespectively(h => h!.Contents.MarkupContent!.Value.Should().Be(expectedHoverContent));
+            hovers.Single()!.Contents.MarkupContent!.Value.Should().Be(expectedHoverContent);
         }
 
         [TestMethod]
@@ -886,9 +888,9 @@ param foo|bar = true
             var hovers = await RequestHovers(client, paramsFile, cursors);
 
             hovers.Should().SatisfyRespectively(
-                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```bicep\nparam foo: 'value1' | 'value2'\n```\nthis is a string value\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```bicep\nparam bar: 0 | 1\n```\nthis is an int value\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```bicep\nparam foobar: bool\n```\nthis is a bool value\n")
+                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```bicep\nparam foo: 'value1' | 'value2'\n```  \nthis is a string value  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```bicep\nparam bar: 0 | 1\n```  \nthis is an int value  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```bicep\nparam foobar: bool\n```  \nthis is a bool value  \n")
             );
         }
 
@@ -927,9 +929,9 @@ param foo|bar = true
             var hovers = await RequestHovers(client, mainFile, cursors);
 
             hovers.Should().SatisfyRespectively(
-                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```bicep\ntype foo: Type<string>\n```\nThe foo type\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```bicep\nmod namespace\n```\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```bicep\nfoo: Type<string>\n```\nThe foo type\n"));
+                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```bicep\ntype foo: Type<string>\n```  \nThe foo type  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```bicep\nmod namespace\n```  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```bicep\nfoo: Type<string>\n```  \nThe foo type  \n"));
         }
 
         [TestMethod]
@@ -954,12 +956,13 @@ param foo1 foo = {
             var hover = await file.RequestHover(cursor);
             hover!.Contents!.MarkupContent!.Value
                 .Should().BeEquivalentToIgnoringNewlines(
-                    "```bicep\n" +
-                    "sourcePortRanges: string[]\n" +
-                    "```  \n" +
-                    "Source port ranges.\n" +
-                    "    Can be a single valid port number, a range in the form of \\<start\\>-\\<end\\>, or a * for any ports.\n" +
-                    "    When a wildcard is used, that needs to be the only value.  \n");
+                    @"```bicep
+sourcePortRanges: string[]
+```  " + @"
+Source port ranges.
+    Can be a single valid port number, a range in the form of \<start\>-\<end\>, or a * for any ports.
+    When a wildcard is used, that needs to be the only value.  " + @"
+");
         }
 
 

--- a/src/Bicep.LangServer.IntegrationTests/ParamsCompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/ParamsCompletionTests.cs
@@ -344,25 +344,25 @@ param myArray array
                 x =>
                 {
                     x.Label.Should().Be("myArray");
-                    x.Documentation!.MarkupContent!.Value.Should().Be("Type: array");
+                    x.Documentation!.MarkupContent!.Value.Should().Be("Type: `array`  \n");
                     x.Kind.Should().Be(CompletionItemKind.Field);
                 },
                 x =>
                 {
                     x.Label.Should().Be("myBool");
-                    x.Documentation!.MarkupContent!.Value.Should().Be("Type: bool  \nthis is a bool value");
+                    x.Documentation!.MarkupContent!.Value.Should().Be("Type: `bool`  \nthis is a bool value  \n");
                     x.Kind.Should().Be(CompletionItemKind.Field);
                 },
                 x =>
                 {
                     x.Label.Should().Be("myInt");
-                    x.Documentation!.MarkupContent!.Value.Should().Be("Type: 0 | 1  \nthis is an int value");
+                    x.Documentation!.MarkupContent!.Value.Should().Be("Type: `0 | 1`  \nthis is an int value  \n");
                     x.Kind.Should().Be(CompletionItemKind.Field);
                 },
                 x =>
                 {
                     x.Label.Should().Be("myStr");
-                    x.Documentation!.MarkupContent!.Value.Should().Be("Type: 'value1' | 'value2'  \nthis is a string value");
+                    x.Documentation!.MarkupContent!.Value.Should().Be("Type: `'value1' | 'value2'`  \nthis is a string value  \n");
                     x.Kind.Should().Be(CompletionItemKind.Field);
                 }
                 );

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -40,8 +40,6 @@ namespace Bicep.LanguageServer.Completions
 {
     public class BicepCompletionProvider : ICompletionProvider
     {
-        private const string MarkdownNewLine = "  \n";
-
         private static readonly Container<string> ResourceSymbolCommitChars = new(":");
 
         private static readonly Container<string> PropertyAccessCommitChars = new(".");
@@ -111,8 +109,8 @@ namespace Bicep.LanguageServer.Completions
                                 GetCompletionItemKind(SymbolKind.ParameterAssignment),
                                 metadata.Name)
                             .WithDocumentation(
-                                $"Type: {metadata.TypeReference.Type}" +
-                                (metadata.Description is null ? "" : $"{MarkdownNewLine}{metadata.Description}"))
+                                MarkdownHelper.AppendNewline($"Type: `{metadata.TypeReference.Type}`") +
+                                MarkdownHelper.AppendNewline(metadata.Description))
                             .WithDetail(metadata.Name)
                             .WithPlainTextEdit(paramsCompletionContext.ReplacementRange, metadata.Name)
                             .Build();
@@ -1793,7 +1791,9 @@ namespace Bicep.LanguageServer.Completions
                     // Lower-case all resource types in filter text otherwise editor may prefer those with casing that match what the user has already typed (#9168)
                     .WithFilterText(insertText.ToLowerInvariant())
                     .WithPlainTextEdit(replacementRange, insertText)
-                    .WithDocumentation($"Type: `{resourceType.Type}`{MarkdownNewLine}API Version: `{resourceType.ApiVersion}`")
+                    .WithDocumentation(
+                        MarkdownHelper.AppendNewline($"Type: `{resourceType.Type}`") +
+                        MarkdownHelper.AppendNewline($"API Version: `{resourceType.ApiVersion}`"))
                     .WithSortText(index.ToString("x8"))
                     .Build();
             }
@@ -1802,7 +1802,8 @@ namespace Bicep.LanguageServer.Completions
                 var insertText = StringUtils.EscapeBicepString(resourceType.Type);
                 return CompletionItemBuilder.Create(CompletionItemKind.Class, insertText)
                     .WithSnippetEdit(replacementRange, $"{insertText[..^1]}@$0'")
-                    .WithDocumentation($"Type: `{resourceType.Type}`{MarkdownNewLine}`")
+                    .WithDocumentation(
+                        MarkdownHelper.AppendNewline($"Type: `{resourceType.Type}`"))
                     .WithFollowupCompletion("resource type completion")
                     .WithSortText(index.ToString("x8"))
                     .Build();
@@ -1816,11 +1817,11 @@ namespace Bicep.LanguageServer.Completions
                 StringUtils.EscapeBicepString($"{resourceType.TypeSegments[^1]}@{resourceType.ApiVersion}") :
                 StringUtils.EscapeBicepString($"{resourceType.TypeSegments[^1]}");
 
-            var apiVersionMarkdown = displayApiVersion is not null ? $"{MarkdownNewLine}API Version: `{displayApiVersion}`" : "";
-
             return CompletionItemBuilder.Create(CompletionItemKind.Class, insertText)
                 .WithPlainTextEdit(replacementRange, insertText)
-                .WithDocumentation($"Type: `{resourceType.FormatType()}`{apiVersionMarkdown}")
+                .WithDocumentation(
+                    MarkdownHelper.AppendNewline($"Type: `{resourceType.Type}`") +
+                    MarkdownHelper.AppendNewline(displayApiVersion is not null ? $"API Version: `{displayApiVersion}`" : null))
                 // 8 hex digits is probably overkill :)
                 .WithSortText(index.ToString("x8"))
                 .Build();
@@ -1853,7 +1854,7 @@ namespace Bicep.LanguageServer.Completions
             CompletionItemBuilder.Create(CompletionItemKind.Snippet, label)
                 .WithSnippetEdit(replacementRange, snippet)
                 .WithDetail(detail)
-                .WithDocumentation($"```bicep\n{new Snippet(snippet).FormatDocumentation()}\n```")
+                .WithDocumentation(MarkdownHelper.CodeBlock(new Snippet(snippet).FormatDocumentation()))
                 .WithSortText(GetSortText(label, priority))
                 .Preselect(preselect)
                 .Build();
@@ -1866,7 +1867,7 @@ namespace Bicep.LanguageServer.Completions
                 .WithSnippetEdit(replacementRange, snippet)
                 .WithCommand(command)
                 .WithDetail(detail)
-                .WithDocumentation($"```bicep\n{new Snippet(snippet).FormatDocumentation()}\n```")
+                .WithDocumentation(MarkdownHelper.CodeBlock(new Snippet(snippet).FormatDocumentation()))
                 .WithSortText(GetSortText(label, priority))
                 .Preselect(preselect)
                 .Build();
@@ -1879,7 +1880,7 @@ namespace Bicep.LanguageServer.Completions
                 .WithSnippetEdit(replacementRange, snippet)
                 .WithAdditionalEdits(additionalTextEdits)
                 .WithDetail(detail)
-                .WithDocumentation($"```bicep\n{new Snippet(snippet).FormatDocumentation()}\n```")
+                .WithDocumentation(MarkdownHelper.CodeBlock(new Snippet(snippet).FormatDocumentation()))
                 .WithSortText(GetSortText(label, priority))
                 .Build();
 
@@ -2109,29 +2110,26 @@ namespace Bicep.LanguageServer.Completions
         {
             var buffer = new StringBuilder();
 
-            buffer.Append($"Type: `{property.TypeReference.Type}`{MarkdownNewLine}");
+            buffer.Append(MarkdownHelper.AppendNewline($"Type: `{property.TypeReference.Type}`"));
 
             if (property.Flags.HasFlag(TypePropertyFlags.ReadOnly))
             {
                 // this case will be used for dot property access completions
                 // this flag is not possible in property name completions
-                buffer.Append($"Read-only property{MarkdownNewLine}");
+                buffer.Append(MarkdownHelper.AppendNewline($"Read-only property"));
             }
 
             if (property.Flags.HasFlag(TypePropertyFlags.WriteOnly))
             {
-                buffer.Append($"Write-only property{MarkdownNewLine}");
+                buffer.Append(MarkdownHelper.AppendNewline($"Write-only property"));
             }
 
             if (property.Flags.HasFlag(TypePropertyFlags.Constant))
             {
-                buffer.Append($"Requires a compile-time constant value.{MarkdownNewLine}");
+                buffer.Append(MarkdownHelper.AppendNewline($"Requires a compile-time constant value."));
             }
 
-            if (property.Description is not null)
-            {
-                buffer.Append($"{property.Description}{MarkdownNewLine}");
-            }
+            buffer.Append(MarkdownHelper.AppendNewline(property.Description));
 
             return buffer.ToString();
         }
@@ -2140,13 +2138,19 @@ namespace Bicep.LanguageServer.Completions
         {
             if (symbol is DeclaredSymbol declaredSymbol && declaredSymbol.DeclaringSyntax is DecorableSyntax decorableSyntax)
             {
-                var documentation = DescriptionHelper.TryGetFromDecorator(model, decorableSyntax);
+                var buffer = new StringBuilder();
+
                 if (declaredSymbol is ParameterSymbol)
                 {
-                    documentation = $"Type: {declaredSymbol.Type}" + (documentation is null ? "" : $"{MarkdownNewLine}{documentation}");
+                    buffer.Append(MarkdownHelper.AppendNewline($"Type: `{declaredSymbol.Type}`"));
                 }
-                return documentation;
+
+                var documentation = DescriptionHelper.TryGetFromDecorator(model, decorableSyntax);
+                buffer.Append(MarkdownHelper.AppendNewline(documentation));
+                
+                return buffer.ToString();
             }
+
             return null;
         }
     }

--- a/src/Bicep.LangServer/Completions/CompletionItemBuilder.cs
+++ b/src/Bicep.LangServer/Completions/CompletionItemBuilder.cs
@@ -96,7 +96,7 @@ namespace Bicep.LanguageServer.Completions
         //                                          +--------------------+
         public CompletionItemBuilder WithDocumentation(string? markdown)
         {
-            if (markdown is not null)
+            if (!string.IsNullOrEmpty(markdown))
             {
                 this.documentation = new StringOrMarkupContent(new MarkupContent
                 {

--- a/src/Bicep.LangServer/Completions/CompletionItemBuilder.cs
+++ b/src/Bicep.LangServer/Completions/CompletionItemBuilder.cs
@@ -14,6 +14,7 @@ namespace Bicep.LanguageServer.Completions
         private readonly CompletionItemKind kind;
         private readonly string label;
 
+        private CompletionItemLabelDetails? labelDetails;
         private TextEditContainer? additionalTextEdits;
         private Container<string>? commitCharacters;
         private string? detail;
@@ -41,6 +42,7 @@ namespace Bicep.LanguageServer.Completions
             return new()
             {
                 Label = this.label,
+                LabelDetails = this.labelDetails,
                 Kind = kind,
 
                 AdditionalTextEdits = this.additionalTextEdits,
@@ -137,6 +139,17 @@ namespace Bicep.LanguageServer.Completions
             this.insertText = snippet;
             this.insertTextFormat = InsertTextFormat.Snippet;
             this.insertTextMode = InsertTextMode.AdjustIndentation;
+
+            return this;
+        }
+
+        public CompletionItemBuilder WithLabelDetails(string detail, string description)
+        {
+            this.labelDetails = new CompletionItemLabelDetails
+            {
+                Detail = detail,
+                Description = description,
+            };
 
             return this;
         }

--- a/src/Bicep.LangServer/Completions/ModuleReferenceCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/ModuleReferenceCompletionProvider.cs
@@ -18,6 +18,7 @@ using Bicep.Core.Syntax;
 using Bicep.LanguageServer.Providers;
 using Bicep.LanguageServer.Settings;
 using Bicep.LanguageServer.Telemetry;
+using Bicep.LanguageServer.Utils;
 using Microsoft.Win32;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
@@ -226,7 +227,7 @@ namespace Bicep.LanguageServer.Completions
                     .WithFilterText(insertText)
                     .WithSortText(GetSortText(version, i))
                     .WithDetail(description)
-                    .WithDocumentation(GetDocumentationLink(documentationUri))
+                    .WithDocumentation(MarkdownHelper.GetDocumentationLink(documentationUri))
                     .Build();
 
                 completions.Add(completionItem);
@@ -374,7 +375,7 @@ namespace Bicep.LanguageServer.Completions
                                         .WithFilterText(insertText)
                                         .WithSortText(GetSortText(label, ModuleCompletionPriority.Alias))
                                         .WithDetail(description)
-                                        .WithDocumentation(GetDocumentationLink(documentationUri))
+                                        .WithDocumentation(MarkdownHelper.GetDocumentationLink(documentationUri))
                                         .WithFollowupCompletion("module version completion")
                                         .Build();
 
@@ -423,7 +424,7 @@ namespace Bicep.LanguageServer.Completions
                                     .WithFilterText(insertText)
                                     .WithSortText(GetSortText(label, ModuleCompletionPriority.Alias))
                                     .WithDetail(module.Description)
-                                    .WithDocumentation(GetDocumentationLink(module.DocumentationUri))
+                                    .WithDocumentation(MarkdownHelper.GetDocumentationLink(module.DocumentationUri))
                                     .WithFollowupCompletion("module version completion")
                                     .Build();
                                 completions.Add(completionItem);
@@ -520,7 +521,7 @@ namespace Bicep.LanguageServer.Completions
                     .WithFilterText(insertText)
                     .WithSortText(GetSortText(moduleName))
                     .WithDetail(description)
-                    .WithDocumentation(GetDocumentationLink(documentationUri))
+                    .WithDocumentation(MarkdownHelper.GetDocumentationLink(documentationUri))
                     .WithFollowupCompletion("module version completion")
                     .Build();
 
@@ -660,11 +661,6 @@ namespace Bicep.LanguageServer.Completions
             }
 
             return completions;
-        }
-
-        private static string? GetDocumentationLink(string? documentationUri)
-        {
-            return Bicep.LanguageServer.Utils.MarkdownHelper.GetDocumentationLink(documentationUri);
         }
 
         private static string GetSortText(string label, int priority) => $"{priority}_{label}";

--- a/src/Bicep.LangServer/Handlers/BicepHoverHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepHoverHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -219,7 +220,7 @@ namespace Bicep.LanguageServer.Handlers
                 }
             }
 
-            var descriptions = descriptionLines.Select(MarkdownHelper.AppendNewline).ConcatString("");
+            var descriptions = MarkdownHelper.JoinWithNewlines(descriptionLines.WhereNotNull());
             return AsMarkdown(MarkdownHelper.CodeBlockWithDescription($"module {module.Name} '{filePath}'", descriptions));
         }
 

--- a/src/Bicep.LangServer/Utils/MarkdownHelper.cs
+++ b/src/Bicep.LangServer/Utils/MarkdownHelper.cs
@@ -3,28 +3,28 @@
 
 using System;
 
-namespace Bicep.LanguageServer.Utils
+namespace Bicep.LanguageServer.Utils;
+
+public static class MarkdownHelper
 {
-    public static class MarkdownHelper
-    {
-        private const int MaxHoverMarkdownCodeBlockLength = 90000;
-        //actual limit for hover in VS code is 100,000 characters.
+    // Markdown needs two leading whitespaces before newline to insert a line break
+    private const string MarkdownNewLine = "  \n";
 
-        //we need to check for overflow due to using code blocks.
-        //if we reach limit in a code block vscode will truncate it automatically, the block will not be terminated so the hover will not be properly formatted
-        //therefore we need to check for the limit ourselves and truncate text inside code block, making sure it's terminated properly.
-        private static string CodeBlock(string content) =>
-        $"```bicep\n{(content.Length > MaxHoverMarkdownCodeBlockLength ? content.Substring(0, MaxHoverMarkdownCodeBlockLength) : content)}\n```\n";
+    // actual limit for hover in VS code is 100,000 characters.
+    private const int MaxCodeBlockLength = 90000;
 
-        private static string DescriptionFormatting(string description) =>
-        $"{description.Replace("\n", "  \n")}\n";
+    // we need to check for overflow due to using code blocks.
+    // if we reach limit in a code block vscode will truncate it automatically, the block will not be terminated so the hover will not be properly formatted
+    // therefore we need to check for the limit ourselves and truncate text inside code block, making sure it's terminated properly.
+    public static string CodeBlock(string content) =>
+        AppendNewline($"```bicep\n{(content.Length > MaxCodeBlockLength ? content[..MaxCodeBlockLength] : content)}\n```");
 
-        // Markdown needs two leading whitespaces before newline to insert a line break
-        public static string CodeBlockWithDescription(string content, string? description) => CodeBlock(content) + (description is not null ? DescriptionFormatting(description) : string.Empty);
+    public static string CodeBlockWithDescription(string content, string? description)
+        => CodeBlock(content) + AppendNewline(description);
 
-        public static string? GetDocumentationLink(string? documentationUri)
-        {
-            return documentationUri is null ? null : $"[View Documentation]({documentationUri})";
-        }
-    }
+    public static string AppendNewline(string? input)
+        => input is null ? string.Empty : $"{input}{MarkdownNewLine}";
+
+    public static string? GetDocumentationLink(string? documentationUri)
+        => documentationUri is null ? null : $"[View Documentation]({documentationUri})";
 }

--- a/src/Bicep.LangServer/Utils/MarkdownHelper.cs
+++ b/src/Bicep.LangServer/Utils/MarkdownHelper.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 
 namespace Bicep.LanguageServer.Utils;
 
@@ -24,6 +26,9 @@ public static class MarkdownHelper
 
     public static string AppendNewline(string? input)
         => input is null ? string.Empty : $"{input}{MarkdownNewLine}";
+
+    public static string JoinWithNewlines(IEnumerable<string> inputs)
+        => string.Join(MarkdownNewLine, inputs);
 
     public static string? GetDocumentationLink(string? documentationUri)
         => documentationUri is null ? null : $"[View Documentation]({documentationUri})";

--- a/src/vscode-bicep/src/test/e2e/hover.test.ts
+++ b/src/vscode-bicep/src/test/e2e/hover.test.ts
@@ -162,13 +162,13 @@ describe("hover", (): void => {
   }
 
   function codeblock(rawString: string): string {
-    return "```bicep\n" + rawString + "\n```\n";
+    return "```bicep\n" + rawString + "\n```  \n";
   }
 
   function codeblockWithDescription(
     rawString: string,
     description: string,
   ): string {
-    return `${codeblock(rawString)}${description}\n`;
+    return `${codeblock(rawString)}${description}  \n`;
   }
 });


### PR DESCRIPTION
* Embed descriptions as-is without modifications: current logic replaces `\n` with `  \n`, which leads to rendering quirks.
* Ensure we're emitting a double space + newline after every "block".
* Move shared logic to `MarkdownHelper` class.

Closes #12412 

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12654)