### PR TITLE
Minor optimizations to language server integration tests

### DIFF
--- a/src/Bicep.Core.UnitTests/Assertions/StringAssertionsExtensions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/StringAssertionsExtensions.cs
@@ -97,6 +97,16 @@ namespace Bicep.Core.UnitTests.Assertions
             return new AndConstraint<StringAssertions>(instance);
         }
 
+        public static AndConstraint<StringAssertions> EqualIgnoringTrailingWhitespace(this StringAssertions instance, string expected, string because = "", params object[] becauseArgs)
+        {
+            var normalizedActual = string.Join("\n", instance.Subject.ReplaceLineEndings("\n").Split("\n").Select(x => x.TrimEnd()));
+            var normalizedExpected = string.Join("\n", expected.ReplaceLineEndings("\n").Split("\n").Select(x => x.TrimEnd()));
+
+            normalizedActual.Should().Be(normalizedExpected, because, becauseArgs);
+
+            return new AndConstraint<StringAssertions>(instance);
+        }
+
         /// <summary>
         /// Compares two strings after normalizing by unindenting lines until the least indented line is flushed left, similar to
         /// YAML blocks of text.

--- a/src/Bicep.Core.UnitTests/TestBase.cs
+++ b/src/Bicep.Core.UnitTests/TestBase.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.Core.UnitTests;
+
+public class TestBase
+{
+    [NotNull]
+    public TestContext? TestContext { get; set; }
+}

--- a/src/Bicep.LangServer.IntegrationTests/Assertions/AssertionScopeExtensions.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Assertions/AssertionScopeExtensions.cs
@@ -22,7 +22,7 @@ namespace Bicep.LangServer.IntegrationTests.Assertions
                 contextName,
                 (data ?? Enumerable.Empty<T>()).Select(x => new PrintHelper.Annotation(FromRange(bicepFile, rangeFunc(x)), messageFunc(x))));
 
-        private static TextSpan FromRange(BicepSourceFile bicepFile, Range range)
+        public static TextSpan FromRange(BicepSourceFile bicepFile, Range range)
         {
             var position = TextCoordinateConverter.GetOffset(bicepFile.LineStarts, range.Start.Line, range.Start.Character);
             var length = TextCoordinateConverter.GetOffset(bicepFile.LineStarts, range.End.Line, range.End.Character) - position;

--- a/src/Bicep.LangServer.IntegrationTests/ReferencesTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/ReferencesTests.cs
@@ -12,6 +12,7 @@ using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
 using Bicep.Core.Syntax.Visitors;
 using Bicep.Core.Text;
+using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Utils;
 using Bicep.Core.Workspaces;
@@ -28,181 +29,103 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using SymbolKind = Bicep.Core.Semantics.SymbolKind;
 
-namespace Bicep.LangServer.IntegrationTests
+namespace Bicep.LangServer.IntegrationTests;
+
+[TestClass]
+public class ReferencesTests : TestBase
 {
-    [TestClass]
-    public class ReferencesTests
+    private static readonly SharedLanguageHelperManager DefaultServer = new();
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext testContext)
     {
-        private static readonly SharedLanguageHelperManager DefaultServer = new();
+        DefaultServer.Initialize(async () => await MultiFileLanguageServerHelper.StartLanguageServer(testContext));
+    }
 
-        [NotNull]
-        public TestContext? TestContext { get; set; }
+    [ClassCleanup]
+    public static async Task ClassCleanup()
+    {
+        await DefaultServer.DisposeAsync();
+    }
 
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext testContext)
-        {
-            DefaultServer.Initialize(async () => await MultiFileLanguageServerHelper.StartLanguageServer(testContext));
-        }
+    [TestMethod]
+    [DataRow("""
+var te|st = 'asdf'
 
-        [ClassCleanup]
-        public static async Task ClassCleanup()
-        {
-            await DefaultServer.DisposeAsync();
-        }
+var asdf = test
+var blah = '${test}'
+""", """
+1| var test = 'asdf'
+       ~~~~ here
+2|
+3| var asdf = test
+              ~~~~ here
+4| var blah = '${test}'
+                 ~~~~ here
 
-        [DataTestMethod]
-        [DynamicData(nameof(GetData), DynamicDataSourceType.Method, DynamicDataDisplayNameDeclaringType = typeof(DataSet), DynamicDataDisplayName = nameof(DataSet.GetDisplayName))]
-        public async Task FindReferencesWithDeclarationsShouldProduceCorrectResults(DataSet dataSet)
-        {
-            var (compilation, _, fileUri) = await dataSet.SetupPrerequisitesAndCreateCompilation(TestContext);
-            var uri = DocumentUri.From(fileUri);
+""")]
+    public async Task FindReferencesWithDeclarationsShouldProduceCorrectResults(string inputWithCursor, string outputAnnotated)
+    {
+        var (contents, cursor) = ParserHelper.GetFileWithSingleCursor(inputWithCursor);
+        var file = await new ServerRequestHelper(TestContext, DefaultServer).OpenFile(contents);
 
-            var helper = await DefaultServer.GetAsync();
-            await helper.OpenFileOnceAsync(TestContext, dataSet.Bicep, uri);
+        var locations = await file.RequestReferences(cursor, includeDeclaration: true);
 
-            var symbolTable = compilation.ReconstructSymbolTable();
-            var lineStarts = compilation.SourceFileGrouping.EntryPoint.LineStarts;
+        // all URIs should be the same in the results
+        locations!.Select(r => r.Uri.ToUriEncoded()).Should().AllBeEquivalentTo(file.Source.FileUri);
 
-            // filter out bind failures and locals with invalid identifiers
-            // (locals are special because their span is equal to their identifier span)
-            var filteredSymbolTable = symbolTable.Where(pair => pair.Value.Kind != SymbolKind.Error && (pair.Value is not LocalVariableSymbol local || local.NameSource.IsValid));
-            // TODO: Implement for PropertySymbol
-            filteredSymbolTable = filteredSymbolTable.Where(pair => pair.Value is not PropertySymbol);
-            var symbolToSyntaxLookup = filteredSymbolTable.ToLookup(pair => pair.Value, pair => pair.Key);
+        AnnotateWithLocations(file, locations).Should().EqualIgnoringTrailingWhitespace(outputAnnotated);
+    }
 
-            foreach (var (syntax, symbol) in filteredSymbolTable)
-            {
-                var locations = await helper.Client.RequestReferences(new ReferenceParams
-                {
-                    TextDocument = new TextDocumentIdentifier(uri),
-                    Context = new ReferenceContext
-                    {
-                        IncludeDeclaration = true
-                    },
-                    Position = IntegrationTestHelper.GetPosition(lineStarts, syntax)
-                });
+    [TestMethod]
+    [DataRow("""
+var te|st = 'asdf'
 
-                // all URIs should be the same in the results
-                locations!.Select(r => r.Uri).Should().AllBeEquivalentTo(uri);
+var asdf = test
+var blah = '${test}'
+""", """
+2|
+3| var asdf = test
+              ~~~~ here
+4| var blah = '${test}'
+                 ~~~~ here
 
-                // calculate expected ranges
-                var expectedRanges = symbolToSyntaxLookup[symbol]
-                    .Select(node => PositionHelper.GetNameRange(lineStarts, node));
+""")]
+    public async Task FindReferencesWithoutDeclarationsShouldProduceCorrectResults(string inputWithCursor, string outputAnnotated)
+    {
+        var (contents, cursor) = ParserHelper.GetFileWithSingleCursor(inputWithCursor);
+        var file = await new ServerRequestHelper(TestContext, DefaultServer).OpenFile(contents);
 
-                using (new AssertionScope()
-                    .WithAnnotations(compilation.SourceFileGrouping.EntryPoint, "expected", expectedRanges, _ => "here", x => x)
-                    .WithAnnotations(compilation.SourceFileGrouping.EntryPoint, "actual", locations, _ => "here", x => x.Range))
-                {
-                    // ranges should match what we got from our own symbol table
-                    locations!.Select(l => l.Range).Should().BeEquivalentTo(expectedRanges);
-                }
-            }
-        }
+        var locations = await file.RequestReferences(cursor, includeDeclaration: false);
 
-        [DataTestMethod]
-        [DynamicData(nameof(GetData), DynamicDataSourceType.Method, DynamicDataDisplayNameDeclaringType = typeof(DataSet), DynamicDataDisplayName = nameof(DataSet.GetDisplayName))]
-        public async Task FindReferencesWithoutDeclarationsShouldProduceCorrectResults(DataSet dataSet)
-        {
-            var (compilation, _, fileUri) = await dataSet.SetupPrerequisitesAndCreateCompilation(TestContext);
-            var uri = DocumentUri.From(fileUri);
+        // all URIs should be the same in the results
+        locations!.Select(r => r.Uri.ToUriEncoded()).Should().AllBeEquivalentTo(file.Source.FileUri);
 
-            var helper = await DefaultServer.GetAsync();
-            await helper.OpenFileOnceAsync(TestContext, dataSet.Bicep, uri);
+        AnnotateWithLocations(file, locations).Should().EqualIgnoringTrailingWhitespace(outputAnnotated);
+    }
 
-            var symbolTable = compilation.ReconstructSymbolTable();
-            var lineStarts = compilation.SourceFileGrouping.EntryPoint.LineStarts;
+    [TestMethod]
+    [DataRow("""
+var test = 'asdf'
+|
+var asdf = test
+var blah = '${test}'
+""")]
+    public async Task FindReferencesOnNonSymbolsShouldProduceEmptyResult(string inputWithCursor)
+    {
+        var (contents, cursor) = ParserHelper.GetFileWithSingleCursor(inputWithCursor);
+        var file = await new ServerRequestHelper(TestContext, DefaultServer).OpenFile(contents);
 
-            // filter out bind failures and locals with invalid identifiers
-            // (locals are special because their span is equal to their identifier span)
-            var filteredSymbolTable = symbolTable.Where(pair => pair.Value.Kind != SymbolKind.Error && (pair.Value is not LocalVariableSymbol local || local.NameSource.IsValid));
-            // TODO: Implement for PropertySymbol
-            filteredSymbolTable = filteredSymbolTable.Where(pair => pair.Value is not PropertySymbol);
-            var symbolToSyntaxLookup = filteredSymbolTable.ToLookup(pair => pair.Value, pair => pair.Key);
+        var locations = await file.RequestReferences(cursor, includeDeclaration: false);
 
-            foreach (var (syntax, symbol) in filteredSymbolTable)
-            {
-                var locations = await helper.Client.RequestReferences(new ReferenceParams
-                {
-                    TextDocument = new TextDocumentIdentifier(uri),
-                    Context = new ReferenceContext
-                    {
-                        IncludeDeclaration = false
-                    },
-                    Position = IntegrationTestHelper.GetPosition(lineStarts, syntax)
-                });
+        // all URIs should be the same in the results
+        locations.Should().BeNullOrEmpty();
+    }
 
-                // all URIs should be the same in the results
-                locations!.Select(r => r.Uri).Should().AllBeEquivalentTo(uri);
-
-                // exclude declarations when calculating expected ranges
-                var expectedRanges = symbolToSyntaxLookup[symbol]
-                    .Where(node => !(node is INamedDeclarationSyntax))
-                    .Select(node => PositionHelper.GetNameRange(lineStarts, node));
-
-                using (new AssertionScope()
-                    .WithAnnotations(compilation.SourceFileGrouping.EntryPoint, "expected", expectedRanges, _ => "here", x => x)
-                    .WithAnnotations(compilation.SourceFileGrouping.EntryPoint, "actual", locations, _ => "here", x => x.Range))
-                {
-                    // ranges should match what we got from our own symbol table
-                    locations!.Select(l => l.Range).Should().BeEquivalentTo(expectedRanges);
-                }
-            }
-        }
-
-        [TestMethod]
-        [DynamicData(nameof(GetData), DynamicDataSourceType.Method, DynamicDataDisplayNameDeclaringType = typeof(DataSet), DynamicDataDisplayName = nameof(DataSet.GetDisplayName))]
-        public async Task FindReferencesOnNonSymbolsShouldProduceEmptyResult(DataSet dataSet)
-        {
-            // local function
-            static bool IsWrongNode(SyntaxBase node) =>
-                !(node is PropertyAccessSyntax propertyAccessSyntax && propertyAccessSyntax.BaseExpression is ISymbolReference) &&
-                node is not ISymbolReference &&
-                node is not INamedDeclarationSyntax &&
-                node is not Token;
-
-            var (compilation, _, fileUri) = await dataSet.SetupPrerequisitesAndCreateCompilation(TestContext);
-            var uri = DocumentUri.From(fileUri);
-
-            var helper = await DefaultServer.GetAsync();
-            await helper.OpenFileOnceAsync(TestContext, dataSet.Bicep, uri);
-
-            var lineStarts = compilation.SourceFileGrouping.EntryPoint.LineStarts;
-
-            var wrongNodes = SyntaxAggregator.Aggregate(
-                compilation.SourceFileGrouping.EntryPoint.ProgramSyntax,
-                new List<SyntaxBase>(),
-                (accumulated, node) =>
-                {
-                    if (IsWrongNode(node) && !(node is ProgramSyntax))
-                    {
-                        accumulated.Add(node);
-                    }
-
-                    return accumulated;
-                },
-                accumulated => accumulated,
-                (accumulated, node) => IsWrongNode(node));
-
-            foreach (var syntax in wrongNodes)
-            {
-                var locations = await helper.Client.RequestReferences(new ReferenceParams
-                {
-                    TextDocument = new TextDocumentIdentifier(uri),
-                    Context = new ReferenceContext
-                    {
-                        IncludeDeclaration = false
-                    },
-                    Position = IntegrationTestHelper.GetPosition(lineStarts, syntax)
-                });
-
-                locations.Should().BeNullOrEmpty();
-            }
-        }
-
-        [TestMethod]
-        public async Task FindReferences_displays_references_on_namespaced_and_non_namespaced_methods()
-        {
-            var (file, cursors) = ParserHelper.GetFileWithCursors(@"
+    [TestMethod]
+    public async Task FindReferences_displays_references_on_namespaced_and_non_namespaced_methods()
+    {
+        var (contents, cursors) = ParserHelper.GetFileWithCursors(@"
 var rg1 = resourc|eGroup().location
 
 var rg2 = az.r|esourceGroup()
@@ -213,48 +136,33 @@ var dep1 = az.depl|oyment()
 
 var dep2 = az.deploy|ment()
 ",
-                '|');
+            '|');
 
-            var bicepFile = SourceFileFactory.CreateBicepFile(new Uri("file:///path/to/main.bicep"), file);
+        var file = await new ServerRequestHelper(TestContext, DefaultServer).OpenFile(contents);
+        var references = await RequestReferences(file, cursors);
 
-            var helper = await DefaultServer.GetAsync();
-            await helper.OpenFileOnceAsync(TestContext, file, bicepFile.FileUri);
+        references.Should().SatisfyRespectively(
+            r => r.Should().HaveCount(3),
+            r => r.Should().HaveCount(3),
+            r => r.Should().HaveCount(3),
+            r => r.Should().HaveCount(2),
+            r => r.Should().HaveCount(2));
+    }
 
-            var client = helper.Client;
-            var references = await RequestReferences(client, bicepFile, cursors);
+    private static string AnnotateWithLocations(FileRequestHelper file, LocationContainer? locations)
+        => PrintHelper.PrintWithAnnotations(
+            file.Source,
+            locations!.Select(x => new PrintHelper.Annotation(Assertions.AssertionScopeExtensions.FromRange(file.Source, x.Range), "here")), 1, true);
 
-            references.Should().SatisfyRespectively(
-                r => r.Should().HaveCount(3),
-                r => r.Should().HaveCount(3),
-                r => r.Should().HaveCount(3),
-                r => r.Should().HaveCount(2),
-                r => r.Should().HaveCount(2));
-        }
-
-        private static IEnumerable<object[]> GetData()
+    private static async Task<IEnumerable<LocationContainer?>> RequestReferences(FileRequestHelper file, IEnumerable<int> cursors)
+    {
+        var references = new List<LocationContainer?>();
+        foreach (var cursor in cursors)
         {
-            return DataSets.NonStressDataSets.ToDynamicTestData();
+            var referenceList = await file.RequestReferences(cursor, includeDeclaration: false);
+            references.Add(referenceList);
         }
 
-        private static async Task<IEnumerable<LocationContainer?>> RequestReferences(ILanguageClient client, BicepFile bicepFile, IEnumerable<int> cursors)
-        {
-            var references = new List<LocationContainer?>();
-            foreach (var cursor in cursors)
-            {
-                var referenceList = await client.RequestReferences(new ReferenceParams
-                {
-                    TextDocument = new TextDocumentIdentifier(bicepFile.FileUri),
-                    Context = new ReferenceContext
-                    {
-                        IncludeDeclaration = false
-                    },
-                    Position = TextCoordinateConverter.GetPosition(bicepFile.LineStarts, cursor),
-                });
-
-                references.Add(referenceList);
-            }
-
-            return references;
-        }
+        return references;
     }
 }

--- a/src/Bicep.LangServer.IntegrationTests/RenameSymbolTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/RenameSymbolTests.cs
@@ -12,6 +12,9 @@ using Bicep.Core.Samples;
 using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
 using Bicep.Core.Syntax.Visitors;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests;
+using Bicep.Core.UnitTests.Utils;
 using Bicep.LangServer.IntegrationTests.Extensions;
 using Bicep.LangServer.IntegrationTests.Helpers;
 using Bicep.LanguageServer.Utils;
@@ -22,193 +25,63 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using SymbolKind = Bicep.Core.Semantics.SymbolKind;
 
-namespace Bicep.LangServer.IntegrationTests
+namespace Bicep.LangServer.IntegrationTests;
+
+[TestClass]
+public class RenameSymbolTests : TestBase
 {
-    [TestClass]
-    public class RenameSymbolTests
+    private static readonly SharedLanguageHelperManager DefaultServer = new();
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext testContext)
     {
-        private static readonly SharedLanguageHelperManager DefaultServer = new();
+        DefaultServer.Initialize(async () => await MultiFileLanguageServerHelper.StartLanguageServer(testContext));
+    }
 
-        [NotNull]
-        public TestContext? TestContext { get; set; }
+    [ClassCleanup]
+    public static async Task ClassCleanup()
+    {
+        await DefaultServer.DisposeAsync();
+    }
 
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext testContext)
-        {
-            DefaultServer.Initialize(async () => await MultiFileLanguageServerHelper.StartLanguageServer(testContext));
-        }
+    [TestMethod]
+    [DataRow("""
+var te|st = 'asdf'
 
-        [ClassCleanup]
-        public static async Task ClassCleanup()
-        {
-            await DefaultServer.DisposeAsync();
-        }
+var asdf = test
+var blah = '${test}'
+""", """
+var NewIdentifier = 'asdf'
 
-        [DataTestMethod]
-        [DynamicData(nameof(GetData), DynamicDataSourceType.Method, DynamicDataDisplayNameDeclaringType = typeof(DataSet), DynamicDataDisplayName = nameof(DataSet.GetDisplayName))]
-        public async Task RenamingIdentifierAccessOrDeclarationShouldRenameDeclarationAndAllReferences(DataSet dataSet)
-        {
-            var (compilation, _, fileUri) = await dataSet.SetupPrerequisitesAndCreateCompilation(TestContext);
-            var uri = DocumentUri.From(fileUri);
+var asdf = NewIdentifier
+var blah = '${NewIdentifier}'
+""")]
+    public async Task RenamingIdentifierAccessOrDeclarationShouldRenameDeclarationAndAllReferences(string inputWithCursor, string expectedOutput)
+    {
+        var (contents, cursor) = ParserHelper.GetFileWithSingleCursor(inputWithCursor);
+        var file = await new ServerRequestHelper(TestContext, DefaultServer).OpenFile(contents);
 
-            var helper = await DefaultServer.GetAsync();
-            await helper.OpenFileOnceAsync(TestContext, dataSet.Bicep, uri);
+        var edit = await file.RequestRename(cursor, "NewIdentifier");
 
-            var symbolTable = compilation.ReconstructSymbolTable();
-            var lineStarts = compilation.SourceFileGrouping.EntryPoint.LineStarts;
+        var appliedEdit = file.ApplyWorkspaceEdit(edit).ProgramSyntax.ToTextPreserveFormatting();
+        
+        appliedEdit.Should().EqualIgnoringTrailingWhitespace(expectedOutput);
+    }
 
-            var symbolToSyntaxLookup = symbolTable
-                .Where(pair => pair.Value.Kind != SymbolKind.Error)
-                .ToLookup(pair => pair.Value, pair => pair.Key);
+    [TestMethod]
+    [DataRow("""
+var test = 'asdf'
+|
+var asdf = test
+var blah = '${test}'
+""")]
+    public async Task RenamingFunctionsShouldProduceEmptyEdit(string inputWithCursor)
+    {
+        var (contents, cursor) = ParserHelper.GetFileWithSingleCursor(inputWithCursor);
+        var file = await new ServerRequestHelper(TestContext, DefaultServer).OpenFile(contents);
 
-            var validVariableAccessPairs = symbolTable
-                .Where(pair => (pair.Key is VariableAccessSyntax || pair.Key is ResourceAccessSyntax || pair.Key is ITopLevelNamedDeclarationSyntax)
-                               && pair.Value.Kind != SymbolKind.Error
-                               && pair.Value.Kind != SymbolKind.Function
-                               && pair.Value.Kind != SymbolKind.Namespace
-                               && pair.Value is not AmbientTypeSymbol
-                               // symbols whose identifiers have parse errors will have a name like <error> or <missing>
-                               && pair.Value.Name.Contains('<') == false);
+        var edit = await file.RequestRename(cursor, "NewIdentifier");
 
-            const string expectedNewText = "NewIdentifier";
-            foreach (var (syntax, symbol) in validVariableAccessPairs)
-            {
-                var edit = await helper.Client.RequestRename(new RenameParams
-                {
-                    NewName = expectedNewText,
-                    TextDocument = new TextDocumentIdentifier(uri),
-                    Position = IntegrationTestHelper.GetPosition(lineStarts, syntax)
-                });
-
-                edit.Should().NotBeNull();
-                edit!.DocumentChanges.Should().BeNullOrEmpty();
-                edit.Changes.Should().NotBeNull();
-                edit.Changes.Should().HaveCount(1);
-                edit.Changes.Should().ContainKey(uri);
-
-                var textEdits = edit.Changes![uri];
-                textEdits.Should().NotBeEmpty();
-
-                var expectedEdits = symbolToSyntaxLookup[symbol]
-                    .Select(node => CreateExpectedTextEdit(lineStarts, expectedNewText, node));
-
-                textEdits.Should().BeEquivalentTo(expectedEdits);
-            }
-        }
-
-        [DataTestMethod]
-        [DynamicData(nameof(GetData), DynamicDataSourceType.Method, DynamicDataDisplayNameDeclaringType = typeof(DataSet), DynamicDataDisplayName = nameof(DataSet.GetDisplayName))]
-        public async Task RenamingFunctionsShouldProduceEmptyEdit(DataSet dataSet)
-        {
-            var (compilation, _, fileUri) = await dataSet.SetupPrerequisitesAndCreateCompilation(TestContext);
-            var uri = DocumentUri.From(fileUri);
-
-            var helper = await DefaultServer.GetAsync();
-            await helper.OpenFileOnceAsync(TestContext, dataSet.Bicep, uri);
-
-            var symbolTable = compilation.ReconstructSymbolTable();
-            var lineStarts = compilation.SourceFileGrouping.EntryPoint.LineStarts;
-
-            var validFunctionCallPairs = symbolTable
-                .Where(pair => pair.Value is FunctionSymbol)
-                .Select(pair => pair.Key);
-
-            foreach (var syntax in validFunctionCallPairs)
-            {
-                var edit = await helper.Client.RequestRename(new RenameParams
-                {
-                    NewName = "NewIdentifier",
-                    TextDocument = new TextDocumentIdentifier(uri),
-                    Position = IntegrationTestHelper.GetPosition(lineStarts, syntax)
-                });
-
-                edit.Should().BeNull();
-            }
-        }
-
-        [DataTestMethod]
-        [DynamicData(nameof(GetData), DynamicDataSourceType.Method, DynamicDataDisplayNameDeclaringType = typeof(DataSet), DynamicDataDisplayName = nameof(DataSet.GetDisplayName))]
-        public async Task RenamingNonSymbolsShouldProduceEmptyEdit(DataSet dataSet)
-        {
-            // local function
-            bool IsWrongNode(SyntaxBase node) => !(node is ISymbolReference) && !(node is INamedDeclarationSyntax) && !(node is Token);
-
-            var (compilation, _, fileUri) = await dataSet.SetupPrerequisitesAndCreateCompilation(TestContext);
-            var uri = DocumentUri.From(fileUri);
-
-            var helper = await DefaultServer.GetAsync();
-            await helper.OpenFileOnceAsync(TestContext, dataSet.Bicep, uri);
-
-            var lineStarts = compilation.SourceFileGrouping.EntryPoint.LineStarts;
-
-            var wrongNodes = SyntaxAggregator.Aggregate(
-                compilation.SourceFileGrouping.EntryPoint.ProgramSyntax,
-                new List<SyntaxBase>(),
-                (accumulated, node) =>
-                {
-                    if (IsWrongNode(node) && !(node is ProgramSyntax))
-                    {
-                        accumulated.Add(node);
-                    }
-
-                    return accumulated;
-                },
-                accumulated => accumulated,
-                (accumulated, node) => IsWrongNode(node));
-
-            foreach (var syntax in wrongNodes)
-            {
-                var edit = await helper.Client.RequestRename(new RenameParams
-                {
-                    NewName = "NewIdentifier",
-                    TextDocument = new TextDocumentIdentifier(uri),
-                    Position = IntegrationTestHelper.GetPosition(lineStarts, syntax)
-                });
-
-                edit.Should().BeNull();
-            }
-        }
-
-        [DataTestMethod]
-        [DynamicData(nameof(GetData), DynamicDataSourceType.Method, DynamicDataDisplayNameDeclaringType = typeof(DataSet), DynamicDataDisplayName = nameof(DataSet.GetDisplayName))]
-        public async Task RenamingIdentifierWithInvalidNameShouldProduceEmptyEdit(DataSet dataSet)
-        {
-            var (compilation, _, fileUri) = await dataSet.SetupPrerequisitesAndCreateCompilation(TestContext);
-            var uri = DocumentUri.From(fileUri);
-
-            var helper = await DefaultServer.GetAsync();
-            await helper.OpenFileOnceAsync(TestContext, dataSet.Bicep, uri);
-
-            var symbolTable = compilation.ReconstructSymbolTable();
-            var lineStarts = compilation.SourceFileGrouping.EntryPoint.LineStarts;
-
-            var validFunctionCallPairs = symbolTable
-                .Where(pair => pair.Value.Kind == SymbolKind.Parameter)
-                .Select(pair => pair.Key);
-
-            foreach (var syntax in validFunctionCallPairs)
-            {
-                var edit = await helper.Client.RequestRename(new RenameParams
-                {
-                    NewName = "NewIdentifier;",
-                    TextDocument = new TextDocumentIdentifier(uri),
-                    Position = IntegrationTestHelper.GetPosition(lineStarts, syntax)
-                });
-
-                edit.Should().BeNull();
-            }
-        }
-
-        private static TextEdit CreateExpectedTextEdit(ImmutableArray<int> lineStarts, string newText, SyntaxBase syntax) =>
-            new()
-            {
-                NewText = newText,
-                Range = PositionHelper.GetNameRange(lineStarts, syntax)
-            };
-
-        private static IEnumerable<object[]> GetData()
-        {
-            return DataSets.NonStressDataSets.ToDynamicTestData();
-        }
+        edit.Should().BeNull();
     }
 }


### PR DESCRIPTION
Implements some of the ideas under #12409

- Replace a few expensive baseline tests (identified from .trx output) with simpler targeted tests
- Simplify test logic

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12711)