### PR TITLE
Pin moq version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,11 +18,15 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+    ignore:
+      - dependency-name: "Moq"
   - package-ecosystem: "nuget"
     directory: "/src/vs-bicep"
     schedule:
       interval: "weekly"
       day: "sunday"
+    ignore:
+      - dependency-name: "Moq"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/src/Bicep.Cli.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Cli.IntegrationTests/packages.lock.json
@@ -634,8 +634,8 @@
       },
       "Moq": {
         "type": "Transitive",
-        "resolved": "4.20.69",
-        "contentHash": "8P/oAUOL8ZVyXnzBBcgdhTsOD1kQbAWfOcMI7KDQO3HqQtzB/0WYLdnMa4Jefv8nu/MQYiiG0IuoJdvG0v0Nig==",
+        "resolved": "4.18.4",
+        "contentHash": "IOo+W51+7Afnb0noltJrKxPBSfsgMzTKCw+Re5AMx8l/vBbAbMDOynLik4+lBYIWDJSO0uV7Zdqt7cNb6RZZ+A==",
         "dependencies": {
           "Castle.Core": "5.1.1"
         }
@@ -2160,7 +2160,7 @@
           "MSTest.TestAdapter": "[3.1.1, )",
           "MSTest.TestFramework": "[3.1.1, )",
           "Microsoft.NET.Test.Sdk": "[17.8.0, )",
-          "Moq": "[4.20.69, )",
+          "Moq": "[4.18.4, )",
           "System.IO.Abstractions.TestingHelpers": "[19.2.69, )"
         }
       },

--- a/src/Bicep.Core.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Core.IntegrationTests/packages.lock.json
@@ -597,8 +597,8 @@
       },
       "Moq": {
         "type": "Transitive",
-        "resolved": "4.20.69",
-        "contentHash": "8P/oAUOL8ZVyXnzBBcgdhTsOD1kQbAWfOcMI7KDQO3HqQtzB/0WYLdnMa4Jefv8nu/MQYiiG0IuoJdvG0v0Nig==",
+        "resolved": "4.18.4",
+        "contentHash": "IOo+W51+7Afnb0noltJrKxPBSfsgMzTKCw+Re5AMx8l/vBbAbMDOynLik4+lBYIWDJSO0uV7Zdqt7cNb6RZZ+A==",
         "dependencies": {
           "Castle.Core": "5.1.1"
         }
@@ -2067,7 +2067,7 @@
           "MSTest.TestAdapter": "[3.1.1, )",
           "MSTest.TestFramework": "[3.1.1, )",
           "Microsoft.NET.Test.Sdk": "[17.8.0, )",
-          "Moq": "[4.20.69, )",
+          "Moq": "[4.18.4, )",
           "System.IO.Abstractions.TestingHelpers": "[19.2.69, )"
         }
       },

--- a/src/Bicep.Core.Samples/packages.lock.json
+++ b/src/Bicep.Core.Samples/packages.lock.json
@@ -597,8 +597,8 @@
       },
       "Moq": {
         "type": "Transitive",
-        "resolved": "4.20.69",
-        "contentHash": "8P/oAUOL8ZVyXnzBBcgdhTsOD1kQbAWfOcMI7KDQO3HqQtzB/0WYLdnMa4Jefv8nu/MQYiiG0IuoJdvG0v0Nig==",
+        "resolved": "4.18.4",
+        "contentHash": "IOo+W51+7Afnb0noltJrKxPBSfsgMzTKCw+Re5AMx8l/vBbAbMDOynLik4+lBYIWDJSO0uV7Zdqt7cNb6RZZ+A==",
         "dependencies": {
           "Castle.Core": "5.1.1"
         }
@@ -2056,7 +2056,7 @@
           "MSTest.TestAdapter": "[3.1.1, )",
           "MSTest.TestFramework": "[3.1.1, )",
           "Microsoft.NET.Test.Sdk": "[17.8.0, )",
-          "Moq": "[4.20.69, )",
+          "Moq": "[4.18.4, )",
           "System.IO.Abstractions.TestingHelpers": "[19.2.69, )"
         }
       },

--- a/src/Bicep.Core.UnitTests/Bicep.Core.UnitTests.csproj
+++ b/src/Bicep.Core.UnitTests/Bicep.Core.UnitTests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="JsonDiffPatch.Net" Version="2.3.0" />
     <PackageReference Include="DiffPlex" Version="1.7.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">

--- a/src/Bicep.Core.UnitTests/packages.lock.json
+++ b/src/Bicep.Core.UnitTests/packages.lock.json
@@ -66,9 +66,9 @@
       },
       "Moq": {
         "type": "Direct",
-        "requested": "[4.20.69, )",
-        "resolved": "4.20.69",
-        "contentHash": "8P/oAUOL8ZVyXnzBBcgdhTsOD1kQbAWfOcMI7KDQO3HqQtzB/0WYLdnMa4Jefv8nu/MQYiiG0IuoJdvG0v0Nig==",
+        "requested": "[4.18.4, )",
+        "resolved": "4.18.4",
+        "contentHash": "IOo+W51+7Afnb0noltJrKxPBSfsgMzTKCw+Re5AMx8l/vBbAbMDOynLik4+lBYIWDJSO0uV7Zdqt7cNb6RZZ+A==",
         "dependencies": {
           "Castle.Core": "5.1.1"
         }

--- a/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
@@ -597,8 +597,8 @@
       },
       "Moq": {
         "type": "Transitive",
-        "resolved": "4.20.69",
-        "contentHash": "8P/oAUOL8ZVyXnzBBcgdhTsOD1kQbAWfOcMI7KDQO3HqQtzB/0WYLdnMa4Jefv8nu/MQYiiG0IuoJdvG0v0Nig==",
+        "resolved": "4.18.4",
+        "contentHash": "IOo+W51+7Afnb0noltJrKxPBSfsgMzTKCw+Re5AMx8l/vBbAbMDOynLik4+lBYIWDJSO0uV7Zdqt7cNb6RZZ+A==",
         "dependencies": {
           "Castle.Core": "5.1.1"
         }
@@ -2056,7 +2056,7 @@
           "MSTest.TestAdapter": "[3.1.1, )",
           "MSTest.TestFramework": "[3.1.1, )",
           "Microsoft.NET.Test.Sdk": "[17.8.0, )",
-          "Moq": "[4.20.69, )",
+          "Moq": "[4.18.4, )",
           "System.IO.Abstractions.TestingHelpers": "[19.2.69, )"
         }
       },

--- a/src/Bicep.Decompiler.UnitTests/packages.lock.json
+++ b/src/Bicep.Decompiler.UnitTests/packages.lock.json
@@ -597,8 +597,8 @@
       },
       "Moq": {
         "type": "Transitive",
-        "resolved": "4.20.69",
-        "contentHash": "8P/oAUOL8ZVyXnzBBcgdhTsOD1kQbAWfOcMI7KDQO3HqQtzB/0WYLdnMa4Jefv8nu/MQYiiG0IuoJdvG0v0Nig==",
+        "resolved": "4.18.4",
+        "contentHash": "IOo+W51+7Afnb0noltJrKxPBSfsgMzTKCw+Re5AMx8l/vBbAbMDOynLik4+lBYIWDJSO0uV7Zdqt7cNb6RZZ+A==",
         "dependencies": {
           "Castle.Core": "5.1.1"
         }
@@ -2056,7 +2056,7 @@
           "MSTest.TestAdapter": "[3.1.1, )",
           "MSTest.TestFramework": "[3.1.1, )",
           "Microsoft.NET.Test.Sdk": "[17.8.0, )",
-          "Moq": "[4.20.69, )",
+          "Moq": "[4.18.4, )",
           "System.IO.Abstractions.TestingHelpers": "[19.2.69, )"
         }
       },

--- a/src/Bicep.LangServer.IntegrationTests/packages.lock.json
+++ b/src/Bicep.LangServer.IntegrationTests/packages.lock.json
@@ -2081,7 +2081,7 @@
           "MSTest.TestAdapter": "[3.1.1, )",
           "MSTest.TestFramework": "[3.1.1, )",
           "Microsoft.NET.Test.Sdk": "[17.8.0, )",
-          "Moq": "[4.20.69, )",
+          "Moq": "[4.18.4, )",
           "System.IO.Abstractions.TestingHelpers": "[19.2.69, )"
         }
       },

--- a/src/Bicep.LangServer.UnitTests/packages.lock.json
+++ b/src/Bicep.LangServer.UnitTests/packages.lock.json
@@ -2095,7 +2095,7 @@
           "MSTest.TestAdapter": "[3.1.1, )",
           "MSTest.TestFramework": "[3.1.1, )",
           "Microsoft.NET.Test.Sdk": "[17.8.0, )",
-          "Moq": "[4.20.69, )",
+          "Moq": "[4.18.4, )",
           "System.IO.Abstractions.TestingHelpers": "[19.2.69, )"
         }
       },

--- a/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
@@ -2305,7 +2305,7 @@
           "MSTest.TestAdapter": "[3.1.1, )",
           "MSTest.TestFramework": "[3.1.1, )",
           "Microsoft.NET.Test.Sdk": "[17.8.0, )",
-          "Moq": "[4.20.69, )",
+          "Moq": "[4.18.4, )",
           "System.IO.Abstractions.TestingHelpers": "[19.2.69, )"
         }
       },

--- a/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
@@ -2299,7 +2299,7 @@
           "MSTest.TestAdapter": "[3.1.1, )",
           "MSTest.TestFramework": "[3.1.1, )",
           "Microsoft.NET.Test.Sdk": "[17.8.0, )",
-          "Moq": "[4.20.69, )",
+          "Moq": "[4.18.4, )",
           "System.IO.Abstractions.TestingHelpers": "[19.2.69, )"
         }
       },

--- a/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
@@ -2305,7 +2305,7 @@
           "MSTest.TestAdapter": "[3.1.1, )",
           "MSTest.TestFramework": "[3.1.1, )",
           "Microsoft.NET.Test.Sdk": "[17.8.0, )",
-          "Moq": "[4.20.69, )",
+          "Moq": "[4.18.4, )",
           "System.IO.Abstractions.TestingHelpers": "[19.2.69, )"
         }
       },

--- a/src/Bicep.Tools.Benchmark/packages.lock.json
+++ b/src/Bicep.Tools.Benchmark/packages.lock.json
@@ -2168,7 +2168,7 @@
           "MSTest.TestAdapter": "[3.1.1, )",
           "MSTest.TestFramework": "[3.1.1, )",
           "Microsoft.NET.Test.Sdk": "[17.8.0, )",
-          "Moq": "[4.20.69, )",
+          "Moq": "[4.18.4, )",
           "System.IO.Abstractions.TestingHelpers": "[19.2.69, )"
         }
       },

--- a/src/vs-bicep/Bicep.VSLanguageServerClient.UnitTests/Bicep.VSLanguageServerClient.UnitTests.csproj
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient.UnitTests/Bicep.VSLanguageServerClient.UnitTests.csproj
@@ -14,7 +14,7 @@
 		<PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.5.0-2.final" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="17.2.8" />
 		<PackageReference Include="Microsoft.VisualStudio.Utilities" Version="17.2.32505.113" />
-		<PackageReference Include="Moq" Version="4.16.1" />
+		<PackageReference Include="Moq" Version="4.18.4" />
 		<PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
 		<PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
 	</ItemGroup>

--- a/src/vs-bicep/Bicep.VSLanguageServerClient.UnitTests/packages.lock.json
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient.UnitTests/packages.lock.json
@@ -73,11 +73,11 @@
       },
       "Moq": {
         "type": "Direct",
-        "requested": "[4.16.1, )",
-        "resolved": "4.16.1",
-        "contentHash": "bw3R9q8cVNhWXNpnvWb0OGP4HadS4zvClq+T1zf7AF+tLY1haZ2AvbHidQekf4PDv1T40c6brZeT/V0IBq7cEQ==",
+        "requested": "[4.18.4, )",
+        "resolved": "4.18.4",
+        "contentHash": "IOo+W51+7Afnb0noltJrKxPBSfsgMzTKCw+Re5AMx8l/vBbAbMDOynLik4+lBYIWDJSO0uV7Zdqt7cNb6RZZ+A==",
         "dependencies": {
-          "Castle.Core": "4.4.0",
+          "Castle.Core": "5.1.1",
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
@@ -101,8 +101,8 @@
       },
       "Castle.Core": {
         "type": "Transitive",
-        "resolved": "4.4.0",
-        "contentHash": "b5rRL5zeaau1y/5hIbI+6mGw3cwun16YjkHZnV9RRT5UyUIFsgLmNXJ0YnIN9p8Hw7K7AbG1q1UclQVU3DinAQ=="
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g=="
       },
       "MediatR": {
         "type": "Transitive",


### PR DESCRIPTION
This is to fix a Component Governance issue. The suggestion from the security team is to pin moq to version 4.18.4 or use another mock library. For now we'll just pin moq version.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12718)