### PR TITLE
include `required` mark for parameters that doesn't have a default value

### DIFF
--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -111,7 +111,7 @@ namespace Bicep.LanguageServer.Completions
                             .WithDocumentation(
                                 MarkdownHelper.AppendNewline($"Type: `{metadata.TypeReference.Type}`") +
                                 MarkdownHelper.AppendNewline(metadata.Description))
-                            .WithDetail(metadata.Name)
+                            .WithDetail(!metadata.IsRequired ? metadata.Name : $"{metadata.Name} (Required)")
                             .WithPlainTextEdit(paramsCompletionContext.ReplacementRange, metadata.Name)
                             .Build();
                     }
@@ -2147,7 +2147,7 @@ namespace Bicep.LanguageServer.Completions
 
                 var documentation = DescriptionHelper.TryGetFromDecorator(model, decorableSyntax);
                 buffer.Append(MarkdownHelper.AppendNewline(documentation));
-                
+
                 return buffer.ToString();
             }
 


### PR DESCRIPTION
Fixes #12039 

Adding `(Required)` text to the parameter title when the parameter doesn't have a default value;

Screenshot of a `.bicepparam` file with a `(Required)` parameter shown;

![image](https://github.com/Azure/bicep/assets/118744/4f0087ef-fe90-41ea-8890-c415429e22df)

Screenshot of a `.bicepparam` file with a `not` `(Required)` parameter shown;

![image](https://github.com/Azure/bicep/assets/118744/41377372-898e-4f22-a615-2a6a37e3ac89)

> Just like submodule parameters in `.bicep` files has `(Required)` text if they don't have a default value;

Screenshot of a sample `.bicep` file;

![image](https://github.com/Azure/bicep/assets/118744/2d12576c-db36-4508-8f2b-b8505fef435e)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12749)