### PR TITLE
Fix Moq versions in more projects

### DIFF
--- a/src/Bicep.LangServer.IntegrationTests/Bicep.LangServer.IntegrationTests.csproj
+++ b/src/Bicep.LangServer.IntegrationTests/Bicep.LangServer.IntegrationTests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.7.30" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.19.9" />

--- a/src/Bicep.LangServer.IntegrationTests/packages.lock.json
+++ b/src/Bicep.LangServer.IntegrationTests/packages.lock.json
@@ -64,9 +64,9 @@
       },
       "Moq": {
         "type": "Direct",
-        "requested": "[4.20.69, )",
-        "resolved": "4.20.69",
-        "contentHash": "8P/oAUOL8ZVyXnzBBcgdhTsOD1kQbAWfOcMI7KDQO3HqQtzB/0WYLdnMa4Jefv8nu/MQYiiG0IuoJdvG0v0Nig==",
+        "requested": "[4.18.4, )",
+        "resolved": "4.18.4",
+        "contentHash": "IOo+W51+7Afnb0noltJrKxPBSfsgMzTKCw+Re5AMx8l/vBbAbMDOynLik4+lBYIWDJSO0uV7Zdqt7cNb6RZZ+A==",
         "dependencies": {
           "Castle.Core": "5.1.1"
         }

--- a/src/Bicep.LangServer.UnitTests/Bicep.LangServer.UnitTests.csproj
+++ b/src/Bicep.LangServer.UnitTests/Bicep.LangServer.UnitTests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.19.9" />

--- a/src/Bicep.LangServer.UnitTests/packages.lock.json
+++ b/src/Bicep.LangServer.UnitTests/packages.lock.json
@@ -51,9 +51,9 @@
       },
       "Moq": {
         "type": "Direct",
-        "requested": "[4.20.69, )",
-        "resolved": "4.20.69",
-        "contentHash": "8P/oAUOL8ZVyXnzBBcgdhTsOD1kQbAWfOcMI7KDQO3HqQtzB/0WYLdnMa4Jefv8nu/MQYiiG0IuoJdvG0v0Nig==",
+        "requested": "[4.18.4, )",
+        "resolved": "4.18.4",
+        "contentHash": "IOo+W51+7Afnb0noltJrKxPBSfsgMzTKCw+Re5AMx8l/vBbAbMDOynLik4+lBYIWDJSO0uV7Zdqt7cNb6RZZ+A==",
         "dependencies": {
           "Castle.Core": "5.1.1"
         }
@@ -2122,7 +2122,7 @@
           "MSTest.TestFramework": "[3.1.1, )",
           "Microsoft.NET.Test.Sdk": "[17.8.0, )",
           "Microsoft.VisualStudio.Threading": "[17.7.30, )",
-          "Moq": "[4.20.69, )",
+          "Moq": "[4.18.4, )",
           "OmniSharp.Extensions.LanguageClient": "[0.19.9, )"
         }
       }

--- a/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
@@ -761,8 +761,8 @@
       },
       "Moq": {
         "type": "Transitive",
-        "resolved": "4.20.69",
-        "contentHash": "8P/oAUOL8ZVyXnzBBcgdhTsOD1kQbAWfOcMI7KDQO3HqQtzB/0WYLdnMa4Jefv8nu/MQYiiG0IuoJdvG0v0Nig==",
+        "resolved": "4.18.4",
+        "contentHash": "IOo+W51+7Afnb0noltJrKxPBSfsgMzTKCw+Re5AMx8l/vBbAbMDOynLik4+lBYIWDJSO0uV7Zdqt7cNb6RZZ+A==",
         "dependencies": {
           "Castle.Core": "5.1.1"
         }
@@ -2328,7 +2328,7 @@
           "Bicep.Core.UnitTests": "[1.0.0, )",
           "FluentAssertions": "[6.12.0, )",
           "JsonPatch.Net": "[2.1.0, )",
-          "Moq": "[4.20.69, )",
+          "Moq": "[4.18.4, )",
           "System.IO.Abstractions.TestingHelpers": "[19.2.69, )"
         }
       }

--- a/src/Bicep.RegistryModuleTool.TestFixtures/Bicep.RegistryModuleTool.TestFixtures.csproj
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/Bicep.RegistryModuleTool.TestFixtures.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="JsonPatch.Net" Version="2.1.0" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="19.2.69" />
   </ItemGroup>
 

--- a/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
@@ -44,9 +44,9 @@
       },
       "Moq": {
         "type": "Direct",
-        "requested": "[4.20.69, )",
-        "resolved": "4.20.69",
-        "contentHash": "8P/oAUOL8ZVyXnzBBcgdhTsOD1kQbAWfOcMI7KDQO3HqQtzB/0WYLdnMa4Jefv8nu/MQYiiG0IuoJdvG0v0Nig==",
+        "requested": "[4.18.4, )",
+        "resolved": "4.18.4",
+        "contentHash": "IOo+W51+7Afnb0noltJrKxPBSfsgMzTKCw+Re5AMx8l/vBbAbMDOynLik4+lBYIWDJSO0uV7Zdqt7cNb6RZZ+A==",
         "dependencies": {
           "Castle.Core": "5.1.1"
         }

--- a/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
@@ -761,8 +761,8 @@
       },
       "Moq": {
         "type": "Transitive",
-        "resolved": "4.20.69",
-        "contentHash": "8P/oAUOL8ZVyXnzBBcgdhTsOD1kQbAWfOcMI7KDQO3HqQtzB/0WYLdnMa4Jefv8nu/MQYiiG0IuoJdvG0v0Nig==",
+        "resolved": "4.18.4",
+        "contentHash": "IOo+W51+7Afnb0noltJrKxPBSfsgMzTKCw+Re5AMx8l/vBbAbMDOynLik4+lBYIWDJSO0uV7Zdqt7cNb6RZZ+A==",
         "dependencies": {
           "Castle.Core": "5.1.1"
         }
@@ -2328,7 +2328,7 @@
           "Bicep.Core.UnitTests": "[1.0.0, )",
           "FluentAssertions": "[6.12.0, )",
           "JsonPatch.Net": "[2.1.0, )",
-          "Moq": "[4.20.69, )",
+          "Moq": "[4.18.4, )",
           "System.IO.Abstractions.TestingHelpers": "[19.2.69, )"
         }
       }

--- a/src/Bicep.Tools.Benchmark/packages.lock.json
+++ b/src/Bicep.Tools.Benchmark/packages.lock.json
@@ -669,8 +669,8 @@
       },
       "Moq": {
         "type": "Transitive",
-        "resolved": "4.20.69",
-        "contentHash": "8P/oAUOL8ZVyXnzBBcgdhTsOD1kQbAWfOcMI7KDQO3HqQtzB/0WYLdnMa4Jefv8nu/MQYiiG0IuoJdvG0v0Nig==",
+        "resolved": "4.18.4",
+        "contentHash": "IOo+W51+7Afnb0noltJrKxPBSfsgMzTKCw+Re5AMx8l/vBbAbMDOynLik4+lBYIWDJSO0uV7Zdqt7cNb6RZZ+A==",
         "dependencies": {
           "Castle.Core": "5.1.1"
         }
@@ -2195,7 +2195,7 @@
           "MSTest.TestFramework": "[3.1.1, )",
           "Microsoft.NET.Test.Sdk": "[17.8.0, )",
           "Microsoft.VisualStudio.Threading": "[17.7.30, )",
-          "Moq": "[4.20.69, )",
+          "Moq": "[4.18.4, )",
           "OmniSharp.Extensions.LanguageClient": "[0.19.9, )"
         }
       }


### PR DESCRIPTION
Missed a few places where Moq is used in my previous PR. We should probably enable central package management to avoid this in the future. I've created https://github.com/Azure/bicep/issues/12750 to track it.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12751)