### PR TITLE
Code lenses to switch between bicep and JSON module source

### DIFF
--- a/src/Bicep.Core.UnitTests/Assertions/CodeLensAssertions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/CodeLensAssertions.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Linq;
+using System.Reactive.Subjects;
+using Bicep.Core.UnitTests.Registry;
+using FluentAssertions;
+using FluentAssertions.Primitives;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Bicep.Core.UnitTests.Assertions;
+
+public static class CodeLensAssertionsExtensions
+{
+    public static CodeLensAssertions Should(this CodeLens codeLens)
+    {
+        return new CodeLensAssertions(codeLens);
+    }
+}
+
+public class CodeLensAssertions : ObjectAssertions<CodeLens, CodeLensAssertions>
+{
+    public CodeLensAssertions(CodeLens subject)
+        : base(subject)
+    {
+    }
+
+    protected override string Identifier => nameof(CodeLens);
+
+    public AndConstraint<CodeLensAssertions> HaveCommandTitle(string title, string because = "", params object[] becauseArgs)
+    {
+        Subject.Command.Should().NotBeNull("Code lens command should not be null");
+        Subject.Command!.Title.Should().Be(title, because, becauseArgs);
+
+        return new(this);
+    }
+
+    public AndConstraint<CodeLensAssertions> HaveCommandName(string commandName, string because = "", params object[] becauseArgs)
+    {
+        Subject.Command.Should().NotBeNull("Code lens command should not be null");
+        Subject.Command!.Name.Should().Be(commandName, because, becauseArgs);
+
+        return new(this);
+    }
+
+    public AndConstraint<CodeLensAssertions> HaveCommandArguments(params string[] commandArguments)
+    {
+        Subject.Command.Should().NotBeNull("Code lens command should not be null");
+        Subject.Command!.Arguments.Should().NotBeNull("Command args should not be null");
+        var actualCommandArguments = Subject.CommandArguments();
+        actualCommandArguments.Should().BeEquivalentTo(commandArguments);
+
+        return new(this);
+    }
+
+    public AndConstraint<CodeLensAssertions> HaveNoCommandArguments()
+    {
+        Subject.CommandArguments().Should().BeEmpty("Command should have no arguments");
+
+        return new(this);
+    }
+
+    public AndConstraint<CodeLensAssertions> HaveRange(Range range, string because = "", params object[] becauseArgs)
+    {
+        Subject.Range.Should().Be(range, because, becauseArgs);
+
+        return new(this);
+    }
+
+
+}

--- a/src/Bicep.Core.UnitTests/Extensions/CodeLensExtensions.cs
+++ b/src/Bicep.Core.UnitTests/Extensions/CodeLensExtensions.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Linq;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Bicep.Core.UnitTests.Assertions;
+
+public static class CodeLensExtensions
+{
+    public static string[]? CommandArguments(this CodeLens codeLens)
+    {
+        return codeLens.Command?.Arguments?.Children().Select(token => token.ToString()).ToArray();
+    }
+}

--- a/src/Bicep.Core.UnitTests/Utils/OciModuleRegistryHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/OciModuleRegistryHelper.cs
@@ -67,7 +67,7 @@ namespace Bicep.Core.UnitTests.Utils
             }
         }
 
-        // public a new (real) OciArtifactRegistry instance with an empty on-disk cache that can push and pull modules
+        // create a new (real) OciArtifactRegistry instance with an empty on-disk cache that can push and pull modules
         public static (OciArtifactRegistry, MockRegistryBlobClient) CreateModuleRegistry(
             Uri parentModuleUri,
             IFeatureProvider featureProvider)

--- a/src/Bicep.Core/Navigation/IArtifactReferenceSyntax.cs
+++ b/src/Bicep.Core/Navigation/IArtifactReferenceSyntax.cs
@@ -6,7 +6,7 @@ using Bicep.Core.Syntax;
 namespace Bicep.Core.Navigation;
 
 /// <summary>
-/// Objects that implement IArtifactReferenceSyntax, contain syntax that can reference a foregin artifact, the artifact address
+/// Objects that implement IArtifactReferenceSyntax, contain syntax that can reference a foreign artifact, the artifact address
 /// is returned by `TryGetPath` and `SourceSyntax` contains the source syntax object to use for error propagation.
 /// </summary>
 public interface IArtifactReferenceSyntax

--- a/src/Bicep.Core/Registry/DefaultArtifactRegistryProvider.cs
+++ b/src/Bicep.Core/Registry/DefaultArtifactRegistryProvider.cs
@@ -29,7 +29,12 @@ namespace Bicep.Core.Registry
             this.serviceProvider = serviceProvider;
         }
 
-        // NOTE: The templateUri affects how module aliases are resolved, by determining how the bicepconfig.json is located, which contains alias definitions
+        /// <summary>
+        /// Gets the registries available for module references inside a given template URI.
+        /// </summary>
+        /// <param name="templateUri">URI of the Bicep template source code which contains the module references.
+        /// This is needed to determine the appropriate bicepconfig.json (which contains module alias definitions) and features provider to bind to</param>
+        /// <returns></returns>
         public ImmutableArray<IArtifactRegistry> Registries(Uri templateUri)
         {
             var configuration = configurationManager.GetConfiguration(templateUri);

--- a/src/Bicep.Core/Utils/Result.cs
+++ b/src/Bicep.Core/Utils/Result.cs
@@ -43,7 +43,7 @@ public class Result<TSuccess, TError>
 
     /// <summary>
     /// Returns the succcessful result, assuming success. Throws an exception if not.
-    /// This should only be called if you'e already verified that the result is successful.
+    /// This should only be called if you've already verified that the result is successful.
     /// </summary>
     public TSuccess Unwrap()
         => TryUnwrap() ?? throw new InvalidOperationException("Cannot unwrap a failed result.");

--- a/src/Bicep.LangServer.IntegrationTests/CodeLensTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CodeLensTests.cs
@@ -1,0 +1,230 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Bicep.Core.Registry;
+using Bicep.Core.Samples;
+using Bicep.Core.SourceCode;
+using Bicep.Core.UnitTests;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Mock;
+using Bicep.Core.UnitTests.Utils;
+using Bicep.Core.Workspaces;
+using Bicep.LangServer.IntegrationTests.Helpers;
+using Bicep.LanguageServer.Handlers;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.WindowsAzure.ResourceStack.Common.Extensions;
+using Moq;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+namespace Bicep.LangServer.IntegrationTests
+{
+    [TestClass]
+    public class CodeLensTests
+    {
+        [NotNull]
+        public TestContext? TestContext { get; set; }
+
+        public static string GetDisplayName(MethodInfo info, object[] row)
+        {
+            row.Should().HaveCount(3);
+            row[0].Should().BeOfType<DataSet>();
+            row[1].Should().BeOfType<string>();
+            row[2].Should().BeAssignableTo<IList<Position>>();
+
+            return $"{info.Name}_{((DataSet)row[0]).Name}_{row[1]}";
+        }
+
+        // If entrypointSource is not null, then a source archive will be created with the given entrypointSource, otherwise no source archive will be created.
+        private SharedLanguageHelperManager CreateServer(Uri? bicepModuleEntrypoint, string? entrypointSource)
+        {
+            var moduleRegistry = StrictMock.Of<IArtifactRegistry>();
+            SourceArchive? sourceArchive = null;
+            if (bicepModuleEntrypoint is not null && entrypointSource is not null)
+            {
+                BicepFile moduleEntrypointFile = SourceFileFactory.CreateBicepFile(bicepModuleEntrypoint, entrypointSource);
+                sourceArchive = SourceArchive.FromStream(SourceArchive.PackSourcesIntoStream(moduleEntrypointFile.FileUri, moduleEntrypointFile));
+            }
+            moduleRegistry.Setup(m => m.TryGetSource(It.IsAny<ArtifactReference>())).Returns(sourceArchive);
+
+            var defaultServer = new SharedLanguageHelperManager();
+            defaultServer.Initialize(
+                async () => await MultiFileLanguageServerHelper.StartLanguageServer(
+                    TestContext,
+                    services => services.WithFeatureOverrides(new(TestContext, ExtensibilityEnabled: true)),
+                    moduleRegistry.Object.AsArray()));
+            return defaultServer;
+        }
+
+        [DataTestMethod]
+        [DataRow("file://path/to/localfile.bicep")]
+        [DataRow("file://path/to/localfile.json")]
+        [DataRow("file://path/to/localfile.bicepparam")]
+        [DataRow("untitled:Untitled-1")]
+        public async Task DisplayingLocalFile_NotExtSourceScheme_ShouldNotHaveCodeLens(string fileName)
+        {
+            var uri = DocumentUri.From($"/{this.TestContext.TestName}");
+
+            await using var server = CreateServer(null, null);
+            var helper = await server.GetAsync();
+            await helper.OpenFileOnceAsync(this.TestContext, string.Empty, uri);
+
+            // Local files will have a "file://" scheme
+            var documentUri = DocumentUri.FromFileSystemPath(fileName);
+            var lenses = await GetExternalSourceCodeLenses(helper, documentUri);
+
+            lenses.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public async Task DisplayingExternalModuleSource_EntrypointFile_ShouldHaveCodeLens_ToShowModuleCompiledJson()
+        {
+            var uri = DocumentUri.From($"/{this.TestContext.TestName}");
+            var moduleEntrypointUri = DocumentUri.From($"/module entrypoint.bicep");
+
+            await using var server = CreateServer(moduleEntrypointUri.ToUriEncoded(), "// module entrypoint");
+            var helper = await server.GetAsync();
+            await helper.OpenFileOnceAsync(this.TestContext, string.Empty, uri);
+
+            var externalSourceUri = new ExternalSourceReference("title", "br:myregistry.azurecr.io/myrepo/bicep/module1:v1", Path.GetFileName(moduleEntrypointUri.Path)).ToUri();
+            var lenses = await GetExternalSourceCodeLenses(helper, externalSourceUri);
+
+            lenses.Should().HaveCount(1);
+            var lens = lenses.First();
+            lens.Should().HaveRange(new Range(0, 0, 0, 0));
+            lens.Should().HaveCommandName("bicep.internal.showModuleSourceFile");
+            lens.Should().HaveCommandTitle("Show compiled JSON");
+            var target = new ExternalSourceReference(lens.CommandArguments().Single());
+            target.IsRequestingCompiledJson.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public async Task DisplayingExternalModuleSource_BicepButNotEntrypointFile_ShouldHaveCodeLens_ToShowModuleCompiledJson()
+        {
+            var uri = DocumentUri.From($"/{this.TestContext.TestName}");
+            var moduleEntrypointUri = DocumentUri.From($"/module entrypoint.bicep");
+
+            await using var server = CreateServer(moduleEntrypointUri.ToUriEncoded(), "// module entrypoint");
+            var helper = await server.GetAsync();
+            await helper.OpenFileOnceAsync(this.TestContext, string.Empty, uri);
+
+            var externalSourceUri = new ExternalSourceReference("title", "br:myregistry.azurecr.io/myrepo/bicep/module1:v1", "not the entrypoint.bicep").ToUri();
+            var lenses = await GetExternalSourceCodeLenses(helper, externalSourceUri);
+
+            lenses.Should().HaveCount(1);
+            var lens = lenses.First();
+            lens.Should().HaveRange(new Range(0, 0, 0, 0));
+            lens.Should().HaveCommandName("bicep.internal.showModuleSourceFile");
+            lens.Should().HaveCommandTitle("Show compiled JSON");
+            var target = new ExternalSourceReference(lens.CommandArguments().Single());
+            target.IsRequestingCompiledJson.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public async Task DisplayingExternalModuleSource_JsonFileThatIsIncludedInSources_ShouldHaveCodeLens_ToShowCompiledJson_ForTheWholeModule()
+        {
+            var uri = DocumentUri.From($"/{this.TestContext.TestName}");
+            var moduleEntrypointUri = DocumentUri.From($"/module entrypoint.bicep");
+
+            await using var server = CreateServer(moduleEntrypointUri.ToUriEncoded(), "// module entrypoint");
+            var helper = await server.GetAsync();
+            await helper.OpenFileOnceAsync(this.TestContext, string.Empty, uri);
+
+            var externalSourceUri = new ExternalSourceReference("title", "br:myregistry.azurecr.io/myrepo/bicep/module1:v1", "source file.json").ToUri();
+            var lenses = await GetExternalSourceCodeLenses(helper, externalSourceUri);
+
+            lenses.Should().HaveCount(1);
+            var lens = lenses.First();
+            lens.Should().HaveRange(new Range(0, 0, 0, 0));
+            lens.Should().HaveCommandName("bicep.internal.showModuleSourceFile");
+            lens.Should().HaveCommandTitle("Show compiled JSON");
+            var target = new ExternalSourceReference(lens.CommandArguments().Single());
+            target.IsRequestingCompiledJson.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public async Task DisplayingModuleCompiledJsonFile_AndSourceIsAvailable_ShouldHaveCodeLens_ToShowBicepEntrypointFile()
+        {
+            var uri = DocumentUri.From($"/{this.TestContext.TestName}");
+            var moduleEntrypointUri = DocumentUri.From($"/module entrypoint.bicep");
+
+            await using var server = CreateServer(moduleEntrypointUri.ToUriEncoded(), "// module entrypoint");
+            var helper = await server.GetAsync();
+            await helper.OpenFileOnceAsync(this.TestContext, string.Empty, uri);
+
+            var externalSourceUri = new ExternalSourceReference("title", "br:myregistry.azurecr.io/myrepo/bicep/module1:v1", null /* main.json */).ToUri();
+            var lenses = await GetExternalSourceCodeLenses(helper, externalSourceUri);
+
+            lenses.Should().HaveCount(1);
+            var lens = lenses.First();
+            lens.Should().HaveRange(new Range(0, 0, 0, 0));
+            lens.Should().HaveCommandName("bicep.internal.showModuleSourceFile");
+            lens.Should().HaveCommandTitle("Show Bicep source");
+            var target = new ExternalSourceReference(lens.CommandArguments().Single());
+            target.IsRequestingCompiledJson.Should().BeFalse();
+            target.RequestedFile.Should().Be(Path.GetFileName(moduleEntrypointUri.Path));
+        }
+
+        [TestMethod]
+        public async Task DisplayingModuleCompiledJsonFile_AndSourceNotAvailable_ShouldHaveCodeLens_ToExplainWhyNoSources()
+        {
+            var uri = DocumentUri.From($"/{this.TestContext.TestName}");
+            var moduleEntrypointUri = DocumentUri.From($"/module entrypoint.bicep");
+
+            await using var server = CreateServer(moduleEntrypointUri.ToUriEncoded(), null);
+            var helper = await server.GetAsync();
+            await helper.OpenFileOnceAsync(this.TestContext, string.Empty, uri);
+
+            var externalSourceUri = new ExternalSourceReference("title", "br:myregistry.azurecr.io/myrepo/bicep/module1:v1", null /* main.json */).ToUri();
+            var lenses = await GetExternalSourceCodeLenses(helper, externalSourceUri);
+
+            lenses.Should().HaveCount(1);
+            var lens = lenses.First();
+            lens.Should().HaveRange(new Range(0, 0, 0, 0));
+            lens.Should().HaveCommandName("");
+            lens.Should().HaveCommandTitle("No source code is available for this module");
+            lens.Should().HaveNoCommandArguments();
+        }
+
+        [TestMethod]
+        public async Task HasBadUri_ShouldHaveCodeLens_ToExplainError()
+        {
+            var uri = DocumentUri.From($"/{this.TestContext.TestName}");
+            var moduleEntrypointUri = DocumentUri.From($"/module entrypoint.bicep");
+
+            await using var server = CreateServer(moduleEntrypointUri.ToUriEncoded(), "// module entrypoint");
+            var helper = await server.GetAsync();
+            await helper.OpenFileOnceAsync(this.TestContext, string.Empty, uri);
+
+            var badDocumentUri = new ExternalSourceReference("title", "br:myregistry.azurecr.io/myrepo/bicep/module1:v1", null /* main.json */).ToUri().AbsoluteUri.Replace("v1", ""); // bad version string
+            var lenses = await GetExternalSourceCodeLenses(helper, badDocumentUri);
+
+            lenses.Should().HaveCount(1);
+            var lens = lenses.First();
+            lens.Should().HaveRange(new Range(0, 0, 0, 0));
+            lens.Should().HaveCommandName("");
+            lens.Should().HaveCommandTitle("There was an error retrieving source code for this module: Invalid module reference 'br:myregistry.azurecr.io/myrepo/bicep/module1:'. The specified OCI artifact reference \"br:myregistry.azurecr.io/myrepo/bicep/module1:\" is not valid. The module tag or digest is missing. (Parameter 'fullyQualifiedModuleReference')");
+            lens.Should().HaveNoCommandArguments();
+        }
+
+        private async Task<CodeLens[]> GetExternalSourceCodeLenses(MultiFileLanguageServerHelper helper, DocumentUri documentUri)
+        {
+            return (await helper.Client.RequestCodeLens(new CodeLensParams
+            {
+                TextDocument = new TextDocumentIdentifier(documentUri)
+            }))?.Where(a => a.IsExternalSourceCodeLens()).ToArray()
+            ?? Array.Empty<CodeLens>();
+        }
+    }
+}

--- a/src/Bicep.LangServer.IntegrationTests/Helpers/LanguageServerHelper.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Helpers/LanguageServerHelper.cs
@@ -6,7 +6,6 @@ using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
 using Bicep.Core.Tracing;
-using Bicep.Core.Registry;
 using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.FileSystem;
 using Bicep.Core.UnitTests.Utils;
@@ -37,20 +36,17 @@ namespace Bicep.LangServer.IntegrationTests
         /// <summary>
         /// Creates and initializes a new language server/client pair without loading any files. This is recommended when you need to open multiple files using the language server.
         /// </summary>
-        public static async Task<LanguageServerHelper> StartServer(TestContext testContext, Action<LanguageClientOptions>? onClientOptions = null, Action<IServiceCollection>? onRegisterServices = null, IArtifactRegistry[]? artifactRegistries = null)
+        public static async Task<LanguageServerHelper> StartServer(TestContext testContext, Action<LanguageClientOptions>? onClientOptions = null, Action<IServiceCollection>? onRegisterServices = null)
         {
             using var timer = new ExecutionTimer($"Starting language server", logInitial: false);
             var clientPipe = new Pipe();
             var serverPipe = new Pipe();
 
-            var (mockDispatcher, mockRestoreScheduler) = BicepTestConstants.CreateMockModuleDispatcherAndRestoreScheduler(artifactRegistries);
-
             var server = new Server(
                 options => options
                     .WithInput(serverPipe.Reader)
                     .WithOutput(clientPipe.Writer)
-                    .WithServices(services => services.AddSingleton(mockDispatcher))
-                    .WithServices(services => services.AddSingleton(mockRestoreScheduler))
+                    .WithServices(services => services.AddSingleton(BicepTestConstants.ModuleRestoreScheduler))
                     .WithServices(services => onRegisterServices?.Invoke(services)));
             var _ = server.RunAsync(CancellationToken.None); // do not wait on this async method, or you'll be waiting a long time!
 

--- a/src/Bicep.LangServer.IntegrationTests/Helpers/MultiFileLanguageServerHelper.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Helpers/MultiFileLanguageServerHelper.cs
@@ -34,7 +34,7 @@ namespace Bicep.LangServer.IntegrationTests
             this.notificationRouter = notificationRouter;
         }
 
-        public static async Task<MultiFileLanguageServerHelper> StartLanguageServer(TestContext testContext, Action<IServiceCollection>? onRegisterServices = null, IArtifactRegistry[]? artifactRegistries = null)
+        public static async Task<MultiFileLanguageServerHelper> StartLanguageServer(TestContext testContext, Action<IServiceCollection>? onRegisterServices = null)
         {
             var notificationRouter = new ConcurrentDictionary<DocumentUri, MultipleMessageListener<PublishDiagnosticsParams>>();
             var helper = await LanguageServerHelper.StartServer(
@@ -54,8 +54,7 @@ namespace Bicep.LangServer.IntegrationTests
                         throw new AssertFailedException($"Task completion source was not registered for document uri '{p.Uri}'.");
                     });
                 },
-                onRegisterServices,
-                artifactRegistries);
+                onRegisterServices);
 
             return new(helper.Server, helper.Client, notificationRouter);
         }

--- a/src/Bicep.LangServer.IntegrationTests/Helpers/MultiFileLanguageServerHelper.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Helpers/MultiFileLanguageServerHelper.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading.Tasks;
 using Bicep.Core.Navigation;
+using Bicep.Core.Registry;
 using Bicep.Core.Workspaces;
 using Bicep.LangServer.IntegrationTests.Helpers;
 using Bicep.LanguageServer;
@@ -33,7 +34,7 @@ namespace Bicep.LangServer.IntegrationTests
             this.notificationRouter = notificationRouter;
         }
 
-        public static async Task<MultiFileLanguageServerHelper> StartLanguageServer(TestContext testContext, Action<IServiceCollection>? onRegisterServices = null)
+        public static async Task<MultiFileLanguageServerHelper> StartLanguageServer(TestContext testContext, Action<IServiceCollection>? onRegisterServices = null, IArtifactRegistry[]? artifactRegistries = null)
         {
             var notificationRouter = new ConcurrentDictionary<DocumentUri, MultipleMessageListener<PublishDiagnosticsParams>>();
             var helper = await LanguageServerHelper.StartServer(
@@ -53,7 +54,8 @@ namespace Bicep.LangServer.IntegrationTests
                         throw new AssertFailedException($"Task completion source was not registered for document uri '{p.Uri}'.");
                     });
                 },
-                onRegisterServices);
+                onRegisterServices,
+                artifactRegistries);
 
             return new(helper.Server, helper.Client, notificationRouter);
         }

--- a/src/Bicep.LangServer.IntegrationTests/Helpers/ServerRequestHelper.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Helpers/ServerRequestHelper.cs
@@ -89,6 +89,14 @@ namespace Bicep.LangServer.IntegrationTests
             });
         }
 
+        public async Task<CodeLensContainer?> RequestCodeLens(int cursor)
+        {
+            return await client.RequestCodeLens(new CodeLensParams
+            {
+                TextDocument = new TextDocumentIdentifier(bicepFile.FileUri),
+            });
+        }
+
         public async Task<SignatureHelp?> RequestSignatureHelp(int cursor, SignatureHelpContext? context = null) =>
             await client.RequestSignatureHelp(new SignatureHelpParams
             {

--- a/src/Bicep.LangServer.IntegrationTests/Helpers/SharedLanguageHelperManager.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Helpers/SharedLanguageHelperManager.cs
@@ -36,13 +36,14 @@ namespace Bicep.LangServer.IntegrationTests.Helpers
 
         public async ValueTask DisposeAsync()
         {
-            if (this.lazy is null)
+            if (this.lazy is null || !this.lazy.IsValueCreated)
             {
                 return;
             }
 
             var helper = await this.lazy.GetValueAsync();
             helper.Dispose();
+            this.lazy = null;
         }
     }
 }

--- a/src/Bicep.LangServer.UnitTests/BicepExternalSourceRequestHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepExternalSourceRequestHandlerTests.cs
@@ -154,26 +154,25 @@ namespace Bicep.LangServer.UnitTests.Handlers
             // needed for mocking out parameters
             DiagnosticBuilder.ErrorBuilderDelegate? nullBuilder = null;
             DiagnosticBuilder.ErrorBuilderDelegate? readFailureBuilder = x => x.ErrorOccurredReadingFile("Mock file read failure.");
-            string? fileContents = null;
+            var compiledJsonUri = new Uri("file:///foo/bar/main.json");
 
             const string UnqualifiedModuleRefStr = "example.azurecr.invalid/foo/bar:v3";
             const string ModuleRefStr = "br:" + UnqualifiedModuleRefStr;
 
-            var fileUri = new Uri("file:///main.bicep");
             var configuration = IConfigurationManager.GetBuiltInConfiguration();
-            OciArtifactReference.TryParseModule(null, UnqualifiedModuleRefStr, configuration, fileUri).IsSuccess(out var moduleReference).Should().BeTrue();
+            OciArtifactReference.TryParseModule(null, UnqualifiedModuleRefStr, configuration, compiledJsonUri).IsSuccess(out var moduleReference).Should().BeTrue();
             moduleReference.Should().NotBeNull();
 
             ArtifactReference? outRef = moduleReference;
             dispatcher.Setup(m => m.TryGetArtifactReference(ArtifactType.Module, ModuleRefStr, It.IsAny<Uri>())).Returns(ResultHelper.Create(outRef, null));
             dispatcher.Setup(m => m.GetArtifactRestoreStatus(moduleReference!, out nullBuilder)).Returns(ArtifactRestoreStatus.Succeeded);
-            dispatcher.Setup(m => m.TryGetLocalArtifactEntryPointUri(moduleReference!)).Returns(ResultHelper.Create(fileUri, null));
+            dispatcher.Setup(m => m.TryGetLocalArtifactEntryPointUri(moduleReference!)).Returns(ResultHelper.Create(compiledJsonUri, null));
 
             SourceArchive? sourceArchive = null;
             dispatcher.Setup(m => m.TryGetModuleSources(moduleReference!)).Returns(sourceArchive);
 
             var resolver = StrictMock.Of<IFileResolver>();
-            resolver.Setup(m => m.TryRead(fileUri)).Returns(ResultHelper.Create(fileContents, readFailureBuilder));
+            resolver.Setup(m => m.TryRead(compiledJsonUri)).Returns(ResultHelper.Create((string?)null, readFailureBuilder));
 
             var handler = new BicepExternalSourceRequestHandler(dispatcher.Object, resolver.Object);
 
@@ -182,7 +181,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
                 .Awaiting(() => handler.Handle(@params, default))
                 .Should()
                 .ThrowAsync<InvalidOperationException>())
-                .WithMessage($"Unable to read file 'file:///main.bicep'. An error occurred reading file. Mock file read failure.");
+                .WithMessage($"Unable to read file 'file:///foo/bar/main.json'. An error occurred reading file. Mock file read failure.");
         }
 
         [TestMethod]
@@ -193,27 +192,27 @@ namespace Bicep.LangServer.UnitTests.Handlers
             // needed for mocking out parameters
             DiagnosticBuilder.ErrorBuilderDelegate? nullBuilder = null;
             DiagnosticBuilder.ErrorBuilderDelegate? readFailureBuilder = x => x.ErrorOccurredReadingFile("Mock file read failure.");
-            string? fileContents = "mock file contents";
+            string? compiledJsonContents = "mock main.json contents";
+            var compiledJsonUri = new Uri("file:///foo/bar/main.json");
 
             const string UnqualifiedModuleRefStr = "example.azurecr.invalid/foo/bar:v3";
             const string ModuleRefStr = "br:" + UnqualifiedModuleRefStr;
 
-            var fileUri = new Uri("file:///foo/bar/main.bicep");
-            var configuration = ConfigurationManager.GetConfiguration(fileUri);
+            var configuration = ConfigurationManager.GetConfiguration(compiledJsonUri);
 
-            OciArtifactReference.TryParseModule(null, UnqualifiedModuleRefStr, configuration, fileUri).IsSuccess(out var moduleReference).Should().BeTrue();
+            OciArtifactReference.TryParseModule(null, UnqualifiedModuleRefStr, configuration, compiledJsonUri).IsSuccess(out var moduleReference).Should().BeTrue();
             moduleReference.Should().NotBeNull();
 
             ArtifactReference? outRef = moduleReference;
             dispatcher.Setup(m => m.TryGetArtifactReference(ArtifactType.Module, ModuleRefStr, It.IsAny<Uri>())).Returns(ResultHelper.Create(outRef, null));
             dispatcher.Setup(m => m.GetArtifactRestoreStatus(moduleReference!, out nullBuilder)).Returns(ArtifactRestoreStatus.Succeeded);
-            dispatcher.Setup(m => m.TryGetLocalArtifactEntryPointUri(moduleReference!)).Returns(ResultHelper.Create(fileUri, null));
+            dispatcher.Setup(m => m.TryGetLocalArtifactEntryPointUri(moduleReference!)).Returns(ResultHelper.Create(compiledJsonUri, null));
 
             SourceArchive? sourceArchive = null;
             dispatcher.Setup(m => m.TryGetModuleSources(moduleReference!)).Returns(sourceArchive);
 
             var resolver = StrictMock.Of<IFileResolver>();
-            resolver.Setup(m => m.TryRead(fileUri)).Returns(ResultHelper.Create(fileContents, nullBuilder));
+            resolver.Setup(m => m.TryRead(compiledJsonUri)).Returns(ResultHelper.Create(compiledJsonContents, nullBuilder));
 
             var handler = new BicepExternalSourceRequestHandler(dispatcher.Object, resolver.Object);
 
@@ -221,40 +220,83 @@ namespace Bicep.LangServer.UnitTests.Handlers
             var response = await handler.Handle(@params, default);
 
             response.Should().NotBeNull();
-            response.Content.Should().Be(fileContents);
+            response.Content.Should().Be(compiledJsonContents);
         }
 
         [TestMethod]
-        public async Task RestoredValidModule_WithSource_ShouldReturnBicepContents()
+        public async Task RestoredValidModule_WithSource_RequestingBicepFile_ShouldReturnBicepContents()
         {
             var dispatcher = StrictMock.Of<IModuleDispatcher>();
 
             // needed for mocking out parameters
             DiagnosticBuilder.ErrorBuilderDelegate? nullBuilder = null;
             DiagnosticBuilder.ErrorBuilderDelegate? readFailureBuilder = x => x.ErrorOccurredReadingFile("Mock file read failure.");
-            string? fileContents = "mock file contents";
+            string? compiledJsonContents = "mock main.json contents";
+            var compiledJsonUri = new Uri("file:///foo/bar/main.json");
 
             const string UnqualifiedModuleRefStr = "example.azurecr.invalid/foo/bar:v3";
             const string ModuleRefStr = "br:" + UnqualifiedModuleRefStr;
 
-            var fileUri = new Uri("file:///foo/bar/main.bicep");
-            var configuration = ConfigurationManager.GetConfiguration(fileUri);
+            var configuration = ConfigurationManager.GetConfiguration(compiledJsonUri);
 
-            OciArtifactReference.TryParseModule(null, UnqualifiedModuleRefStr, configuration, fileUri).IsSuccess(out var moduleReference).Should().BeTrue();
+            OciArtifactReference.TryParseModule(null, UnqualifiedModuleRefStr, configuration, compiledJsonUri).IsSuccess(out var moduleReference).Should().BeTrue();
             moduleReference.Should().NotBeNull();
 
             ArtifactReference? outRef = moduleReference;
             dispatcher.Setup(m => m.TryGetArtifactReference(ArtifactType.Module, ModuleRefStr, It.IsAny<Uri>())).Returns(ResultHelper.Create(outRef, null));
             dispatcher.Setup(m => m.GetArtifactRestoreStatus(moduleReference!, out nullBuilder)).Returns(ArtifactRestoreStatus.Succeeded);
-            dispatcher.Setup(m => m.TryGetLocalArtifactEntryPointUri(moduleReference!)).Returns(ResultHelper.Create(fileUri, null));
+            dispatcher.Setup(m => m.TryGetLocalArtifactEntryPointUri(moduleReference!)).Returns(ResultHelper.Create(compiledJsonUri, null));
 
-            var bicepSource = "metadata hi 'mom'";
-            var sourceArchive = SourceArchive.FromStream(SourceArchive.PackSourcesIntoStream(fileUri, new Core.Workspaces.ISourceFile[] {
-                SourceFileFactory.CreateBicepFile(fileUri, bicepSource)}));
+            var bicepSource = "metadata hi = 'This is the bicep source file'";
+            var bicepUri = new Uri("file:///foo/bar/entrypoint.bicep");
+            var sourceArchive = SourceArchive.FromStream(SourceArchive.PackSourcesIntoStream(bicepUri, new Core.Workspaces.ISourceFile[] {
+                SourceFileFactory.CreateBicepFile(bicepUri, bicepSource)}));
             dispatcher.Setup(m => m.TryGetModuleSources(moduleReference!)).Returns(sourceArchive);
 
             var resolver = StrictMock.Of<IFileResolver>();
-            resolver.Setup(m => m.TryRead(fileUri)).Returns(ResultHelper.Create(fileContents, nullBuilder));
+            resolver.Setup(m => m.TryRead(compiledJsonUri)).Returns(ResultHelper.Create(compiledJsonContents, nullBuilder));
+
+            var handler = new BicepExternalSourceRequestHandler(dispatcher.Object, resolver.Object);
+
+            var @params = new BicepExternalSourceParams(ModuleRefStr, Path.GetFileName(bicepUri.AbsoluteUri));
+            var response = await handler.Handle(@params, default);
+
+            response.Should().NotBeNull();
+            response.Content.Should().Be(bicepSource);
+        }
+
+        [TestMethod]
+        public async Task RestoredValidModule_WithSource_RequestingCompiledJson_ShouldReturnMainJsonContents()
+        {
+            var dispatcher = StrictMock.Of<IModuleDispatcher>();
+
+            // needed for mocking out parameters
+            DiagnosticBuilder.ErrorBuilderDelegate? nullBuilder = null;
+            DiagnosticBuilder.ErrorBuilderDelegate? readFailureBuilder = x => x.ErrorOccurredReadingFile("Mock file read failure.");
+            string? compiledJsonContents = "mock main.json contents";
+            var compiledJsonUri = new Uri("file:///foo/bar/main.json");
+
+            const string UnqualifiedModuleRefStr = "example.azurecr.invalid/foo/bar:v3";
+            const string ModuleRefStr = "br:" + UnqualifiedModuleRefStr;
+
+            var configuration = ConfigurationManager.GetConfiguration(compiledJsonUri);
+
+            OciArtifactReference.TryParseModule(null, UnqualifiedModuleRefStr, configuration, compiledJsonUri).IsSuccess(out var moduleReference).Should().BeTrue();
+            moduleReference.Should().NotBeNull();
+
+            ArtifactReference? outRef = moduleReference;
+            dispatcher.Setup(m => m.TryGetArtifactReference(ArtifactType.Module, ModuleRefStr, It.IsAny<Uri>())).Returns(ResultHelper.Create(outRef, null));
+            dispatcher.Setup(m => m.GetArtifactRestoreStatus(moduleReference!, out nullBuilder)).Returns(ArtifactRestoreStatus.Succeeded);
+            dispatcher.Setup(m => m.TryGetLocalArtifactEntryPointUri(moduleReference!)).Returns(ResultHelper.Create(compiledJsonUri, null));
+
+            var bicepSource = "metadata hi = 'This is the bicep source file'";
+            var bicepUri = new Uri("file:///foo/bar/entrypoint.bicep");
+            var sourceArchive = SourceArchive.FromStream(SourceArchive.PackSourcesIntoStream(bicepUri, new Core.Workspaces.ISourceFile[] {
+                SourceFileFactory.CreateBicepFile(bicepUri, bicepSource)}));
+            dispatcher.Setup(m => m.TryGetModuleSources(moduleReference!)).Returns(sourceArchive);
+
+            var resolver = StrictMock.Of<IFileResolver>();
+            resolver.Setup(m => m.TryRead(compiledJsonUri)).Returns(ResultHelper.Create(compiledJsonContents, nullBuilder));
 
             var handler = new BicepExternalSourceRequestHandler(dispatcher.Object, resolver.Object);
 
@@ -262,7 +304,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
             var response = await handler.Handle(@params, default);
 
             response.Should().NotBeNull();
-            response.Content.Should().Be(bicepSource);
+            response.Content.Should().Be(compiledJsonContents);
         }
 
         #region GetExternalSourceLinkUri tests

--- a/src/Bicep.LangServer/Handlers/BicepCodeLensHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepCodeLensHandler.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Bicep.Core;
+using Bicep.Core.Registry;
+using Bicep.LanguageServer.CompilationManager;
+using Bicep.LanguageServer.Providers;
+using Bicep.LanguageServer.Utils;
+using Microsoft.WindowsAzure.ResourceStack.Common.Extensions;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Bicep.LanguageServer.Handlers
+{
+    // Provides code lenses for a range in a Bicep document
+    public class BicepCodeLensHandler : CodeLensHandlerBase
+    {
+        private readonly IClientCapabilitiesProvider clientCapabilitiesProvider;
+        private readonly ICompilationManager compilationManager;
+        private readonly IModuleDispatcher moduleDispatcher;
+
+        public BicepCodeLensHandler(ICompilationManager compilationManager, IClientCapabilitiesProvider clientCapabilitiesProvider, IModuleDispatcher moduleDispatcher)
+        {
+            this.clientCapabilitiesProvider = clientCapabilitiesProvider;
+            this.compilationManager = compilationManager;
+            this.moduleDispatcher = moduleDispatcher;
+        }
+
+        public override Task<CodeLensContainer?> Handle(CodeLensParams request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var lenses = ExternalSourceCodeLensProvider.GetCodeLenses(moduleDispatcher, request, cancellationToken);
+
+            return Task.FromResult<CodeLensContainer?>(new CodeLensContainer(lenses));
+        }
+
+        public override Task<CodeLens> Handle(CodeLens request, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override CodeLensRegistrationOptions CreateRegistrationOptions(CodeLensCapability capability, ClientCapabilities clientCapabilities) => new()
+        {
+            DocumentSelector =new( 
+                DocumentSelectorFactory.AllSupportedLangIds
+                .Concat(TextDocumentFilter.ForScheme(LangServerConstants.ExternalSourceFileScheme))),
+            ResolveProvider = false
+        };
+    }
+}

--- a/src/Bicep.LangServer/Handlers/BicepTextDocumentSyncHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepTextDocumentSyncHandler.cs
@@ -113,7 +113,7 @@ namespace Bicep.LanguageServer.Handlers
         protected override TextDocumentSyncRegistrationOptions CreateRegistrationOptions(TextSynchronizationCapability capability, ClientCapabilities clientCapabilities) => new()
         {
             Change = TextDocumentSyncKind.Full,
-            DocumentSelector = DocumentSelectorFactory.CreateForTextDocumentSync()
+            DocumentSelector = DocumentSelectorFactory.CreateForAllSupportedLangIds()
         };
     }
 }

--- a/src/Bicep.LangServer/Handlers/ExternalSourceCodeLensProvider.cs
+++ b/src/Bicep.LangServer/Handlers/ExternalSourceCodeLensProvider.cs
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using Bicep.Core.Registry;
+using Newtonsoft.Json.Linq;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+namespace Bicep.LanguageServer.Handlers
+{
+    // Provides code lenses when displaying source from an external bicep module
+    public static class ExternalSourceCodeLensProvider
+    {
+        private static readonly Range DocumentStart = new(new Position(0, 0), new Position(0, 0));
+
+        public static IEnumerable<CodeLens> GetCodeLenses(IModuleDispatcher moduleDispatcher, CodeLensParams request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (request.TextDocument.Uri.Scheme == LangServerConstants.ExternalSourceFileScheme)
+            {
+                string? error = null;
+                ExternalSourceReference? externalReference = null;
+
+                try
+                {
+                    externalReference = new ExternalSourceReference(request.TextDocument.Uri);
+                }
+                catch (Exception ex)
+                {
+                    error = ex.Message;
+                }
+
+                if (externalReference is not null)
+                {
+                    Debug.Assert(error is null);
+
+                    var isDisplayingCompiledJson = externalReference.IsRequestingCompiledJson;
+                    if (externalReference.ToArtifactReference().IsSuccess(out var artifactReference, out error))
+                    {
+                        var sourceArchive = artifactReference is { } ? moduleDispatcher.TryGetModuleSources(artifactReference) : null;
+
+                        if (isDisplayingCompiledJson)
+                        {
+                            if (sourceArchive is { })
+                            {
+                                yield return CreateCodeLens(
+                                    DocumentStart,
+                                    "Show Bicep source",
+                                    "bicep.internal.showModuleSourceFile",
+                                    new ExternalSourceReference(request.TextDocument.Uri).WithRequestForSourceFile(sourceArchive.EntrypointRelativePath).ToUri().ToString());
+                            }
+                            else
+                            {
+                                yield return CreateCodeLens(
+                                    DocumentStart,
+                                    "No source code is available for this module");
+                            }
+                        }
+                        else
+                        {
+                            if (sourceArchive is { })
+                            {
+                                // We're displaying some source file other than the compiled JSON for the module. Allow user to switch to the compiled JSON.
+                                yield return CreateCodeLens(
+                                    DocumentStart,
+                                    "Show compiled JSON",
+                                    "bicep.internal.showModuleSourceFile",
+                                    new ExternalSourceReference(request.TextDocument.Uri).WithRequestForCompiledJson().ToUri().ToString());
+                            }else
+                            {
+                                // This can happen if the user has a source file open in the editor and then restores to a version of the module that doesn't have source code available.
+                                error = "Could not find the expected source archive in the module registry";
+                            }
+                        }
+                    }
+                }
+
+                if (error is not null)
+                {
+                    yield return CreateErrorLens($"There was an error retrieving source code for this module: {error}");
+                }
+            }
+
+            CodeLens CreateErrorLens(string message)
+            {
+                return CreateCodeLens(DocumentStart, message);
+            }
+        }
+
+        private static CodeLens CreateCodeLens(Range range, string title, string? commandName = null, params string[] commandArguments)
+        {
+            return new CodeLens
+            {
+                Range = range,
+                Command = new Command
+                {
+                    Title = title,
+                    Name = commandName ?? string.Empty,
+                }
+                .WithArguments(commandArguments),
+                Data = nameof(ExternalSourceCodeLensProvider)
+            };
+        }
+
+        // Allows tests to filter to just code lenses that were created by this provider
+        public static bool IsExternalSourceCodeLens(this CodeLens codeLens)
+        {
+            return codeLens.Data?.Value<string>() == nameof(ExternalSourceCodeLensProvider);
+        }
+    }
+}

--- a/src/Bicep.LangServer/LangServerConstants.cs
+++ b/src/Bicep.LangServer/LangServerConstants.cs
@@ -25,5 +25,7 @@ namespace Bicep.LanguageServer
 
         // This is under "bicep.completions" in configuration
         public const string GetAllAzureContainerRegistriesForCompletionsSetting = "getAllAccessibleAzureContainerRegistries";
+
+        public const string ExternalSourceFileScheme = "bicep-extsrc";
     }
 }

--- a/src/Bicep.LangServer/Server.cs
+++ b/src/Bicep.LangServer/Server.cs
@@ -51,6 +51,7 @@ namespace Bicep.LanguageServer
                     .WithHandler<BicepHoverHandler>()
                     .WithHandler<BicepCompletionHandler>()
                     .WithHandler<BicepCodeActionHandler>()
+                    .WithHandler<BicepCodeLensHandler>()
                     .WithHandler<BicepCreateConfigFileHandler>()
                     .WithHandler<BicepDidChangeWatchedFilesHandler>()
                     .WithHandler<BicepEditLinterRuleCommandHandler>()

--- a/src/Bicep.LangServer/Utils/DocumentSelectorFactory.cs
+++ b/src/Bicep.LangServer/Utils/DocumentSelectorFactory.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using System.Linq;
 using Bicep.Core;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
@@ -7,16 +8,21 @@ namespace Bicep.LanguageServer.Utils
 {
     public class DocumentSelectorFactory
     {
-        public static TextDocumentSelector CreateForBicepAndParams() => TextDocumentSelector.ForLanguage(
-            LanguageConstants.LanguageId,
-            LanguageConstants.ParamsLanguageId);
+        public static readonly TextDocumentFilter[] BicepAndParams = {
+            TextDocumentFilter.ForLanguage(LanguageConstants.LanguageId),
+            TextDocumentFilter.ForLanguage(LanguageConstants.ParamsLanguageId)
+        };
 
-        public static TextDocumentSelector CreateForTextDocumentSync() => TextDocumentSelector.ForLanguage(
-            LanguageConstants.LanguageId,
-            LanguageConstants.ParamsLanguageId,
-            LanguageConstants.JsoncLanguageId,
-            LanguageConstants.JsonLanguageId,
-            LanguageConstants.ArmTemplateLanguageId);
+        public static readonly TextDocumentFilter[] AllSupportedLangIds = {
+                TextDocumentFilter.ForLanguage(LanguageConstants.LanguageId),
+                TextDocumentFilter.ForLanguage(LanguageConstants.ParamsLanguageId),
+                TextDocumentFilter.ForLanguage(LanguageConstants.JsoncLanguageId),
+                TextDocumentFilter.ForLanguage(LanguageConstants.JsonLanguageId),
+                TextDocumentFilter.ForLanguage(LanguageConstants.ArmTemplateLanguageId)
+        };
+
+        public static TextDocumentSelector CreateForBicepAndParams() => new(BicepAndParams);
+        public static TextDocumentSelector CreateForAllSupportedLangIds() => new(AllSupportedLangIds);
     }
 }
 

--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -279,6 +279,11 @@
         "icon": "$(output)"
       },
       {
+        "command": "bicep.internal.showModuleSourceFile",
+        "title": "(Show a source file from a module)",
+        "category": "Bicep Internal"
+      },
+      {
         "$section": "================== Walkthrough commands (not visible to users) ==================",
         "command": "bicep.gettingStarted.createBicepFile",
         "title": "Create Empty Bicep File (Walkthrough)",
@@ -618,6 +623,10 @@
         {
           "command": "bicep.buildParams",
           "group": "0_bicep"
+        },
+        {
+          "command": "bicep.internal.showModuleSourceFile",
+          "when": "never"
         }
       ]
     },

--- a/src/vscode-bicep/src/commands/ShowModuleSourceFileCommand.ts
+++ b/src/vscode-bicep/src/commands/ShowModuleSourceFileCommand.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import vscode, { Uri } from "vscode";
+import { IActionContext } from "@microsoft/vscode-azext-utils";
+import { Command } from "./types";
+import { decodeExternalSourceUri } from "../language/decodeExternalSourceUri";
+import path from "path";
+
+export class ShowModuleSourceFileCommand implements Command {
+  public readonly id = "bicep.internal.showModuleSourceFile";
+  public disclaimerShownThisSession = false;
+
+  public async execute(
+    context: IActionContext,
+    _documentUri: Uri,
+    targetUri: string,
+  ): Promise<void> {
+    const uri = Uri.parse(targetUri, true);
+    const doc = await vscode.workspace.openTextDocument(uri);
+
+    const { requestedSourceFile } = decodeExternalSourceUri(uri);
+    context.telemetry.properties.extension = requestedSourceFile
+      ? path.extname(requestedSourceFile)
+      : ".json";
+    context.telemetry.properties.isCompiledJson = String(!requestedSourceFile);
+
+    await vscode.window.showTextDocument(doc);
+  }
+}

--- a/src/vscode-bicep/src/extension.ts
+++ b/src/vscode-bicep/src/extension.ts
@@ -60,6 +60,7 @@ import { DecompileParamsCommand } from "./commands/decompileParams";
 import { DeployPaneViewManager } from "./panes/deploy";
 import { AzureUiManager } from "./azure/AzureUiManager";
 import { BicepExternalSourceScheme } from "./language/decodeExternalSourceUri";
+import { ShowModuleSourceFileCommand } from "./commands/ShowModuleSourceFileCommand";
 
 let languageClient: lsp.LanguageClient | null = null;
 
@@ -195,6 +196,7 @@ export async function activate(
             new WalkthroughCreateBicepFileCommand(),
             new WalkthroughOpenBicepFileCommand(),
             new ImportKubernetesManifestCommand(languageClient),
+            new ShowModuleSourceFileCommand(),
           );
 
         // Register events

--- a/src/vscode-bicep/src/language/bicepExternalSourceContentProvider.ts
+++ b/src/vscode-bicep/src/language/bicepExternalSourceContentProvider.ts
@@ -4,7 +4,10 @@
 import * as vscode from "vscode";
 import { LanguageClient } from "vscode-languageclient/node";
 import { Disposable } from "../utils/disposable";
-import { bicepExternalSourceRequestType } from "./protocol";
+import {
+  BicepExternalSourceParams,
+  bicepExternalSourceRequestType,
+} from "./protocol";
 import * as path from "path";
 import { Uri } from "vscode";
 import {
@@ -48,10 +51,14 @@ export class BicepExternalSourceContentProvider
     return response.content;
   }
 
-  private bicepExternalSourceRequest(uri: vscode.Uri) {
-    const { moduleReference } = decodeExternalSourceUri(uri);
+  private bicepExternalSourceRequest(
+    uri: vscode.Uri,
+  ): BicepExternalSourceParams {
+    const { moduleReference, requestedSourceFile } =
+      decodeExternalSourceUri(uri);
     return {
       target: moduleReference,
+      requestedSourceFile,
     };
   }
 

--- a/src/vscode-bicep/src/language/protocol.ts
+++ b/src/vscode-bicep/src/language/protocol.ts
@@ -59,10 +59,6 @@ export const getDeploymentDataRequestType = new ProtocolRequestType<
   void
 >("bicep/getDeploymentData");
 
-export interface BicepExternalSourceParams {
-  target: string;
-}
-
 export interface BicepDeploymentScopeParams {
   textDocument: TextDocumentIdentifier;
 }
@@ -144,6 +140,11 @@ export enum ParameterType {
   Int = 3,
   Object = 4,
   String = 5,
+}
+
+export interface BicepExternalSourceParams {
+  target: string; // The full module reference to get source for
+  requestedSourceFile: string | undefined; // The relative source path of the file in the module to get source for
 }
 
 export interface BicepExternalSourceResponse {


### PR DESCRIPTION
Fixes #12757 

No source was published:
![image](https://github.com/Azure/bicep/assets/6913354/c7a9493e-2714-477a-94d0-7b7ac1c8b669)

Showing module's main.bicep source:
![image](https://github.com/Azure/bicep/assets/6913354/edfc5fe7-dcbc-483a-85ea-c72581455974)

After clicking on "Show compiled JSON":
![image](https://github.com/Azure/bicep/assets/6913354/83d8af0a-a0b7-4802-ba73-9675f7514dfc)


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12762)