### PR TITLE
Refactoring: renames and one small bug fix

### DIFF
--- a/src/Bicep.Core/Registry/Oci/OciArtifactReference.cs
+++ b/src/Bicep.Core/Registry/Oci/OciArtifactReference.cs
@@ -90,7 +90,7 @@ namespace Bicep.Core.Registry.Oci
         }
 
         // Doesn't handle aliases
-        public static ResultWithDiagnostic<IArtifactAddressComponents> TryParseFullyQualifiedParts(string rawValue)
+        public static ResultWithDiagnostic<IArtifactAddressComponents> TryParseFullyQualifiedComponents(string rawValue)
         {
             return TryParseParts(ArtifactType.Module, aliasName: null, rawValue, configuration: null);
         }

--- a/src/Bicep.Core/Registry/Oci/OciArtifactReference.cs
+++ b/src/Bicep.Core/Registry/Oci/OciArtifactReference.cs
@@ -18,6 +18,7 @@ namespace Bicep.Core.Registry.Oci
         public OciArtifactReference(ArtifactType type, IArtifactAddressComponents artifactIdParts, Uri parentModuleUri) :
             base(OciArtifactReferenceFacts.Scheme, parentModuleUri)
         {
+            Type = type;
             AddressComponents = artifactIdParts;
         }
 

--- a/src/Bicep.LangServer.IntegrationTests/Registry/ModuleRestoreSchedulerTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Registry/ModuleRestoreSchedulerTests.cs
@@ -25,7 +25,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 
-namespace Bicep.LangServer.UnitTests.Registry
+namespace Bicep.LangServer.IntegrationTests.Registry
 {
     [TestClass]
     public class ModuleRestoreSchedulerTests

--- a/src/Bicep.LangServer.UnitTests/BicepExternalSourceRequestHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepExternalSourceRequestHandlerTests.cs
@@ -340,7 +340,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
         public void GetExternalSourceLinkUri_ModuleReferenceShouldBeCorrect(ExternalSourceLinkTestData testData)
         {
             Uri result = GetExternalSourceLinkUri(testData);
-            DecodeExternalSourceUri(result).ModuleParts.ArtifactId.Should().Be($"{testData.registry}/{testData.repository}{testData.tagOrDigest}");
+            DecodeExternalSourceUri(result).Components.ArtifactId.Should().Be($"{testData.registry}/{testData.repository}{testData.tagOrDigest}");
         }
 
         [DataTestMethod]

--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -207,7 +207,7 @@
         "icon": "$(type-hierarchy-sub)"
       },
       {
-        "command": "bicep.showSource",
+        "command": "bicep.showSourceFromVisualizer",
         "title": "Open Source",
         "category": "Bicep",
         "icon": "$(go-to-file)"
@@ -351,7 +351,7 @@
           "group": "navigation"
         },
         {
-          "command": "bicep.showSource",
+          "command": "bicep.showSourceFromVisualizer",
           "when": "bicepVisualizerFocus",
           "group": "navigation"
         },
@@ -605,7 +605,7 @@
           "command": "bicep.importKubernetesManifest"
         },
         {
-          "command": "bicep.showSource",
+          "command": "bicep.showSourceFromVisualizer",
           "when": "never"
         },
         {

--- a/src/vscode-bicep/src/commands/showSourceFromVisualizer.ts
+++ b/src/vscode-bicep/src/commands/showSourceFromVisualizer.ts
@@ -5,8 +5,9 @@ import vscode from "vscode";
 import { BicepVisualizerViewManager } from "../visualizer";
 import { Command } from "./types";
 
-export class ShowSourceCommand implements Command {
-  public readonly id = "bicep.showSource";
+export class ShowSourceFromVisualizerCommand implements Command {
+  public static readonly CommandId = "bicep.showSourceFromVisualizer";
+  public readonly id = ShowSourceFromVisualizerCommand.CommandId;
 
   public constructor(
     private readonly viewManager: BicepVisualizerViewManager,

--- a/src/vscode-bicep/src/extension.ts
+++ b/src/vscode-bicep/src/extension.ts
@@ -43,7 +43,7 @@ import {
   ShowVisualizerCommand,
   ShowVisualizerToSideCommand,
 } from "./commands/showVisualizer";
-import { ShowSourceCommand } from "./commands/showSource";
+import { ShowSourceFromVisualizerCommand } from "./commands/showSourceFromVisualizer";
 import { WalkthroughCopyToClipboardCommand } from "./commands/gettingStarted/WalkthroughCopyToClipboardCommand";
 import { WalkthroughCreateBicepFileCommand } from "./commands/gettingStarted/WalkthroughCreateBicepFileCommand";
 import { WalkthroughOpenBicepFileCommand } from "./commands/gettingStarted/WalkthroughOpenBicepFileCommand";
@@ -191,7 +191,7 @@ export async function activate(
             new ShowDeployPaneToSideCommand(deployPaneViewManager),
             new ShowVisualizerCommand(viewManager),
             new ShowVisualizerToSideCommand(viewManager),
-            new ShowSourceCommand(viewManager),
+            new ShowSourceFromVisualizerCommand(viewManager),
             new WalkthroughCopyToClipboardCommand(),
             new WalkthroughCreateBicepFileCommand(),
             new WalkthroughOpenBicepFileCommand(),

--- a/src/vscode-bicep/src/test/e2e/commands.ts
+++ b/src/vscode-bicep/src/test/e2e/commands.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import * as vscode from "vscode";
+import { ShowSourceFromVisualizerCommand } from "../../commands/showSourceFromVisualizer";
 
 // More can be added as needed: https://code.visualstudio.com/api/references/commands.
 
@@ -82,7 +83,7 @@ export async function executeShowDeployPaneToSideCommand(
 export async function executeShowSourceCommand(): Promise<
   vscode.TextEditor | undefined
 > {
-  return await vscode.commands.executeCommand("bicep.showSource");
+  return await vscode.commands.executeCommand(ShowSourceFromVisualizerCommand.CommandId);
 }
 
 export async function executeBuildCommand(


### PR DESCRIPTION
[Fix: Assign Type in OciArtifactReference constr](#aad34e89610ee23f326260776600705475d3e6e9)
[Rename ExternalSourceReference.ModuleParts -> Components](#c427645ba4571ee135a7108e5a2ab3e534f8be58)
[Rename bicep.showSource -> bicep.showSourceFromVisualizer](#6f08193423b5f6cd88b247bee91c869832df9c7d)
[Fix name of Bicep.LangServer.IntegrationTests.Registry](#599ce589336d34a71608ffa75d04ed976f3aa4f5)


  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12796)