### PR TITLE
Add custom nightly install options

### DIFF
--- a/docs/installing-nightly.md
+++ b/docs/installing-nightly.md
@@ -51,37 +51,55 @@ The CLI (`bicep-release-*-x64`) should replace any current Bicep executable that
 
 ## Advanced Script Options
 ### VSCode Extension
-- (Mac/Linux) Installing from a [GitHub branch](https://github.com/Azure/bicep/branches):
-   ```powershell
+- Mac/Linux
+   ```sh
+   # install from a fork repo
+   bash <(curl -Ls https://aka.ms/bicep/nightly-vsix.sh) --repo anthony-c-martin/bicep
+
+   # install from a custom branch
    bash <(curl -Ls https://aka.ms/bicep/nightly-vsix.sh) --branch jeskew/variable-imports
-   ```
-- (Windows) Installing from a [GitHub branch](https://github.com/Azure/bicep/branches):
-   ```powershell
-   iex "& { $(irm https://aka.ms/bicep/nightly-vsix.ps1) } -Branch jeskew/variable-imports"
-   ```
-- (Mac/Linux) Installing from a [GitHub Action run](https://github.com/Azure/bicep/actions/workflows/build.yml):
-   ```powershell
+
+   # install from a specific github action run
    bash <(curl -Ls https://aka.ms/bicep/nightly-vsix.sh) --run-id 6146657618
    ```
-- (Windows) Installing from a [GitHub Action run](https://github.com/Azure/bicep/actions/workflows/build.yml):
+- Windows
    ```powershell
+   # install from a fork repo
+   iex "& { $(irm https://aka.ms/bicep/nightly-vsix.ps1) } -Repo anthony-c-martin/bicep"
+
+   # install from a custom branch
+   iex "& { $(irm https://aka.ms/bicep/nightly-vsix.ps1) } -Branch jeskew/variable-imports"
+
+   # install from a specific github action run
    iex "& { $(irm https://aka.ms/bicep/nightly-vsix.ps1) } -RunId 6146657618"
    ```
 
-### Azure CLI
-- (Mac/Linux) Installing from a [GitHub branch](https://github.com/Azure/bicep/branches):
-   ```powershell
+### Bicep CLI
+- Mac/Linux
+   ```sh
+   # install to a custom directory
+   bash <(curl -Ls https://aka.ms/bicep/nightly-cli.sh) --binary-path /usr/local/bin
+
+   # install from a fork repo
+   bash <(curl -Ls https://aka.ms/bicep/nightly-cli.sh) --repo anthony-c-martin/bicep
+
+   # install from a custom branch
    bash <(curl -Ls https://aka.ms/bicep/nightly-cli.sh) --branch jeskew/variable-imports
-   ```
-- (Windows) Installing from a [GitHub branch](https://github.com/Azure/bicep/branches):
-   ```powershell
-   iex "& { $(irm https://aka.ms/bicep/nightly-cli.ps1) } -Branch jeskew/variable-imports"
-   ```
-- (Mac/Linux) Installing from a [GitHub Action run](https://github.com/Azure/bicep/actions/workflows/build.yml):
-   ```powershell
+
+   # install from a specific github action run
    bash <(curl -Ls https://aka.ms/bicep/nightly-cli.sh) --run-id 6146657618
    ```
-- (Windows) Installing from a [GitHub Action run](https://github.com/Azure/bicep/actions/workflows/build.yml):
+- Windows
    ```powershell
+   # install to a custom directory
+   iex "& { $(irm https://aka.ms/bicep/nightly-cli.ps1) } -BinaryPath C:\"
+
+   # install from a fork repo
+   iex "& { $(irm https://aka.ms/bicep/nightly-cli.ps1) } -Repo anthony-c-martin/bicep"
+
+   # install from a custom branch
+   iex "& { $(irm https://aka.ms/bicep/nightly-cli.ps1) } -Branch jeskew/variable-imports"
+
+   # install from a specific github action run
    iex "& { $(irm https://aka.ms/bicep/nightly-cli.ps1) } -RunId 6146657618"
    ```

--- a/scripts/install_vsix_nightly.ps1
+++ b/scripts/install_vsix_nightly.ps1
@@ -1,7 +1,8 @@
 [cmdletbinding()]
 param(
    [string]$RunId,
-   [string]$Branch
+   [string]$Branch,
+   [string]$Repo
 )
 
 $ErrorActionPreference="Stop"
@@ -11,20 +12,22 @@ if ((Get-Command "gh" -ErrorAction SilentlyContinue) -eq $null) {
 }
 
 # Fetch
-$repo = "Azure/bicep"
+if (!$Repo) {
+  $Repo = "Azure/bicep"
+}
 if (!$Branch) {
   $Branch = "main"
 }
 if (!$RunId) {
-    $RunId = & gh run list -R $repo --branch $Branch --workflow build --status success -L 1 --json databaseId -q ".[0].databaseId"; if(!$?) { throw }
+    $RunId = & gh run list -R $Repo --branch $Branch --workflow build --status success -L 1 --json databaseId -q ".[0].databaseId"; if(!$?) { throw }
 }
 $tmpDir = [System.IO.Path]::combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
-& gh run download -R $repo $RunId -n "vscode-bicep.vsix" --dir $tmpDir; if(!$?) { throw }
+& gh run download -R $Repo $RunId -n "vscode-bicep.vsix" --dir $tmpDir; if(!$?) { throw }
 
 # Install
 & code --install-extension "$tmpDir/vscode-bicep.vsix" --force; if(!$?) { throw }
 
-echo "Installed Bicep VSCode extension from https://github.com/Azure/bicep/actions/runs/$RunId"
+echo "Installed Bicep VSCode extension from https://github.com/$Repo/actions/runs/$RunId"
 
 # Cleanup
 Remove-Item $tmpDir -Recurse

--- a/scripts/install_vsix_nightly.sh
+++ b/scripts/install_vsix_nightly.sh
@@ -3,9 +3,10 @@ set -e
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --run-id)   runId="${2}"; shift;;
-    --branch)   branch="${2}"; shift;;
-    *)          echo "Unrecognized argument \"${1}\"."; exit 1;;
+    --run-id)  runId="${2}"; shift;;
+    --branch)  branch="${2}"; shift;;
+    --repo)    repo="${2}"; shift;;
+    *)         echo "Unrecognized argument \"${1}\"."; exit 1;;
   esac
   shift
 done
@@ -15,20 +16,22 @@ if ! command -v gh > /dev/null; then
 fi
 
 # Fetch
-REPO="Azure/bicep"
+if [ -z "$repo" ]; then
+  repo="Azure/bicep"
+fi
 if [ -z "$branch" ]; then
   branch=main
 fi
 if [ -z "$runId" ]; then
-  runId=$(gh run list -R $REPO --branch $branch --workflow build --status success -L 1 --json databaseId -q ".[0].databaseId")
+  runId=$(gh run list -R $repo --branch $branch --workflow build --status success -L 1 --json databaseId -q ".[0].databaseId")
 fi
 tmpDir=$(mktemp -d)
-gh run download -R $REPO $runId -n "vscode-bicep.vsix" --dir $tmpDir
+gh run download -R $repo $runId -n "vscode-bicep.vsix" --dir $tmpDir
 
 # Install
 code --install-extension "$tmpDir/vscode-bicep.vsix" --force
 
-echo "Installed Bicep VSCode extension from https://github.com/Azure/bicep/actions/runs/$runId"
+echo "Installed Bicep VSCode extension from https://github.com/$repo/actions/runs/$runId"
 
 # Cleanup
 rm -Rf $tmpDir


### PR DESCRIPTION
Add the following options to install scripts:

### VSCode Extension
- Mac/Linux
   ```sh
   # install from a fork repo
   bash <(curl -Ls https://aka.ms/bicep/nightly-vsix.sh) --repo anthony-c-martin/bicep
   ```
- Windows
   ```powershell
   # install from a fork repo
   iex "& { $(irm https://aka.ms/bicep/nightly-vsix.ps1) } -Repo anthony-c-martin/bicep"
   ```

### Bicep CLI
- Mac/Linux
   ```sh
   # install to a custom directory
   bash <(curl -Ls https://aka.ms/bicep/nightly-cli.sh) --binary-path /usr/local/bin

   # install from a fork repo
   bash <(curl -Ls https://aka.ms/bicep/nightly-cli.sh) --repo anthony-c-martin/bicep
   ```
- Windows
   ```powershell
   # install to a custom directory
   iex "& { $(irm https://aka.ms/bicep/nightly-cli.ps1) } -BinaryPath C:\"

   # install from a fork repo
   iex "& { $(irm https://aka.ms/bicep/nightly-cli.ps1) } -Repo anthony-c-martin/bicep"
   ```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12804)