### PR TITLE
Show compiled JSON first for now, and handle source code errors and compatibility

### DIFF
--- a/src/Bicep.Core.UnitTests/Assertions/CachedModuleExtensions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/CachedModuleExtensions.cs
@@ -38,12 +38,12 @@ namespace Bicep.Core.UnitTests.Assertions
             if (f)
             {
                 Subject.HasSourceLayer.Should().BeTrue();
-                Subject.TryGetSource().Should().NotBeNull();
+                Subject.TryGetSource().SourceArchive.Should().NotBeNull();
             }
             else
             {
                 Subject.HasSourceLayer.Should().BeFalse();
-                Subject.TryGetSource().Should().BeNull();
+                Subject.TryGetSource().SourceArchive.Should().BeNull();
             }
 
             return new(this);

--- a/src/Bicep.Core.UnitTests/Assertions/CachedModuleExtensions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/CachedModuleExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
@@ -10,6 +11,7 @@ using System.Text.Json.Nodes;
 using Bicep.Core.Modules;
 using Bicep.Core.Registry;
 using Bicep.Core.Registry.Oci;
+using Bicep.Core.SourceCode;
 using Bicep.Core.UnitTests.Registry;
 using FluentAssertions;
 using FluentAssertions.Primitives;
@@ -31,19 +33,21 @@ namespace Bicep.Core.UnitTests.Assertions
 
         protected override string Identifier => $"CachedModule at {Subject.ModuleCacheFolder}";
 
-        public AndConstraint<CachedModuleAssertions> HaveSource(bool f = true)
+        public AndConstraint<CachedModuleAssertions> HaveSource(bool shouldHaveSource = true)
         {
             Subject.Should().BeValid();
 
-            if (f)
+            if (shouldHaveSource)
             {
                 Subject.HasSourceLayer.Should().BeTrue();
-                Subject.TryGetSource().SourceArchive.Should().NotBeNull();
+                Subject.TryGetSource().IsSuccess().Should().BeTrue();
             }
             else
             {
                 Subject.HasSourceLayer.Should().BeFalse();
-                Subject.TryGetSource().SourceArchive.Should().BeNull();
+                Subject.TryGetSource().IsSuccess().Should().BeFalse();
+                Subject.TryGetSource().IsSuccess(out _, out var ex);
+                ex.Should().BeOfType<SourceNotAvailableException>();
             }
 
             return new(this);

--- a/src/Bicep.Core.UnitTests/Assertions/MockRegistryAssertions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/MockRegistryAssertions.cs
@@ -120,6 +120,7 @@ namespace Bicep.Core.UnitTests.Assertions
                                     expectedSourceContent!.Position = 0;
                                     byte[] expectedSourceBytes = new byte[expectedSourceContent.Length];
                                     expectedSourceContent.Read(expectedSourceBytes, 0, expectedSourceBytes.Length);
+                                    expectedSourceContent.Position = 0;
 
                                     actualSourcesBytes.Should().Equal(expectedSourceBytes, "module sources should match");
                                 }

--- a/src/Bicep.Core.UnitTests/Registry/CachedModules.cs
+++ b/src/Bicep.Core.UnitTests/Registry/CachedModules.cs
@@ -85,14 +85,14 @@ public record CachedModule(
 
     public bool HasSourceLayer => LayerMediaTypes.Contains("application/vnd.ms.bicep.module.source.v1.tar+gzip");
 
-    public SourceArchive? TryGetSource()
+    public SourceArchiveResult TryGetSource()
     {
         var sourceArchivePath = Path.Combine(ModuleCacheFolder, $"source.tar.gz");
         if (File.Exists(sourceArchivePath))
         {
-            return SourceArchive.FromStream(File.OpenRead(sourceArchivePath));
+            return SourceArchive.UnpackFromStream(File.OpenRead(sourceArchivePath));
         }
 
-        return null;
+        return new();
     }
 }

--- a/src/Bicep.Core.UnitTests/Registry/CachedModules.cs
+++ b/src/Bicep.Core.UnitTests/Registry/CachedModules.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
+using Bicep.Core.Diagnostics;
 using Bicep.Core.Registry;
 using Bicep.Core.SourceCode;
 using FluentAssertions;
@@ -85,7 +86,7 @@ public record CachedModule(
 
     public bool HasSourceLayer => LayerMediaTypes.Contains("application/vnd.ms.bicep.module.source.v1.tar+gzip");
 
-    public SourceArchiveResult TryGetSource()
+    public ResultWithException<SourceArchive> TryGetSource()
     {
         var sourceArchivePath = Path.Combine(ModuleCacheFolder, $"source.tar.gz");
         if (File.Exists(sourceArchivePath))
@@ -93,6 +94,6 @@ public record CachedModule(
             return SourceArchive.UnpackFromStream(File.OpenRead(sourceArchivePath));
         }
 
-        return new();
+        return new(new SourceNotAvailableException());
     }
 }

--- a/src/Bicep.Core.UnitTests/Registry/OciModuleRegistryTests.cs
+++ b/src/Bicep.Core.UnitTests/Registry/OciModuleRegistryTests.cs
@@ -678,16 +678,16 @@ namespace Bicep.Core.UnitTests.Registry
             await RestoreModule(ociRegistry, moduleReference);
 
             ociRegistry.Should().HaveValidCachedModules(withSource: publishSource);
-            var actualSource = ociRegistry.TryGetSource(moduleReference);
+            var actualSourceResult = ociRegistry.TryGetSource(moduleReference);
 
             if (sourceStream is { })
             {
-                actualSource.SourceArchive.Should().NotBeNull();
-                actualSource.SourceArchive.Should().BeEquivalentTo(SourceArchive.UnpackFromStream(sourceStream).SourceArchive!);
+                actualSourceResult.TryUnwrap().Should().NotBeNull();
+                actualSourceResult.Unwrap().Should().BeEquivalentTo(SourceArchive.UnpackFromStream(sourceStream).Unwrap());
             }
             else
             {
-                actualSource.SourceArchive.Should().BeNull();
+                actualSourceResult.IsSuccess().Should().BeFalse();
             }
         }
 

--- a/src/Bicep.Core.UnitTests/Registry/OciModuleRegistryTests.cs
+++ b/src/Bicep.Core.UnitTests/Registry/OciModuleRegistryTests.cs
@@ -682,12 +682,12 @@ namespace Bicep.Core.UnitTests.Registry
 
             if (sourceStream is { })
             {
-                actualSource.Should().NotBeNull();
-                actualSource.Should().BeEquivalentTo(SourceArchive.FromStream(sourceStream));
+                actualSource.SourceArchive.Should().NotBeNull();
+                actualSource.SourceArchive.Should().BeEquivalentTo(SourceArchive.UnpackFromStream(sourceStream).SourceArchive!);
             }
             else
             {
-                actualSource.Should().BeNull();
+                actualSource.SourceArchive.Should().BeNull();
             }
         }
 

--- a/src/Bicep.Core.UnitTests/Registry/SourceArchiveTests.cs
+++ b/src/Bicep.Core.UnitTests/Registry/SourceArchiveTests.cs
@@ -147,8 +147,9 @@ public class SourceArchiveTests
         using var stream = SourceArchive.PackSourcesIntoStream(mainBicep.FileUri, mainBicep, mainJson, standaloneJson, templateSpecMainJson, localModuleJson);
         stream.Length.Should().BeGreaterThan(0);
 
-        SourceArchive sourceArchive = SourceArchive.FromStream(stream);
-        sourceArchive.EntrypointRelativePath.Should().Be("main.bicep");
+        SourceArchive? sourceArchive = SourceArchive.UnpackFromStream(stream).SourceArchive;
+        sourceArchive.Should().NotBeNull();
+        sourceArchive!.EntrypointRelativePath.Should().Be("main.bicep");
 
 
         var archivedFiles = sourceArchive.SourceFiles.ToArray();
@@ -210,9 +211,10 @@ public class SourceArchiveTests
 
         using var stream = SourceArchive.PackSourcesIntoStream(mainBicep.FileUri, mainBicep, testFile);
 
-        SourceArchive sourceArchive = SourceArchive.FromStream(stream);
+        SourceArchive? sourceArchive = SourceArchive.UnpackFromStream(stream).SourceArchive;
 
-        sourceArchive.EntrypointRelativePath.Should().Be("my main.bicep");
+        sourceArchive.Should().NotBeNull();
+        sourceArchive!.EntrypointRelativePath.Should().Be("my main.bicep");
 
         var archivedTestFile = sourceArchive.SourceFiles.Single(f => f.Path != "my main.bicep");
         archivedTestFile.Path.Should().Be(expecteArchivedUri);
@@ -246,7 +248,7 @@ public class SourceArchiveTests
             )
         );
 
-        var sut = SourceArchive.FromStream(zip);
+        var sut = SourceArchive.UnpackFromStream(zip).SourceArchive!;
         var file = sut.SourceFiles.Single();
 
         file.Kind.Should().Be("bicep");
@@ -280,7 +282,7 @@ public class SourceArchiveTests
             )
         );
 
-        var sut = SourceArchive.FromStream(zip);
+        var sut = SourceArchive.UnpackFromStream(zip).SourceArchive!;
         var file = sut.SourceFiles.Single();
 
         file.Kind.Should().Be("bicep");
@@ -318,12 +320,74 @@ public class SourceArchiveTests
             )
         );
 
-        var sut = SourceArchive.FromStream(zip);
+        var sut = SourceArchive.UnpackFromStream(zip).SourceArchive!;
         var file = sut.SourceFiles.Single();
 
         file.Kind.Should().Be("bicep");
         file.Contents.Should().Be("bicep contents");
         file.Path.Should().Contain("main.bicep");
+    }
+
+    [TestMethod]
+    public void GetSourceFiles_ShouldGiveError_ForIncompatibleOlderVersion()
+    {
+        var zip = CreateGzippedTarredFileStream(
+            (
+                "__metadata.json",
+                @"
+                {
+                  ""entryPoint"": ""file:///main.bicep"",
+                  ""metadataVersion"": <version>,
+                  ""bicepVersion"": ""0.whatever.0"",
+                  ""sourceFiles"": [
+                    {
+                      ""path"": ""file:///main.bicep"",
+                      ""archivePath"": ""main.bicep"",
+                      ""kind"": ""bicep""
+                    }
+                  ]
+                }".Replace("<version>", (SourceArchive.CurrentMetadataVersion - 1).ToString())
+            ),
+            (
+                "main.bicep",
+                @"bicep contents"
+            )
+        );
+
+        var sut = SourceArchive.UnpackFromStream(zip);
+        sut.SourceArchive.Should().BeNull();
+        sut.Message.Should().StartWith("This source code was published with an older, incompatible version of Bicep (0.whatever.0). You are using version ");
+    }
+
+    [TestMethod]
+    public void GetSourceFiles_ShouldGiveError_ForIncompatibleNewerVersion()
+    {
+        var zip = CreateGzippedTarredFileStream(
+            (
+                "__metadata.json",
+                @"
+                {
+                  ""entryPoint"": ""file:///main.bicep"",
+                  ""metadataVersion"": <version>,
+                  ""bicepVersion"": ""0.whatever.0"",
+                  ""sourceFiles"": [
+                    {
+                      ""path"": ""file:///main.bicep"",
+                      ""archivePath"": ""main.bicep"",
+                      ""kind"": ""bicep""
+                    }
+                  ]
+                }".Replace("<version>", (SourceArchive.CurrentMetadataVersion + 1).ToString())
+            ),
+            (
+                "main.bicep",
+                @"bicep contents"
+            )
+        );
+
+        var sut = SourceArchive.UnpackFromStream(zip);
+        sut.SourceArchive.Should().BeNull();
+        sut.Message.Should().StartWith("This source code was published with a newer, incompatible version of Bicep (0.whatever.0). You are using version ");
     }
 
     private Stream CreateGzippedTarredFileStream(params (string relativePath, string contents)[] files)

--- a/src/Bicep.Core/Diagnostics/ResultWithException.cs
+++ b/src/Bicep.Core/Diagnostics/ResultWithException.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Bicep.Core.Utils;
+
+namespace Bicep.Core.Diagnostics;
+
+public class ResultWithException<TSuccess> : Result<TSuccess, Exception>
+    where TSuccess : class
+{
+    public ResultWithException(TSuccess success) : base(success) { }
+
+    public ResultWithException(Exception exception) : base(exception) { }
+}

--- a/src/Bicep.Core/Registry/ArtifactRegistry.cs
+++ b/src/Bicep.Core/Registry/ArtifactRegistry.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.SourceCode;
+using Bicep.Core.Utils;
 
 namespace Bicep.Core.Registry
 {
@@ -37,7 +38,7 @@ namespace Bicep.Core.Registry
 
         public abstract Task<string?> TryGetDescription(T reference);
 
-        public abstract SourceArchiveResult TryGetSource(T reference);
+        public abstract ResultWithException<SourceArchive> TryGetSource(T reference);
 
         public bool IsArtifactRestoreRequired(ArtifactReference reference) => this.IsArtifactRestoreRequired(ConvertReference(reference));
 
@@ -62,7 +63,7 @@ namespace Bicep.Core.Registry
 
         public async Task<string?> TryGetDescription(ArtifactReference reference) => await this.TryGetDescription(ConvertReference(reference));
 
-        public SourceArchiveResult TryGetSource(ArtifactReference reference) => this.TryGetSource(ConvertReference(reference));
+        public ResultWithException<SourceArchive> TryGetSource(ArtifactReference reference) => this.TryGetSource(ConvertReference(reference));
 
         public abstract RegistryCapabilities GetCapabilities(T reference);
 

--- a/src/Bicep.Core/Registry/ArtifactRegistry.cs
+++ b/src/Bicep.Core/Registry/ArtifactRegistry.cs
@@ -37,7 +37,7 @@ namespace Bicep.Core.Registry
 
         public abstract Task<string?> TryGetDescription(T reference);
 
-        public abstract SourceArchive? TryGetSource(T reference);
+        public abstract SourceArchiveResult TryGetSource(T reference);
 
         public bool IsArtifactRestoreRequired(ArtifactReference reference) => this.IsArtifactRestoreRequired(ConvertReference(reference));
 
@@ -62,7 +62,7 @@ namespace Bicep.Core.Registry
 
         public async Task<string?> TryGetDescription(ArtifactReference reference) => await this.TryGetDescription(ConvertReference(reference));
 
-        public SourceArchive? TryGetSource(ArtifactReference reference) => this.TryGetSource(ConvertReference(reference));
+        public SourceArchiveResult TryGetSource(ArtifactReference reference) => this.TryGetSource(ConvertReference(reference));
 
         public abstract RegistryCapabilities GetCapabilities(T reference);
 

--- a/src/Bicep.Core/Registry/IArtifactDispatcher.cs
+++ b/src/Bicep.Core/Registry/IArtifactDispatcher.cs
@@ -32,6 +32,6 @@ namespace Bicep.Core.Registry
         void PruneRestoreStatuses();
 
         // Retrieves the sources that have been restored along with the module into the cache (if available)
-        SourceArchive? TryGetModuleSources(ArtifactReference reference);
+        SourceArchiveResult TryGetModuleSources(ArtifactReference reference);
     }
 }

--- a/src/Bicep.Core/Registry/IArtifactDispatcher.cs
+++ b/src/Bicep.Core/Registry/IArtifactDispatcher.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Threading.Tasks;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.SourceCode;
+using Bicep.Core.Utils;
 
 namespace Bicep.Core.Registry
 {
@@ -32,6 +33,6 @@ namespace Bicep.Core.Registry
         void PruneRestoreStatuses();
 
         // Retrieves the sources that have been restored along with the module into the cache (if available)
-        SourceArchiveResult TryGetModuleSources(ArtifactReference reference);
+        ResultWithException<SourceArchive> TryGetModuleSources(ArtifactReference reference);
     }
 }

--- a/src/Bicep.Core/Registry/IArtifactRegistry.cs
+++ b/src/Bicep.Core/Registry/IArtifactRegistry.cs
@@ -102,6 +102,6 @@ namespace Bicep.Core.Registry
         /// </summary>
         /// <param name="reference">The module reference</param>
         /// <returns>A source archive</returns>
-        SourceArchive? TryGetSource(ArtifactReference reference);
+        SourceArchiveResult TryGetSource(ArtifactReference reference);
     }
 }

--- a/src/Bicep.Core/Registry/IArtifactRegistry.cs
+++ b/src/Bicep.Core/Registry/IArtifactRegistry.cs
@@ -10,6 +10,7 @@ using Bicep.Core.Diagnostics;
 using Bicep.Core.Modules;
 using Bicep.Core.Registry.Providers;
 using Bicep.Core.SourceCode;
+using Bicep.Core.Utils;
 
 namespace Bicep.Core.Registry
 {
@@ -102,6 +103,6 @@ namespace Bicep.Core.Registry
         /// </summary>
         /// <param name="reference">The module reference</param>
         /// <returns>A source archive</returns>
-        SourceArchiveResult TryGetSource(ArtifactReference reference);
+        ResultWithException<SourceArchive> TryGetSource(ArtifactReference reference);
     }
 }

--- a/src/Bicep.Core/Registry/LocalModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/LocalModuleRegistry.cs
@@ -106,9 +106,9 @@ namespace Bicep.Core.Registry
             return null;
         }
 
-        public override SourceArchive? TryGetSource(LocalModuleReference reference)
+        public override SourceArchiveResult TryGetSource(LocalModuleReference reference)
         {
-            return null;
+            return new();
         }
     }
 }

--- a/src/Bicep.Core/Registry/LocalModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/LocalModuleRegistry.cs
@@ -11,6 +11,7 @@ using Bicep.Core.FileSystem;
 using Bicep.Core.Modules;
 using Bicep.Core.Semantics;
 using Bicep.Core.SourceCode;
+using Bicep.Core.Utils;
 
 namespace Bicep.Core.Registry
 {
@@ -106,9 +107,9 @@ namespace Bicep.Core.Registry
             return null;
         }
 
-        public override SourceArchiveResult TryGetSource(LocalModuleReference reference)
+        public override ResultWithException<SourceArchive> TryGetSource(LocalModuleReference reference)
         {
-            return new();
+            return new(new SourceNotAvailableException());
         }
     }
 }

--- a/src/Bicep.Core/Registry/ModuleDispatcher.cs
+++ b/src/Bicep.Core/Registry/ModuleDispatcher.cs
@@ -228,7 +228,7 @@ namespace Bicep.Core.Registry
         private IArtifactRegistry GetRegistry(ArtifactReference reference) =>
             Registries(reference.ParentModuleUri).TryGetValue(reference.Scheme, out var registry) ? registry : throw new InvalidOperationException($"Unexpected artifactDeclaration reference scheme '{reference.Scheme}'.");
 
-        public SourceArchive? TryGetModuleSources(ArtifactReference reference)
+        public SourceArchiveResult TryGetModuleSources(ArtifactReference reference)
         {
             var registry = this.GetRegistry(reference);
             return registry.TryGetSource(reference);

--- a/src/Bicep.Core/Registry/ModuleDispatcher.cs
+++ b/src/Bicep.Core/Registry/ModuleDispatcher.cs
@@ -16,6 +16,7 @@ using Bicep.Core.Navigation;
 using Bicep.Core.Semantics;
 using Bicep.Core.SourceCode;
 using Bicep.Core.Syntax;
+using Bicep.Core.Utils;
 
 namespace Bicep.Core.Registry
 {
@@ -228,7 +229,7 @@ namespace Bicep.Core.Registry
         private IArtifactRegistry GetRegistry(ArtifactReference reference) =>
             Registries(reference.ParentModuleUri).TryGetValue(reference.Scheme, out var registry) ? registry : throw new InvalidOperationException($"Unexpected artifactDeclaration reference scheme '{reference.Scheme}'.");
 
-        public SourceArchiveResult TryGetModuleSources(ArtifactReference reference)
+        public ResultWithException<SourceArchive> TryGetModuleSources(ArtifactReference reference)
         {
             var registry = this.GetRegistry(reference);
             return registry.TryGetSource(reference);

--- a/src/Bicep.Core/Registry/OciArtifactRegistry.cs
+++ b/src/Bicep.Core/Registry/OciArtifactRegistry.cs
@@ -506,15 +506,16 @@ namespace Bicep.Core.Registry
             return fileSystem.Path.Combine(this.GetArtifactDirectoryPath(reference), fileName);
         }
 
-        public override SourceArchive? TryGetSource(OciArtifactReference reference)
+        public override SourceArchiveResult TryGetSource(OciArtifactReference reference)
         {
             var zipPath = GetArtifactFilePath(reference, ArtifactFileType.Source);
             if (File.Exists(zipPath))
             {
-                return SourceArchive.FromStream(File.OpenRead(zipPath));
+                return SourceArchive.UnpackFromStream(File.OpenRead(zipPath));
             }
 
-            return null;
+            // No sources available (presumably they weren't published)
+            return new();
         }
 
         private enum ArtifactFileType

--- a/src/Bicep.Core/Registry/OciArtifactRegistry.cs
+++ b/src/Bicep.Core/Registry/OciArtifactRegistry.cs
@@ -21,6 +21,7 @@ using Bicep.Core.Registry.Oci;
 using Bicep.Core.Semantics;
 using Bicep.Core.SourceCode;
 using Bicep.Core.Tracing;
+using Bicep.Core.Utils;
 using Newtonsoft.Json;
 
 namespace Bicep.Core.Registry
@@ -506,7 +507,7 @@ namespace Bicep.Core.Registry
             return fileSystem.Path.Combine(this.GetArtifactDirectoryPath(reference), fileName);
         }
 
-        public override SourceArchiveResult TryGetSource(OciArtifactReference reference)
+        public override ResultWithException<SourceArchive> TryGetSource(OciArtifactReference reference)
         {
             var zipPath = GetArtifactFilePath(reference, ArtifactFileType.Source);
             if (File.Exists(zipPath))
@@ -515,7 +516,7 @@ namespace Bicep.Core.Registry
             }
 
             // No sources available (presumably they weren't published)
-            return new();
+            return new(new SourceNotAvailableException());
         }
 
         private enum ArtifactFileType

--- a/src/Bicep.Core/Registry/TemplateSpecModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/TemplateSpecModuleRegistry.cs
@@ -153,9 +153,9 @@ namespace Bicep.Core.Registry
             return Task.FromResult<string?>(null);
         }
 
-        public override SourceArchive? TryGetSource(TemplateSpecModuleReference reference)
+        public override SourceArchiveResult TryGetSource(TemplateSpecModuleReference reference)
         {
-            return null;
+            return new();
         }
     }
 }

--- a/src/Bicep.Core/Registry/TemplateSpecModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/TemplateSpecModuleRegistry.cs
@@ -14,6 +14,7 @@ using Bicep.Core.Modules;
 using Bicep.Core.Semantics;
 using Bicep.Core.SourceCode;
 using Bicep.Core.Tracing;
+using Bicep.Core.Utils;
 
 namespace Bicep.Core.Registry
 {
@@ -153,9 +154,9 @@ namespace Bicep.Core.Registry
             return Task.FromResult<string?>(null);
         }
 
-        public override SourceArchiveResult TryGetSource(TemplateSpecModuleReference reference)
+        public override ResultWithException<SourceArchive> TryGetSource(TemplateSpecModuleReference reference)
         {
-            return new();
+            return new(new SourceNotAvailableException());
         }
     }
 }

--- a/src/Bicep.Core/SourceCode/SourceArchive.cs
+++ b/src/Bicep.Core/SourceCode/SourceArchive.cs
@@ -198,7 +198,6 @@ namespace Bicep.Core.SourceCode
         {
             var filesBuilder = ImmutableDictionary.CreateBuilder<string, string>();
 
-            stream.Position = 0;
             var gz = new GZipStream(stream, CompressionMode.Decompress);
             using var tarReader = new TarReader(gz);
 

--- a/src/Bicep.Core/SourceCode/SourceArchive.cs
+++ b/src/Bicep.Core/SourceCode/SourceArchive.cs
@@ -18,27 +18,64 @@ using Bicep.Core.Exceptions;
 using Bicep.Core.Navigation;
 using Bicep.Core.Registry.Oci;
 using Bicep.Core.Semantics;
+using Bicep.Core.Utils;
 using Bicep.Core.Workspaces;
 using static Bicep.Core.SourceCode.SourceArchive;
 
 namespace Bicep.Core.SourceCode
 {
-    // Contains the individual source code files for a Bicep file and all of its dependencies.
-    public partial class SourceArchive
+    public record SourceArchiveResult
     {
+        public SourceArchiveResult()
+        {
+            // This is the case when the source code is not available in the registry cache (presumably wasn't published)
+            SourceArchive = null;
+            Message = null;
+        }
+
+        public SourceArchiveResult(SourceArchive sourceArchive)
+        {
+            SourceArchive = sourceArchive;
+            Message = null;
+        }
+
+        public SourceArchiveResult(string message)
+        {
+            SourceArchive = null;
+            Message = message;
+        }
+
+        // If both are null, there is no source code available in the registry cache (presumably wasn't published)
+        public SourceArchive? SourceArchive;
+        public string? Message;
+    }
+
+    // Contains the individual source code files for a Bicep file and all of its dependencies.
+    public partial class SourceArchive // Partial required for serialization
+    {
+
+        // Attributes of this archive instance
+
+        private ArchiveMetadata InstanceMetadata { get; init; }
+
         public ImmutableArray<SourceFileInfo> SourceFiles { get; init; }
-        public string EntrypointRelativePath { get; init; }
+        public string EntrypointRelativePath => InstanceMetadata.EntryPoint;
+        // The version of Bicep which created this deserialized archive instance.
+        public string BicepVersion => InstanceMetadata.BicepVersion;
+        // The version of the metadata file format used by this archive instance.
+        public int MetadataVersion => InstanceMetadata.MetadataVersion;
+
+        // Constants
 
         public const string SourceKind_Bicep = "bicep";
         public const string SourceKind_ArmTemplate = "armTemplate";
         public const string SourceKind_TemplateSpec = "templateSpec";
 
-        private const string MetadataArchivedFileName = "__metadata.json";
+        private const string MetadataFileName = "__metadata.json";
 
-        private bool isDisposed = false;//asfdg remove
-
-        // WARNING: Only change this value if there is a breaking change such that old versions of Bicep should fail on reading this source archive
-        private const int CurrentMetadataVersion = 0; // TODO: Change to 1 when remove experimental flag
+        // NOTE: Only change this value if there is a breaking change such that old versions of Bicep should fail on reading new source archives
+        public const int CurrentMetadataVersion = 0;
+        private static readonly string CurrentBicepVersion = ThisAssembly.AssemblyVersion;
 
         public partial record SourceFileInfo(
             string Path,        // the location, relative to the main.bicep file's folder, for the file that will be shown to the end user (required in all Bicep versions)
@@ -47,15 +84,16 @@ namespace Bicep.Core.SourceCode
             string Contents
         );
 
-        [JsonSerializable(typeof(MetadataEntry))]
+        [JsonSerializable(typeof(ArchiveMetadata))]
         [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
         private partial class MetadataSerializationContext : JsonSerializerContext { }
 
-        [JsonSerializable(typeof(MetadataEntry))]
-        private record MetadataEntry(
+        [JsonSerializable(typeof(ArchiveMetadata))]
+        private record ArchiveMetadata(
             int MetadataVersion,
             string EntryPoint, // Path of the entrypoint file
-            IEnumerable<SourceFileInfoEntry> SourceFiles
+            IEnumerable<SourceFileInfoEntry> SourceFiles,
+            string BicepVersion = "unknown"
         );
 
         [JsonSerializable(typeof(SourceFileInfoEntry))]
@@ -68,9 +106,32 @@ namespace Bicep.Core.SourceCode
             string Kind         // kind of source
         );
 
-        public static SourceArchive FromStream(Stream stream)
+        private string? GetRequiredBicepVersionMessage()
         {
-            return new SourceArchive(stream);
+            if (MetadataVersion < CurrentMetadataVersion)
+            {
+                return $"This source code was published with an older, incompatible version of Bicep ({BicepVersion}). You are using version {ThisAssembly.AssemblyVersion}.";
+            }
+
+            if (MetadataVersion > CurrentMetadataVersion)
+            {
+                return $"This source code was published with a newer, incompatible version of Bicep ({BicepVersion}). You are using version {ThisAssembly.AssemblyVersion}. You need a newer version in order to view the module source.";
+            }
+
+            return null;
+        }
+
+        public static SourceArchiveResult UnpackFromStream(Stream stream)
+        {
+            var archive = new SourceArchive(stream);
+            if (archive.GetRequiredBicepVersionMessage() is string message)
+            {
+                return new(message);
+            }
+            else
+            {
+                return new(archive);
+            }
         }
 
         /// <summary>
@@ -133,7 +194,7 @@ namespace Bicep.Core.SourceCode
 
                     // Add the metadata file
                     var metadataContents = CreateMetadataFileContents(entryPointPath, filesMetadata);
-                    WriteNewFileEntry(tarWriter, MetadataArchivedFileName, metadataContents);
+                    WriteNewFileEntry(tarWriter, MetadataFileName, metadataContents);
                 }
             }
 
@@ -150,11 +211,6 @@ namespace Bicep.Core.SourceCode
 
         private SourceArchive(Stream stream)
         {
-            if (isDisposed)
-            {
-                throw new ObjectDisposedException(nameof(SourceArchive));
-            }
-
             var filesBuilder = ImmutableDictionary.CreateBuilder<string, string>();
 
             stream.Position = 0;
@@ -169,9 +225,9 @@ namespace Bicep.Core.SourceCode
 
             var dictionary = filesBuilder.ToImmutableDictionary();
 
-            var metadataJson = dictionary[MetadataArchivedFileName]
+            var metadataJson = dictionary[MetadataFileName]
                 ?? throw new BicepException("Incorrectly formatted source file: No {MetadataArchivedFileName} entry");
-            var metadata = JsonSerializer.Deserialize<MetadataEntry>(metadataJson, MetadataSerializationContext.Default.MetadataEntry)
+            var metadata = JsonSerializer.Deserialize<ArchiveMetadata>(metadataJson, MetadataSerializationContext.Default.ArchiveMetadata)
                 ?? throw new BicepException("Source archive has invalid metadata entry");
 
             var infos = new List<SourceFileInfo>();
@@ -182,15 +238,15 @@ namespace Bicep.Core.SourceCode
                 infos.Add(new SourceFileInfo(info.Path, info.ArchivePath, info.Kind, contents));
             }
 
-            this.EntrypointRelativePath = metadata.EntryPoint;
+            this.InstanceMetadata = metadata;
             this.SourceFiles = infos.ToImmutableArray();
         }
 
         private static string CreateMetadataFileContents(string entrypointPath, IEnumerable<SourceFileInfoEntry> files)
         {
             // Add the __metadata.json file
-            var metadata = new MetadataEntry(CurrentMetadataVersion, entrypointPath, files);
-            return JsonSerializer.Serialize(metadata, MetadataSerializationContext.Default.MetadataEntry);
+            var metadata = new ArchiveMetadata(CurrentMetadataVersion, entrypointPath, files, CurrentBicepVersion);
+            return JsonSerializer.Serialize(metadata, MetadataSerializationContext.Default.ArchiveMetadata);
         }
 
         private static void WriteNewFileEntry(TarWriter tarWriter, string archivePath, string contents)

--- a/src/Bicep.Core/SourceCode/SourceArchive.cs
+++ b/src/Bicep.Core/SourceCode/SourceArchive.cs
@@ -25,7 +25,8 @@ using static Bicep.Core.SourceCode.SourceArchive;
 
 namespace Bicep.Core.SourceCode
 {
-    public class SourceNotAvailableException : Exception {
+    public class SourceNotAvailableException : Exception
+    {
         public SourceNotAvailableException()
             : base("(Experimental) No source code is available for this module")
         { }
@@ -43,7 +44,8 @@ namespace Bicep.Core.SourceCode
         public string EntrypointRelativePath => InstanceMetadata.EntryPoint;
 
         // The version of Bicep which created this deserialized archive instance.
-        public string BicepVersion => InstanceMetadata.BicepVersion;
+        public string? BicepVersion => InstanceMetadata.BicepVersion;
+        public string FriendlyBicepVersion => InstanceMetadata.BicepVersion ?? "unknown";
 
         // The version of the metadata file format used by this archive instance.
         public int MetadataVersion => InstanceMetadata.MetadataVersion;
@@ -76,7 +78,7 @@ namespace Bicep.Core.SourceCode
             int MetadataVersion,
             string EntryPoint, // Path of the entrypoint file
             IEnumerable<SourceFileInfoEntry> SourceFiles,
-            string BicepVersion = "unknown"
+            string? BicepVersion = null
         );
 
         [JsonSerializable(typeof(SourceFileInfoEntry))]
@@ -93,12 +95,12 @@ namespace Bicep.Core.SourceCode
         {
             if (MetadataVersion < CurrentMetadataVersion)
             {
-                return $"This source code was published with an older, incompatible version of Bicep ({BicepVersion}). You are using version {ThisAssembly.AssemblyVersion}.";
+                return $"This source code was published with an older, incompatible version of Bicep ({FriendlyBicepVersion}). You are using version {ThisAssembly.AssemblyVersion}.";
             }
 
             if (MetadataVersion > CurrentMetadataVersion)
             {
-                return $"This source code was published with a newer, incompatible version of Bicep ({BicepVersion}). You are using version {ThisAssembly.AssemblyVersion}. You need a newer version in order to view the module source.";
+                return $"This source code was published with a newer, incompatible version of Bicep ({FriendlyBicepVersion}). You are using version {ThisAssembly.AssemblyVersion}. You need a newer version in order to view the module source.";
             }
 
             return null;

--- a/src/Bicep.LangServer.IntegrationTests/Registry/ModuleRestoreSchedulerTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Registry/ModuleRestoreSchedulerTests.cs
@@ -210,7 +210,7 @@ namespace Bicep.LangServer.IntegrationTests.Registry
                 return new(new MockArtifactRef(reference, PathHelper.FilePathToFileUrl(Path.GetTempFileName())));
             }
 
-            public SourceArchive? TryGetSource(ArtifactReference artifactReference) => null;
+            public SourceArchiveResult TryGetSource(ArtifactReference artifactReference) => new();
         }
 
         private class MockArtifactRef : ArtifactReference

--- a/src/Bicep.LangServer.IntegrationTests/Registry/ModuleRestoreSchedulerTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Registry/ModuleRestoreSchedulerTests.cs
@@ -210,7 +210,7 @@ namespace Bicep.LangServer.IntegrationTests.Registry
                 return new(new MockArtifactRef(reference, PathHelper.FilePathToFileUrl(Path.GetTempFileName())));
             }
 
-            public SourceArchiveResult TryGetSource(ArtifactReference artifactReference) => new();
+            public ResultWithException<SourceArchive> TryGetSource(ArtifactReference artifactReference) => new(new SourceNotAvailableException());
         }
 
         private class MockArtifactRef : ArtifactReference

--- a/src/Bicep.LangServer.UnitTests/BicepExternalSourceRequestHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepExternalSourceRequestHandlerTests.cs
@@ -168,8 +168,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
             dispatcher.Setup(m => m.GetArtifactRestoreStatus(moduleReference!, out nullBuilder)).Returns(ArtifactRestoreStatus.Succeeded);
             dispatcher.Setup(m => m.TryGetLocalArtifactEntryPointUri(moduleReference!)).Returns(ResultHelper.Create(compiledJsonUri, null));
 
-            SourceArchive? sourceArchive = null;
-            dispatcher.Setup(m => m.TryGetModuleSources(moduleReference!)).Returns(sourceArchive);
+            dispatcher.Setup(m => m.TryGetModuleSources(moduleReference!)).Returns(new SourceArchiveResult());
 
             var resolver = StrictMock.Of<IFileResolver>();
             resolver.Setup(m => m.TryRead(compiledJsonUri)).Returns(ResultHelper.Create((string?)null, readFailureBuilder));
@@ -208,8 +207,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
             dispatcher.Setup(m => m.GetArtifactRestoreStatus(moduleReference!, out nullBuilder)).Returns(ArtifactRestoreStatus.Succeeded);
             dispatcher.Setup(m => m.TryGetLocalArtifactEntryPointUri(moduleReference!)).Returns(ResultHelper.Create(compiledJsonUri, null));
 
-            SourceArchive? sourceArchive = null;
-            dispatcher.Setup(m => m.TryGetModuleSources(moduleReference!)).Returns(sourceArchive);
+            dispatcher.Setup(m => m.TryGetModuleSources(moduleReference!)).Returns(new SourceArchiveResult());
 
             var resolver = StrictMock.Of<IFileResolver>();
             resolver.Setup(m => m.TryRead(compiledJsonUri)).Returns(ResultHelper.Create(compiledJsonContents, nullBuilder));
@@ -249,7 +247,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
 
             var bicepSource = "metadata hi = 'This is the bicep source file'";
             var bicepUri = new Uri("file:///foo/bar/entrypoint.bicep");
-            var sourceArchive = SourceArchive.FromStream(SourceArchive.PackSourcesIntoStream(bicepUri, new Core.Workspaces.ISourceFile[] {
+            var sourceArchive = SourceArchive.UnpackFromStream(SourceArchive.PackSourcesIntoStream(bicepUri, new Core.Workspaces.ISourceFile[] {
                 SourceFileFactory.CreateBicepFile(bicepUri, bicepSource)}));
             dispatcher.Setup(m => m.TryGetModuleSources(moduleReference!)).Returns(sourceArchive);
 
@@ -291,7 +289,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
 
             var bicepSource = "metadata hi = 'This is the bicep source file'";
             var bicepUri = new Uri("file:///foo/bar/entrypoint.bicep");
-            var sourceArchive = SourceArchive.FromStream(SourceArchive.PackSourcesIntoStream(bicepUri, new Core.Workspaces.ISourceFile[] {
+            var sourceArchive = SourceArchive.UnpackFromStream(SourceArchive.PackSourcesIntoStream(bicepUri, new Core.Workspaces.ISourceFile[] {
                 SourceFileFactory.CreateBicepFile(bicepUri, bicepSource)}));
             dispatcher.Setup(m => m.TryGetModuleSources(moduleReference!)).Returns(sourceArchive);
 
@@ -308,6 +306,18 @@ namespace Bicep.LangServer.UnitTests.Handlers
         }
 
         #region GetExternalSourceLinkUri tests
+
+        [TestMethod]
+        public void GetExternalSourceLinkUri_DefaultToBicepIsFalse_WithoutOrWithoutSource_ShouldRequestMainJson()
+        {
+            Uri resultWithSource = GetExternalSourceLinkUri(new ExternalSourceLinkTestData(), defaultToDisplayingBicep: false);
+            DecodeExternalSourceUri(resultWithSource).IsRequestingCompiledJson.Should().BeTrue();
+            DecodeExternalSourceUri(resultWithSource).Title.Should().Contain("main.json");
+
+            Uri resultWithoutSource = GetExternalSourceLinkUri(new ExternalSourceLinkTestData(), defaultToDisplayingBicep: false);
+            DecodeExternalSourceUri(resultWithoutSource).IsRequestingCompiledJson.Should().BeTrue();
+            DecodeExternalSourceUri(resultWithoutSource).Title.Should().Contain("main.json");
+        }
 
         [TestMethod]
         public void GetExternalSourceLinkUri_FullLink_WithSource()
@@ -385,7 +395,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
             (decoded.RequestedFile ?? "main.json").Should().MatchRegex(".+\\.(bicep|json)$", "requested source file should end with .json or .bicep");
         }
 
-        private Uri GetExternalSourceLinkUri(ExternalSourceLinkTestData testData)
+        private Uri GetExternalSourceLinkUri(ExternalSourceLinkTestData testData, bool defaultToDisplayingBicep = true)
         {
             Uri? entrypointUri = testData.sourceEntrypoint is { } ? new($"file:///{testData.sourceEntrypoint}") : null;
             OciArtifactReference reference = new(
@@ -396,23 +406,28 @@ namespace Bicep.LangServer.UnitTests.Handlers
                 testData.tagOrDigest[0] == '@' ? testData.tagOrDigest[1..] : null,
                 new Uri("file:///parent.bicep", UriKind.Absolute));
 
-            var sourceArchive = entrypointUri is { } ?
-                SourceArchive.FromStream(SourceArchive.PackSourcesIntoStream(
+            SourceArchive? sourceArchive = entrypointUri is { } ?
+                SourceArchive.UnpackFromStream(SourceArchive.PackSourcesIntoStream(
                     entrypointUri,
                     new Core.Workspaces.ISourceFile[] {
                         SourceFileFactory.CreateBicepFile(entrypointUri, "metadata description = 'bicep module'")
-                    }))
+                    })).SourceArchive
                 : null;
 
-            return BicepExternalSourceRequestHandler.GetExternalSourceLinkUri(reference, sourceArchive);
+            return BicepExternalSourceRequestHandler.GetExternalSourceLinkUri(reference, sourceArchive, defaultToDisplayingBicep);
         }
 
-        public ExternalSourceReference DecodeExternalSourceUri(Uri uri)
+        private string TrimFirstCharacter(string s)
+        {
+            return s.Length > 2 ? s[1..] : s;
+        }
+
+        private ExternalSourceReference DecodeExternalSourceUri(Uri uri)
         {
             // NOTE: This code should match src\vscode-bicep\src\language\bicepExternalSourceContentProvider.ts
             string title = Uri.UnescapeDataString(uri.AbsolutePath);
-            string moduleReference = Uri.UnescapeDataString(uri.Query[1..]); // skip '?'
-            string? requestedSourceFile = Uri.UnescapeDataString(uri.Fragment[1..]); // skip '#'
+            string moduleReference = Uri.UnescapeDataString(TrimFirstCharacter(uri.Query)); // skip '?'
+            string? requestedSourceFile = Uri.UnescapeDataString(TrimFirstCharacter(uri.Fragment)); // skip '#'
 
             return new ExternalSourceReference(title, moduleReference, requestedSourceFile);
         }

--- a/src/Bicep.LangServer.UnitTests/BicepExternalSourceRequestHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepExternalSourceRequestHandlerTests.cs
@@ -168,7 +168,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
             dispatcher.Setup(m => m.GetArtifactRestoreStatus(moduleReference!, out nullBuilder)).Returns(ArtifactRestoreStatus.Succeeded);
             dispatcher.Setup(m => m.TryGetLocalArtifactEntryPointUri(moduleReference!)).Returns(ResultHelper.Create(compiledJsonUri, null));
 
-            dispatcher.Setup(m => m.TryGetModuleSources(moduleReference!)).Returns(new SourceArchiveResult());
+            dispatcher.Setup(m => m.TryGetModuleSources(moduleReference!)).Returns(new ResultWithException<SourceArchive>(new SourceNotAvailableException()));
 
             var resolver = StrictMock.Of<IFileResolver>();
             resolver.Setup(m => m.TryRead(compiledJsonUri)).Returns(ResultHelper.Create((string?)null, readFailureBuilder));
@@ -207,7 +207,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
             dispatcher.Setup(m => m.GetArtifactRestoreStatus(moduleReference!, out nullBuilder)).Returns(ArtifactRestoreStatus.Succeeded);
             dispatcher.Setup(m => m.TryGetLocalArtifactEntryPointUri(moduleReference!)).Returns(ResultHelper.Create(compiledJsonUri, null));
 
-            dispatcher.Setup(m => m.TryGetModuleSources(moduleReference!)).Returns(new SourceArchiveResult());
+            dispatcher.Setup(m => m.TryGetModuleSources(moduleReference!)).Returns(new ResultWithException<SourceArchive>(new SourceNotAvailableException()));
 
             var resolver = StrictMock.Of<IFileResolver>();
             resolver.Setup(m => m.TryRead(compiledJsonUri)).Returns(ResultHelper.Create(compiledJsonContents, nullBuilder));
@@ -411,7 +411,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
                     entrypointUri,
                     new Core.Workspaces.ISourceFile[] {
                         SourceFileFactory.CreateBicepFile(entrypointUri, "metadata description = 'bicep module'")
-                    })).SourceArchive
+                    })).TryUnwrap()
                 : null;
 
             return BicepExternalSourceRequestHandler.GetExternalSourceLinkUri(reference, sourceArchive, defaultToDisplayingBicep);

--- a/src/Bicep.LangServer/Handlers/BicepDefinitionHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDefinitionHandler.cs
@@ -198,7 +198,8 @@ namespace Bicep.LanguageServer.Handlers
                 return sourceFile.FileUri;
             }
 
-            return BicepExternalSourceRequestHandler.GetExternalSourceLinkUri(ociReference, moduleDispatcher.TryGetModuleSources(reference));
+            //TODO(#12811): set defaultToDisplayingBicep back to default of true when removing experimental flag for publishing source
+            return BicepExternalSourceRequestHandler.GetExternalSourceLinkUri(ociReference, moduleDispatcher?.TryGetModuleSources(reference).SourceArchive, defaultToDisplayingBicep: false);
         }
 
         private LocationOrLocationLinks HandleWildcardImportDeclaration(CompilationContext context, DefinitionParams request, SymbolResolutionResult result, WildcardImportSymbol wildcardImport)

--- a/src/Bicep.LangServer/Handlers/BicepDefinitionHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDefinitionHandler.cs
@@ -199,7 +199,7 @@ namespace Bicep.LanguageServer.Handlers
             }
 
             //TODO(#12811): set defaultToDisplayingBicep back to default of true when removing experimental flag for publishing source
-            return BicepExternalSourceRequestHandler.GetExternalSourceLinkUri(ociReference, moduleDispatcher?.TryGetModuleSources(reference).SourceArchive, defaultToDisplayingBicep: false);
+            return BicepExternalSourceRequestHandler.GetExternalSourceLinkUri(ociReference, moduleDispatcher?.TryGetModuleSources(reference).TryUnwrap(), defaultToDisplayingBicep: false);
         }
 
         private LocationOrLocationLinks HandleWildcardImportDeclaration(CompilationContext context, DefinitionParams request, SymbolResolutionResult result, WildcardImportSymbol wildcardImport)

--- a/src/Bicep.LangServer/Handlers/BicepExternalSourceRequestHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepExternalSourceRequestHandler.cs
@@ -23,7 +23,7 @@ namespace Bicep.LanguageServer.Handlers
         string? requestedSourceFile = null // The relative source path of the file in the module to get source for (main.json if null))
     ) : IRequest<BicepExternalSourceResponse>;
 
-    public record BicepExternalSourceResponse(string Content);
+    public record BicepExternalSourceResponse(string? Content, string? Error = null);
 
     /// <summary>
     /// Handles textDocument/bicepExternalSource LSP requests. These are sent by clients that are resolving contents of document URIs using the bicep-extsrc: scheme.
@@ -72,19 +72,27 @@ namespace Bicep.LanguageServer.Handlers
                     $"Unable to obtain the entry point URI for module '{moduleReference.FullyQualifiedReference}'.");
             }
 
-            if (moduleDispatcher.TryGetModuleSources(moduleReference) is SourceArchive sourceArchive && request.requestedSourceFile is { })
+            if (request.requestedSourceFile is { })
             {
-                var requestedFile = sourceArchive.SourceFiles.FirstOrDefault(f => f.Path == request.requestedSourceFile);
-                if (requestedFile is null)
+                SourceArchiveResult sourceArchiveResult = moduleDispatcher.TryGetModuleSources(moduleReference);
+                if (sourceArchiveResult.SourceArchive is { })
                 {
-                    throw new InvalidOperationException($"Could not find source file \"{request.requestedSourceFile}\" in the sources for module \"{moduleReference.FullyQualifiedReference}\"");
-                }
+                    var requestedFile = sourceArchiveResult.SourceArchive.SourceFiles.FirstOrDefault(f => f.Path == request.requestedSourceFile);
+                    if (requestedFile is null)
+                    {
+                        throw new InvalidOperationException($"Could not find source file \"{request.requestedSourceFile}\" in the sources for module \"{moduleReference.FullyQualifiedReference}\"");
+                    }
 
-                return Task.FromResult(new BicepExternalSourceResponse(requestedFile.Contents));
+                    return Task.FromResult(new BicepExternalSourceResponse(requestedFile.Contents));
+                }
+                else if (sourceArchiveResult?.Message is { })
+                {
+                    return Task.FromResult(new BicepExternalSourceResponse(null, sourceArchiveResult.Message));
+                }
             }
 
-            // No sources available, or specifically requesting the compiled main.json.
-            // Retrieve the JSON source
+            // No sources available, or specifically requesting the compiled main.json (requestedSourceFile=null), or there was an error retrieving sources.
+            // Just show the compiled JSON
             if (!this.fileResolver.TryRead(compiledJsonUri).IsSuccess(out var contents, out var failureBuilder))
             {
                 var message = failureBuilder(DiagnosticBuilder.ForDocumentStart()).Message;
@@ -101,9 +109,9 @@ namespace Bicep.LanguageServer.Handlers
         /// <param name="reference">The module reference</param>
         /// <param name="sourceArchive">The source archive for the module, if sources are available</param>
         /// <returns>A bicep-extsrc: URI</returns>
-        public static Uri GetExternalSourceLinkUri(OciArtifactReference reference, SourceArchive? sourceArchive)
+        public static Uri GetExternalSourceLinkUri(OciArtifactReference reference, SourceArchive? sourceArchive, bool defaultToDisplayingBicep = true)
         {
-            return new ExternalSourceReference(reference, sourceArchive).ToUri();
+            return new ExternalSourceReference(reference, sourceArchive, defaultToDisplayingBicep: defaultToDisplayingBicep).ToUri();
         }
     }
 }

--- a/src/Bicep.LangServer/Handlers/BicepExternalSourceRequestHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepExternalSourceRequestHandler.cs
@@ -74,10 +74,9 @@ namespace Bicep.LanguageServer.Handlers
 
             if (request.requestedSourceFile is { })
             {
-                SourceArchiveResult sourceArchiveResult = moduleDispatcher.TryGetModuleSources(moduleReference);
-                if (sourceArchiveResult.SourceArchive is { })
+                if (moduleDispatcher.TryGetModuleSources(moduleReference).IsSuccess(out var sourceArchive, out var ex))
                 {
-                    var requestedFile = sourceArchiveResult.SourceArchive.SourceFiles.FirstOrDefault(f => f.Path == request.requestedSourceFile);
+                    var requestedFile = sourceArchive.SourceFiles.FirstOrDefault(f => f.Path == request.requestedSourceFile);
                     if (requestedFile is null)
                     {
                         throw new InvalidOperationException($"Could not find source file \"{request.requestedSourceFile}\" in the sources for module \"{moduleReference.FullyQualifiedReference}\"");
@@ -85,9 +84,9 @@ namespace Bicep.LanguageServer.Handlers
 
                     return Task.FromResult(new BicepExternalSourceResponse(requestedFile.Contents));
                 }
-                else if (sourceArchiveResult?.Message is { })
+                else if (ex is not SourceNotAvailableException)
                 {
-                    return Task.FromResult(new BicepExternalSourceResponse(null, sourceArchiveResult.Message));
+                    return Task.FromResult(new BicepExternalSourceResponse(null, ex.Message));
                 }
             }
 

--- a/src/Bicep.LangServer/Handlers/ExternalSourceCodeLensProvider.cs
+++ b/src/Bicep.LangServer/Handlers/ExternalSourceCodeLensProvider.cs
@@ -23,7 +23,7 @@ namespace Bicep.LanguageServer.Handlers
 
             if (request.TextDocument.Uri.Scheme == LangServerConstants.ExternalSourceFileScheme)
             {
-                string? error = null;
+                string? message = null;
                 ExternalSourceReference? externalReference = null;
 
                 try
@@ -32,38 +32,44 @@ namespace Bicep.LanguageServer.Handlers
                 }
                 catch (Exception ex)
                 {
-                    error = ex.Message;
+                    message = $"(Experimental) There was an error retrieving source code for this module: {ex.Message}";
                 }
 
                 if (externalReference is not null)
                 {
-                    Debug.Assert(error is null);
+                    Debug.Assert(message is null);
 
                     var isDisplayingCompiledJson = externalReference.IsRequestingCompiledJson;
-                    if (externalReference.ToArtifactReference().IsSuccess(out var artifactReference, out error))
+                    if (externalReference.ToArtifactReference().IsSuccess(out var artifactReference, out message))
                     {
-                        var sourceArchive = artifactReference is { } ? moduleDispatcher.TryGetModuleSources(artifactReference) : null;
+                        var sourceArchiveResult = moduleDispatcher.TryGetModuleSources(artifactReference);
 
                         if (isDisplayingCompiledJson)
                         {
-                            if (sourceArchive is { })
+                            // Displaying main.json
+
+                            if (sourceArchiveResult.SourceArchive is { })
                             {
                                 yield return CreateCodeLens(
                                     DocumentStart,
-                                    "Show Bicep source",
+                                    "Show Bicep source (experimental)",
                                     "bicep.internal.showModuleSourceFile",
-                                    new ExternalSourceReference(request.TextDocument.Uri).WithRequestForSourceFile(sourceArchive.EntrypointRelativePath).ToUri().ToString());
+                                    new ExternalSourceReference(request.TextDocument.Uri).WithRequestForSourceFile(sourceArchiveResult.SourceArchive.EntrypointRelativePath).ToUri().ToString());
+                            }
+                            else if (sourceArchiveResult.Message is { })
+                            {
+                                message = $"(Experimental) Cannot display source code for this module. {sourceArchiveResult.Message}";
                             }
                             else
                             {
-                                yield return CreateCodeLens(
-                                    DocumentStart,
-                                    "No source code is available for this module");
+                                message = "(Experimental) No source code is available for this module";
                             }
                         }
                         else
                         {
-                            if (sourceArchive is { })
+                            // Displaying a bicep file
+
+                            if (sourceArchiveResult.SourceArchive is { })
                             {
                                 // We're displaying some source file other than the compiled JSON for the module. Allow user to switch to the compiled JSON.
                                 yield return CreateCodeLens(
@@ -74,16 +80,17 @@ namespace Bicep.LanguageServer.Handlers
                             }
                             else
                             {
-                                // This can happen if the user has a source file open in the editor and then restores to a version of the module that doesn't have source code available.
-                                error = "Could not find the expected source archive in the module registry";
+                                message = sourceArchiveResult.Message ??
+                                    // This can happen if the user has a source file open in the editor and then restores to a version of the module that doesn't have source code available.
+                                    "Could not find the expected source archive in the module registry";
                             }
                         }
                     }
                 }
 
-                if (error is not null)
+                if (message is not null)
                 {
-                    yield return CreateErrorLens($"There was an error retrieving source code for this module: {error}");
+                    yield return CreateErrorLens(message);
                 }
             }
 

--- a/src/Bicep.LangServer/Handlers/ExternalSourceReference.cs
+++ b/src/Bicep.LangServer/Handlers/ExternalSourceReference.cs
@@ -77,12 +77,12 @@ namespace Bicep.LanguageServer.Handlers
             return new ExternalSourceReference(Components, requestedSourceFile); // recalculate title
         }
 
-        public ExternalSourceReference(OciArtifactReference moduleReference, SourceArchive? sourceArchive)
+        public ExternalSourceReference(OciArtifactReference moduleReference, SourceArchive? sourceArchive, bool defaultToDisplayingBicep = true)
         {
             Debug.Assert(moduleReference.Type == ArtifactType.Module && moduleReference.Scheme == OciArtifactReferenceFacts.Scheme, "Expecting a module reference, not a provider reference");
             Components = moduleReference.AddressComponents;
 
-            if (sourceArchive is { })
+            if (sourceArchive is { } && defaultToDisplayingBicep)
             {
                 // We have Bicep source code available
                 RequestedFile = sourceArchive.EntrypointRelativePath;

--- a/src/vscode-bicep/src/language/bicepExternalSourceContentProvider.ts
+++ b/src/vscode-bicep/src/language/bicepExternalSourceContentProvider.ts
@@ -48,7 +48,7 @@ export class BicepExternalSourceContentProvider
       token,
     );
 
-    return response.content;
+    return response.error ? `// ${response.error}` : response.content ?? "";
   }
 
   private bicepExternalSourceRequest(

--- a/src/vscode-bicep/src/language/protocol.ts
+++ b/src/vscode-bicep/src/language/protocol.ts
@@ -148,7 +148,8 @@ export interface BicepExternalSourceParams {
 }
 
 export interface BicepExternalSourceResponse {
-  content: string;
+  content: string | undefined;
+  error: string | undefined;
 }
 
 export const bicepExternalSourceRequestType = new ProtocolRequestType<


### PR DESCRIPTION
CHANGES:

1) Error handling if the __metadata.json file format in a source code archive is incompatible with the current Bicep version
2) When pressing F12 on a module, for now show the main.json first instead of the Bicep, until we remove the experimental publish source flag.   This makes it clear that if they click the "Show Bicep sources (experimental)" button they're hitting experimental territory.
3) UnpackFromStream now returns a ResultWithException<SourceArchive> instead of SourceArchive

<img width="542" alt="image" src="https://github.com/Azure/bicep/assets/6913354/070d024a-7aec-4c3b-abdf-eaafa97c2724">


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12814)