### PR TITLE
MAINT: Fix test stability of `ModuleRestoreContentionShouldProduceConsistentState` by making its execution serial vs parallel

### DIFF
--- a/src/Bicep.Core.IntegrationTests/RegistryTests.cs
+++ b/src/Bicep.Core.IntegrationTests/RegistryTests.cs
@@ -160,6 +160,7 @@ namespace Bicep.Core.IntegrationTests
         [DataTestMethod]
         [DataRow(false)]
         [DataRow(true)]
+        [DoNotParallelize()]
         public async Task ModuleRestoreContentionShouldProduceConsistentState(bool publishSource)
         {
             var dataSet = DataSets.Registry_LF;


### PR DESCRIPTION
## Overview

`ModuleRestoreContentionShouldProduceConsistentState` seems to be failing in various PRs as a result of a failure in the restore operation. I tried running this locally and it passes, likely since the runner is parallelizing test execution its susceptible to [noisy neighbor](https://learn.microsoft.com/en-us/azure/architecture/antipatterns/noisy-neighbor/noisy-neighbor) performance issues between tests competing for resources. I think that having serial execution of the test will suffice to ensure its able to behave in a stable way.   
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12854)