### PR TITLE
Use languageVersion 2.0 if types or functions are imported via wildcard

### DIFF
--- a/src/Bicep.Core.IntegrationTests/CompileTimeImportTests.cs
+++ b/src/Bicep.Core.IntegrationTests/CompileTimeImportTests.cs
@@ -1934,4 +1934,22 @@ public class CompileTimeImportTests
         var evaluated = TemplateEvaluator.Evaluate(result.Template);
         evaluated.Should().HaveValueAtPath("outputs.out.value", "ASP999");
     }
+
+    // https://github.com/Azure/bicep/issues/12897
+    [TestMethod]
+    public void LanguageVersion_2_should_be_used_if_types_imported_via_wildcard()
+    {
+        var result = CompilationHelper.Compile(ServicesWithCompileTimeTypeImportsAndUserDefinedFunctions,
+            ("main.bicep", """
+                import * as types from 'types.bicep'
+                """),
+            ("types.bicep", """
+                @export()
+                type str = string
+                """));
+
+        result.Diagnostics.Should().BeEmpty();
+        result.Template.Should().NotBeNull();
+        result.Template.Should().HaveValueAtPath("languageVersion", "2.0");
+    }
 }

--- a/src/Bicep.Core/Emit/EmitterSettings.cs
+++ b/src/Bicep.Core/Emit/EmitterSettings.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using System.Linq;
 using Bicep.Core.Semantics;
+using Bicep.Core.Semantics.Metadata;
 using Bicep.Core.Syntax;
 using Bicep.Core.Syntax.Visitors;
 using Bicep.Core.Workspaces;
@@ -27,6 +28,9 @@ namespace Bicep.Core.Emit
                 model.Root.ImportedTypes.Any() ||
                 // there are any functions imported (it's impossible to tell here if the functions use user-defined types for their parameter or output declarations)
                 model.Root.ImportedFunctions.Any() ||
+                // there are any wildcard imports that include user-defined types or functions
+                model.Root.WildcardImports.Any(w => w.SourceModel.Exports.Values.Any(
+                    e => e.Kind == ExportMetadataKind.Type || e.Kind == ExportMetadataKind.Function)) ||
                 // any user-defined type declaration syntax is used (e.g., in a `param` or `output` statement)
                 SyntaxAggregator.Aggregate(model.SourceFile.ProgramSyntax,
                     seed: false,


### PR DESCRIPTION
Resolves #12897 

Bicep should be targeting languageVersion 2.0 if any types or functions are imported, but the current check will miss cases where those imports are performed using a wildcard (`import * as foo...`) instead of by name (`import {foo, bar} from ...`). The check looks at a model's symbol table, and wildcard imports create a different kind of symbol.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12898)