### PR TITLE
Use languageVersion 2.0 when any compile-time imports are present

### DIFF
--- a/src/Bicep.Core.IntegrationTests/CompileTimeImportTests.cs
+++ b/src/Bicep.Core.IntegrationTests/CompileTimeImportTests.cs
@@ -1583,7 +1583,7 @@ public class CompileTimeImportTests
     }
 
     [TestMethod]
-    public void Importing_variables_only_does_not_result_in_elevated_ARM_language_version()
+    public void Importing_variable_results_in_ARM_language_version_2()
     {
         var result = CompilationHelper.Compile(ServicesWithCompileTimeTypeImports,
             ("main.bicep", """
@@ -1598,7 +1598,7 @@ public class CompileTimeImportTests
                 """));
 
         result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
-        result.Template.Should().NotHaveValueAtPath("languageVersion");
+        result.Template.Should().HaveValueAtPath("languageVersion", "2.0");
     }
 
     [TestMethod]

--- a/src/Bicep.Core.IntegrationTests/CompileTimeImportTests.cs
+++ b/src/Bicep.Core.IntegrationTests/CompileTimeImportTests.cs
@@ -1952,4 +1952,24 @@ public class CompileTimeImportTests
         result.Template.Should().NotBeNull();
         result.Template.Should().HaveValueAtPath("languageVersion", "2.0");
     }
+
+    // https://github.com/Azure/bicep/issues/12899
+    [TestMethod]
+    public void LanguageVersion_2_should_be_used_if_types_imported_via_closure()
+    {
+        var result = CompilationHelper.Compile(ServicesWithCompileTimeTypeImportsAndUserDefinedFunctions,
+            ("main.bicep", """
+                import {a} from 'shared.bicep'
+                """),
+            ("shared.bicep", """
+                @export()
+                var a = b()
+
+                func b() string[] => ['c', 'd']
+                """));
+
+        result.Diagnostics.Should().BeEmpty();
+        result.Template.Should().NotBeNull();
+        result.Template.Should().HaveValueAtPath("languageVersion", "2.0");
+    }
 }

--- a/src/Bicep.Core/Emit/EmitterSettings.cs
+++ b/src/Bicep.Core/Emit/EmitterSettings.cs
@@ -24,13 +24,10 @@ namespace Bicep.Core.Emit
                 model.Features.SymbolicNameCodegenEnabled ||
                 // there are any user-defined type declarations
                 model.Root.TypeDeclarations.Any() ||
-                // there are any user-defined types imported
-                model.Root.ImportedTypes.Any() ||
-                // there are any functions imported (it's impossible to tell here if the functions use user-defined types for their parameter or output declarations)
-                model.Root.ImportedFunctions.Any() ||
-                // there are any wildcard imports that include user-defined types or functions
-                model.Root.WildcardImports.Any(w => w.SourceModel.Exports.Values.Any(
-                    e => e.Kind == ExportMetadataKind.Type || e.Kind == ExportMetadataKind.Function)) ||
+                // there are any compile-time imports (imported functions or variables may enclose user-defined types, and determining definitively requires calculating the full import closure)
+                model.Root.ImportedSymbols.Any() ||
+                // there are any wildcard compile-time imports
+                model.Root.WildcardImports.Any() ||
                 // any user-defined type declaration syntax is used (e.g., in a `param` or `output` statement)
                 SyntaxAggregator.Aggregate(model.SourceFile.ProgramSyntax,
                     seed: false,


### PR DESCRIPTION
Resolves #12899

#12899 highlighted a way in which an imported variable could enclose a user-defined type (and thus necessitate languageVersion 2.0). Since any imported value _might_ require the elevated language version, this PR updates EmitterSettings to use lv 2.0 if any compile-time imports are used.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12902)