### PR TITLE
use-resource-symbol-reference linter rule: detect .name access as well as .id

### DIFF
--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseResourceSymbolReferenceRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseResourceSymbolReferenceRuleTests.cs
@@ -31,6 +31,21 @@ var blah = stg.listKeys().keys
 ");
 
     [TestMethod]
+    public void Codefix_handles_list_functions_with_reference_based_name_and_apiversion() => AssertCodeFix(@"
+resource stg 'Microsoft.Storage/storageAccounts@2022-09-01' existing = {
+  name: 'stgName'
+}
+
+var blah = listKe|ys(stg.name, stg.apiVersion).keys
+", @"
+resource stg 'Microsoft.Storage/storageAccounts@2022-09-01' existing = {
+  name: 'stgName'
+}
+
+var blah = stg.listKeys().keys
+");
+
+    [TestMethod]
     public void Codefix_handles_list_functions_with_reference_based_id_and_apiversion_and_optional_args() => AssertCodeFix(@"
 resource stg 'Microsoft.Storage/storageAccounts@2022-09-01' existing = {
   name: 'stgName'

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseResourceSymbolReferenceRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseResourceSymbolReferenceRule.cs
@@ -60,7 +60,7 @@ public sealed class UseResourceSymbolReferenceRule : LinterRuleBase
     private IEnumerable<DeclaredResourceMetadata> AnalyzeResourceId(SemanticModel model, SyntaxBase syntax)
     {
         if (syntax is PropertyAccessSyntax idProp &&
-            idProp.PropertyName.NameEquals("id") &&
+            (idProp.PropertyName.NameEquals("id") || idProp.PropertyName.NameEquals("name")) &&
             model.ResourceMetadata.TryLookup(idProp.BaseExpression) is DeclaredResourceMetadata idResource)
         {
             yield return idResource;


### PR DESCRIPTION

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12917)