### PR TITLE
Reduce number of concurrent threads for module restore test

### DIFF
--- a/src/Bicep.Core.IntegrationTests/RegistryTests.cs
+++ b/src/Bicep.Core.IntegrationTests/RegistryTests.cs
@@ -194,7 +194,7 @@ namespace Bicep.Core.IntegrationTests
                 dispatcher.GetArtifactRestoreStatus(moduleReference, out _).Should().Be(ArtifactRestoreStatus.Unknown);
             }
 
-            const int ConcurrentTasks = 25;
+            const int ConcurrentTasks = 10;
             var tasks = new List<Task<bool>>();
             for (int i = 0; i < ConcurrentTasks; i++)
             {


### PR DESCRIPTION
ModuleRestoreContentionShouldProduceConsistentState is failing frequently, presumably because of file system contention. This PR reduces the amount of concurrency to reduce contention.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12966)