### PR TITLE
MAINT: Reduce indentation to enhance readability

### DIFF
--- a/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
@@ -33,102 +33,102 @@ namespace Bicep.Core.UnitTests.Configuration
 
       // Assert.
       configuration.Should().HaveContents(/*lang=json,strict*/ """
-                {
-                  "cloud": {
-                    "currentProfile": "AzureCloud",
-                    "profiles": {
-                      "AzureChinaCloud": {
-                        "resourceManagerEndpoint": "https://management.chinacloudapi.cn",
-                        "activeDirectoryAuthority": "https://login.chinacloudapi.cn"
-                      },
-                      "AzureCloud": {
-                        "resourceManagerEndpoint": "https://management.azure.com",
-                        "activeDirectoryAuthority": "https://login.microsoftonline.com"
-                      },
-                      "AzureUSGovernment": {
-                        "resourceManagerEndpoint": "https://management.usgovcloudapi.net",
-                        "activeDirectoryAuthority": "https://login.microsoftonline.us"
-                      }
-                    },
-                    "credentialPrecedence": [
-                      "AzureCLI",
-                      "AzurePowerShell"
-                    ]
-                  },
-                  "moduleAliases": {
-                    "ts": {},
-                    "br": {
-                      "public": {
-                        "registry": "mcr.microsoft.com",
-                        "modulePath": "bicep"
-                      }
-                    }
-                  },
-                  "providerAliases": {
-                    "br": {
-                      "public": {
-                        "registry": "mcr.microsoft.com",
-                        "providerPath": "bicep/providers"
-                      }
-                    }
-                  },
-                  "analyzers": {
-                    "core": {
-                      "verbose": false,
-                      "enabled": true,
-                      "rules": {
-                        "no-hardcoded-env-urls": {
-                          "level": "warning",
-                          "disallowedhosts": [
-                            "api.loganalytics.io",
-                            "azuredatalakeanalytics.net",
-                            "azuredatalakestore.net",
-                            "batch.core.windows.net",
-                            "core.windows.net",
-                            "database.windows.net",
-                            "datalake.azure.net",
-                            "gallery.azure.com",
-                            "graph.windows.net",
-                            "login.microsoftonline.com",
-                            "management.azure.com",
-                            "management.core.windows.net",
-                            "region.asazure.windows.net",
-                            "trafficmanager.net",
-                            "vault.azure.net"
-                          ],
-                          "excludedhosts": [
-                            "schema.management.azure.com"
-                          ]
-                        }
-                      }
-                    }
-                  },
-                  "experimentalFeaturesEnabled": {
-                    "symbolicNameCodegen": false,
-                    "extensibility": false,
-                    "resourceTypedParamsAndOutputs": false,
-                    "sourceMapping": false,
-                    "userDefinedFunctions": false,
-                    "prettyPrinting": false,
-                    "testFramework": false,
-                    "assertions": false,
-                    "dynamicTypeLoading": false,
-                    "providerRegistry": false,
-                    "microsoftGraphPreview": false,
-                    "compileTimeImports": false,
-                    "publishSource": false,
-                    "optionalModuleNames": false,
-                    "resourceDerivedTypes": false
-                  },
-                  "formatting": {
-                    "indentKind": "Space",
-                    "newlineKind": "LF",
-                    "insertFinalNewline": true,
-                    "indentSize": 2,
-                    "width": 80
-                  }
-                }
-                """);
+      {
+        "cloud": {
+          "currentProfile": "AzureCloud",
+          "profiles": {
+            "AzureChinaCloud": {
+              "resourceManagerEndpoint": "https://management.chinacloudapi.cn",
+              "activeDirectoryAuthority": "https://login.chinacloudapi.cn"
+            },
+            "AzureCloud": {
+              "resourceManagerEndpoint": "https://management.azure.com",
+              "activeDirectoryAuthority": "https://login.microsoftonline.com"
+            },
+            "AzureUSGovernment": {
+              "resourceManagerEndpoint": "https://management.usgovcloudapi.net",
+              "activeDirectoryAuthority": "https://login.microsoftonline.us"
+            }
+          },
+          "credentialPrecedence": [
+            "AzureCLI",
+            "AzurePowerShell"
+          ]
+        },
+        "moduleAliases": {
+          "ts": {},
+          "br": {
+            "public": {
+              "registry": "mcr.microsoft.com",
+              "modulePath": "bicep"
+            }
+          }
+        },
+        "providerAliases": {
+          "br": {
+            "public": {
+              "registry": "mcr.microsoft.com",
+              "providerPath": "bicep/providers"
+            }
+          }
+        },
+        "analyzers": {
+          "core": {
+            "verbose": false,
+            "enabled": true,
+            "rules": {
+              "no-hardcoded-env-urls": {
+                "level": "warning",
+                "disallowedhosts": [
+                  "api.loganalytics.io",
+                  "azuredatalakeanalytics.net",
+                  "azuredatalakestore.net",
+                  "batch.core.windows.net",
+                  "core.windows.net",
+                  "database.windows.net",
+                  "datalake.azure.net",
+                  "gallery.azure.com",
+                  "graph.windows.net",
+                  "login.microsoftonline.com",
+                  "management.azure.com",
+                  "management.core.windows.net",
+                  "region.asazure.windows.net",
+                  "trafficmanager.net",
+                  "vault.azure.net"
+                ],
+                "excludedhosts": [
+                  "schema.management.azure.com"
+                ]
+              }
+            }
+          }
+        },
+        "experimentalFeaturesEnabled": {
+          "symbolicNameCodegen": false,
+          "extensibility": false,
+          "resourceTypedParamsAndOutputs": false,
+          "sourceMapping": false,
+          "userDefinedFunctions": false,
+          "prettyPrinting": false,
+          "testFramework": false,
+          "assertions": false,
+          "dynamicTypeLoading": false,
+          "providerRegistry": false,
+          "microsoftGraphPreview": false,
+          "compileTimeImports": false,
+          "publishSource": false,
+          "optionalModuleNames": false,
+          "resourceDerivedTypes": false
+        },
+        "formatting": {
+          "indentKind": "Space",
+          "newlineKind": "LF",
+          "insertFinalNewline": true,
+          "indentSize": 2,
+          "width": 80
+        }
+      }
+      """);
     }
 
     [TestMethod]
@@ -147,72 +147,72 @@ namespace Bicep.Core.UnitTests.Configuration
 
       // Assert.
       configuration.Should().HaveContents(/*lang=json,strict*/ """
-                {
-                  "cloud": {
-                    "currentProfile": "AzureCloud",
-                    "profiles": {
-                      "AzureChinaCloud": {
-                        "resourceManagerEndpoint": "https://management.chinacloudapi.cn",
-                        "activeDirectoryAuthority": "https://login.chinacloudapi.cn"
-                      },
-                      "AzureCloud": {
-                        "resourceManagerEndpoint": "https://management.azure.com",
-                        "activeDirectoryAuthority": "https://login.microsoftonline.com"
-                      },
-                      "AzureUSGovernment": {
-                        "resourceManagerEndpoint": "https://management.usgovcloudapi.net",
-                        "activeDirectoryAuthority": "https://login.microsoftonline.us"
-                      }
-                    },
-                    "credentialPrecedence": [
-                      "AzureCLI",
-                      "AzurePowerShell"
-                    ]
-                  },
-                  "moduleAliases": {
-                    "ts": {},
-                    "br": {
-                      "public": {
-                        "registry": "mcr.microsoft.com",
-                        "modulePath": "bicep"
-                      }
-                    }
-                  },
-                  "providerAliases": {
-                    "br": {
-                      "public": {
-                        "registry": "mcr.microsoft.com",
-                        "providerPath": "bicep/providers"
-                      }
-                    }
-                  },
-                  "analyzers": {},
-                  "experimentalFeaturesEnabled": {
-                    "symbolicNameCodegen": false,
-                    "extensibility": false,
-                    "resourceTypedParamsAndOutputs": false,
-                    "sourceMapping": false,
-                    "userDefinedFunctions": false,
-                    "prettyPrinting": false,
-                    "testFramework": false,
-                    "assertions": false,
-                    "dynamicTypeLoading": false,
-                    "providerRegistry": false,
-                    "microsoftGraphPreview": false,
-                    "compileTimeImports": false,
-                    "publishSource": false,
-                    "optionalModuleNames": false,
-                    "resourceDerivedTypes": false
-                  },
-                  "formatting": {
-                    "indentKind": "Space",
-                    "newlineKind": "LF",
-                    "insertFinalNewline": true,
-                    "indentSize": 2,
-                    "width": 80
-                  }
-                }
-                """);
+      {
+        "cloud": {
+          "currentProfile": "AzureCloud",
+          "profiles": {
+            "AzureChinaCloud": {
+              "resourceManagerEndpoint": "https://management.chinacloudapi.cn",
+              "activeDirectoryAuthority": "https://login.chinacloudapi.cn"
+            },
+            "AzureCloud": {
+              "resourceManagerEndpoint": "https://management.azure.com",
+              "activeDirectoryAuthority": "https://login.microsoftonline.com"
+            },
+            "AzureUSGovernment": {
+              "resourceManagerEndpoint": "https://management.usgovcloudapi.net",
+              "activeDirectoryAuthority": "https://login.microsoftonline.us"
+            }
+          },
+          "credentialPrecedence": [
+            "AzureCLI",
+            "AzurePowerShell"
+          ]
+        },
+        "moduleAliases": {
+          "ts": {},
+          "br": {
+            "public": {
+              "registry": "mcr.microsoft.com",
+              "modulePath": "bicep"
+            }
+          }
+        },
+        "providerAliases": {
+          "br": {
+            "public": {
+              "registry": "mcr.microsoft.com",
+              "providerPath": "bicep/providers"
+            }
+          }
+        },
+        "analyzers": {},
+        "experimentalFeaturesEnabled": {
+          "symbolicNameCodegen": false,
+          "extensibility": false,
+          "resourceTypedParamsAndOutputs": false,
+          "sourceMapping": false,
+          "userDefinedFunctions": false,
+          "prettyPrinting": false,
+          "testFramework": false,
+          "assertions": false,
+          "dynamicTypeLoading": false,
+          "providerRegistry": false,
+          "microsoftGraphPreview": false,
+          "compileTimeImports": false,
+          "publishSource": false,
+          "optionalModuleNames": false,
+          "resourceDerivedTypes": false
+        },
+        "formatting": {
+          "indentKind": "Space",
+          "newlineKind": "LF",
+          "insertFinalNewline": true,
+          "indentSize": 2,
+          "width": 80
+        }
+      }
+      """);
     }
 
     [TestMethod]
@@ -223,105 +223,105 @@ namespace Bicep.Core.UnitTests.Configuration
 
       // Assert.
       configuration.Should().HaveContents(/*lang=json,strict*/ """
-                {
-                  "cloud": {
-                    "currentProfile": "AzureCloud",
-                    "profiles": {
-                      "AzureChinaCloud": {
-                        "resourceManagerEndpoint": "https://management.chinacloudapi.cn",
-                        "activeDirectoryAuthority": "https://login.chinacloudapi.cn"
-                      },
-                      "AzureCloud": {
-                        "resourceManagerEndpoint": "https://management.azure.com",
-                        "activeDirectoryAuthority": "https://login.microsoftonline.com"
-                      },
-                      "AzureUSGovernment": {
-                        "resourceManagerEndpoint": "https://management.usgovcloudapi.net",
-                        "activeDirectoryAuthority": "https://login.microsoftonline.us"
-                      }
-                    },
-                    "credentialPrecedence": [
-                      "AzureCLI",
-                      "AzurePowerShell"
-                    ]
-                  },
-                  "moduleAliases": {
-                    "ts": {},
-                    "br": {
-                      "public": {
-                        "registry": "mcr.microsoft.com",
-                        "modulePath": "bicep"
-                      }
-                    }
-                  },
-                  "providerAliases": {
-                    "br": {
-                      "public": {
-                        "registry": "mcr.microsoft.com",
-                        "providerPath": "bicep/providers"
-                      }
-                    }
-                  },
-                  "analyzers": {
-                    "core": {
-                      "verbose": false,
-                      "enabled": true,
-                      "rules": {
-                        "no-hardcoded-env-urls": {
-                          "level": "off",
-                          "disallowedhosts": [
-                            "api.loganalytics.io",
-                            "azuredatalakeanalytics.net",
-                            "azuredatalakestore.net",
-                            "batch.core.windows.net",
-                            "core.windows.net",
-                            "database.windows.net",
-                            "datalake.azure.net",
-                            "gallery.azure.com",
-                            "graph.windows.net",
-                            "login.microsoftonline.com",
-                            "management.azure.com",
-                            "management.core.windows.net",
-                            "region.asazure.windows.net",
-                            "trafficmanager.net",
-                            "vault.azure.net"
-                          ],
-                          "excludedhosts": [
-                            "schema.management.azure.com"
-                          ]
-                        },
-                        "no-unused-vars": {
-                          "level": "off"
-                        }
-                      }
-                    }
-                  },
-                  "experimentalFeaturesEnabled": {
-                    "symbolicNameCodegen": false,
-                    "extensibility": false,
-                    "resourceTypedParamsAndOutputs": false,
-                    "sourceMapping": false,
-                    "userDefinedFunctions": false,
-                    "prettyPrinting": false,
-                    "testFramework": false,
-                    "assertions": false,
-                    "dynamicTypeLoading": false,
-                    "providerRegistry": false,
-                    "microsoftGraphPreview": false,
-                    "compileTimeImports": false,
-                    "publishSource": false,
-                    "optionalModuleNames": false,
-                    "resourceDerivedTypes": false
-                  },
-                  "formatting": {
-                    "indentKind": "Space",
-                    "newlineKind": "LF",
-                    "insertFinalNewline": true,
-                    "indentSize": 2,
-                    "width": 80
-                  }
-                }
-                """);
+      {
+        "cloud": {
+          "currentProfile": "AzureCloud",
+          "profiles": {
+            "AzureChinaCloud": {
+              "resourceManagerEndpoint": "https://management.chinacloudapi.cn",
+              "activeDirectoryAuthority": "https://login.chinacloudapi.cn"
+            },
+            "AzureCloud": {
+              "resourceManagerEndpoint": "https://management.azure.com",
+              "activeDirectoryAuthority": "https://login.microsoftonline.com"
+            },
+            "AzureUSGovernment": {
+              "resourceManagerEndpoint": "https://management.usgovcloudapi.net",
+              "activeDirectoryAuthority": "https://login.microsoftonline.us"
+            }
+          },
+          "credentialPrecedence": [
+            "AzureCLI",
+            "AzurePowerShell"
+          ]
+        },
+        "moduleAliases": {
+          "ts": {},
+          "br": {
+            "public": {
+              "registry": "mcr.microsoft.com",
+              "modulePath": "bicep"
+            }
+          }
+        },
+        "providerAliases": {
+          "br": {
+            "public": {
+              "registry": "mcr.microsoft.com",
+              "providerPath": "bicep/providers"
+            }
+          }
+        },
+        "analyzers": {
+          "core": {
+            "verbose": false,
+            "enabled": true,
+            "rules": {
+              "no-hardcoded-env-urls": {
+                "level": "off",
+                "disallowedhosts": [
+                  "api.loganalytics.io",
+                  "azuredatalakeanalytics.net",
+                  "azuredatalakestore.net",
+                  "batch.core.windows.net",
+                  "core.windows.net",
+                  "database.windows.net",
+                  "datalake.azure.net",
+                  "gallery.azure.com",
+                  "graph.windows.net",
+                  "login.microsoftonline.com",
+                  "management.azure.com",
+                  "management.core.windows.net",
+                  "region.asazure.windows.net",
+                  "trafficmanager.net",
+                  "vault.azure.net"
+                ],
+                "excludedhosts": [
+                  "schema.management.azure.com"
+                ]
+              },
+              "no-unused-vars": {
+                "level": "off"
+              }
+            }
+          }
+        },
+        "experimentalFeaturesEnabled": {
+          "symbolicNameCodegen": false,
+          "extensibility": false,
+          "resourceTypedParamsAndOutputs": false,
+          "sourceMapping": false,
+          "userDefinedFunctions": false,
+          "prettyPrinting": false,
+          "testFramework": false,
+          "assertions": false,
+          "dynamicTypeLoading": false,
+          "providerRegistry": false,
+          "microsoftGraphPreview": false,
+          "compileTimeImports": false,
+          "publishSource": false,
+          "optionalModuleNames": false,
+          "resourceDerivedTypes": false
+        },
+        "formatting": {
+          "indentKind": "Space",
+          "newlineKind": "LF",
+          "insertFinalNewline": true,
+          "indentSize": 2,
+          "width": 80
+        }
+      }
+      """);
     }
 
     [TestMethod]
@@ -410,60 +410,60 @@ namespace Bicep.Core.UnitTests.Configuration
 
     [DataTestMethod]
     [DataRow("""
-            {
-              "cloud": {
-                "currentProfile": "MyCloud"
-              }
-            }
-            """, @"The cloud profile ""MyCloud"" does not exist. Available profiles include ""AzureChinaCloud"", ""AzureCloud"", ""AzureUSGovernment"".")]
+    {
+      "cloud": {
+        "currentProfile": "MyCloud"
+      }
+    }
+    """, @"The cloud profile ""MyCloud"" does not exist. Available profiles include ""AzureChinaCloud"", ""AzureCloud"", ""AzureUSGovernment"".")]
     [DataRow("""
-            {
-              "cloud": {
-                "currentProfile": "MyCloud",
-                "profiles": {
-                  "MyCloud": {
-                  }
-                }
-              }
-            }
-            """, @"The cloud profile ""MyCloud"" is invalid. The ""resourceManagerEndpoint"" property cannot be null or undefined.")]
+    {
+      "cloud": {
+        "currentProfile": "MyCloud",
+        "profiles": {
+          "MyCloud": {
+          }
+        }
+      }
+    }
+    """, @"The cloud profile ""MyCloud"" is invalid. The ""resourceManagerEndpoint"" property cannot be null or undefined.")]
     [DataRow("""
-            {
-              "cloud": {
-                "currentProfile": "MyCloud",
-                "profiles": {
-                  "MyCloud": {
-                    "resourceManagerEndpoint": "Not and URL"
-                  }
-                }
-              }
-            }
-            """, @"The cloud profile ""MyCloud"" is invalid. The value of the ""resourceManagerEndpoint"" property ""Not and URL"" is not a valid URL.")]
+    {
+      "cloud": {
+        "currentProfile": "MyCloud",
+        "profiles": {
+          "MyCloud": {
+            "resourceManagerEndpoint": "Not and URL"
+          }
+        }
+      }
+    }
+    """, @"The cloud profile ""MyCloud"" is invalid. The value of the ""resourceManagerEndpoint"" property ""Not and URL"" is not a valid URL.")]
     [DataRow("""
-            {
-              "cloud": {
-                "currentProfile": "MyCloud",
-                "profiles": {
-                  "MyCloud": {
-                    "resourceManagerEndpoint": "https://example.invalid"
-                  }
-                }
-              }
-            }
-            """, @"The cloud profile ""MyCloud"" is invalid. The ""activeDirectoryAuthority"" property cannot be null or undefined.")]
+    {
+      "cloud": {
+        "currentProfile": "MyCloud",
+        "profiles": {
+          "MyCloud": {
+            "resourceManagerEndpoint": "https://example.invalid"
+          }
+        }
+      }
+    }
+    """, @"The cloud profile ""MyCloud"" is invalid. The ""activeDirectoryAuthority"" property cannot be null or undefined.")]
     [DataRow("""
-            {
-              "cloud": {
-                "currentProfile": "MyCloud",
-                "profiles": {
-                  "MyCloud": {
-                    "resourceManagerEndpoint": "https://example.invalid",
-                    "activeDirectoryAuthority": "Not an URL"
-                  }
-                }
-              }
-            }
-            """, @"The cloud profile ""MyCloud"" is invalid. The value of the ""activeDirectoryAuthority"" property ""Not an URL"" is not a valid URL.")]
+    {
+      "cloud": {
+        "currentProfile": "MyCloud",
+        "profiles": {
+          "MyCloud": {
+            "resourceManagerEndpoint": "https://example.invalid",
+            "activeDirectoryAuthority": "Not an URL"
+          }
+        }
+      }
+    }
+    """, @"The cloud profile ""MyCloud"" is invalid. The value of the ""activeDirectoryAuthority"" property ""Not an URL"" is not a valid URL.")]
     public void GetConfiguration_InvalidCurrentCloudProfile_PropagatesConfigurationDiagnostic(string configurationContents, string expectedExceptionMessage)
     {
       // Arrange.
@@ -485,53 +485,53 @@ namespace Bicep.Core.UnitTests.Configuration
 
     [TestMethod]
     [DataRow("""
-            {
-              "cloud": {
-                "credentialOptions": {
-                    "managedIdentity": {
-                        "type": "UserAssigned"
-                    }
-                }
-              }
+    {
+      "cloud": {
+        "credentialOptions": {
+            "managedIdentity": {
+                "type": "UserAssigned"
             }
-            """, @"The managed-identity configuration is invalid. Either ""clientId"" or ""resourceId"" must be set for user-assigned identity.")]
+        }
+      }
+    }
+    """, @"The managed-identity configuration is invalid. Either ""clientId"" or ""resourceId"" must be set for user-assigned identity.")]
     [DataRow("""
-            {
-              "cloud": {
-                "credentialOptions": {
-                    "managedIdentity": {
-                        "type": "UserAssigned",
-                        "clientId": "foo",
-                        "resourceId": "bar"
-                    }
-                }
-              }
+    {
+      "cloud": {
+        "credentialOptions": {
+            "managedIdentity": {
+                "type": "UserAssigned",
+                "clientId": "foo",
+                "resourceId": "bar"
             }
-            """, @"The managed-identity configuration is invalid. ""clientId"" and ""resourceId"" cannot be set at the same time for user-assigned identity.")]
+        }
+      }
+    }
+    """, @"The managed-identity configuration is invalid. ""clientId"" and ""resourceId"" cannot be set at the same time for user-assigned identity.")]
     [DataRow("""
-            {
-              "cloud": {
-                "credentialOptions": {
-                    "managedIdentity": {
-                        "type": "UserAssigned",
-                        "clientId": "foo"
-                    }
-                }
-              }
+    {
+      "cloud": {
+        "credentialOptions": {
+            "managedIdentity": {
+                "type": "UserAssigned",
+                "clientId": "foo"
             }
-            """, @"The managed-identity configuration is invalid. ""clientId"" must be a GUID.")]
+        }
+      }
+    }
+    """, @"The managed-identity configuration is invalid. ""clientId"" must be a GUID.")]
     [DataRow("""
-            {
-              "cloud": {
-                "credentialOptions": {
-                    "managedIdentity": {
-                        "type": "UserAssigned",
-                        "resourceId": "bar"
-                    }
-                }
-              }
+    {
+      "cloud": {
+        "credentialOptions": {
+            "managedIdentity": {
+                "type": "UserAssigned",
+                "resourceId": "bar"
             }
-            """, @"The managed-identity configuration is invalid. ""resourceId"" must be a valid Azure resource identifier.")]
+        }
+      }
+    }
+    """, @"The managed-identity configuration is invalid. ""resourceId"" must be a valid Azure resource identifier.")]
     public void GetConfiguration_InvalidUserAssignedIdentityOptions_PropagatesConfigurationDiagnostic(string configurationContents, string expectedExceptionMessage)
     {
       // Arrange.
@@ -562,83 +562,83 @@ namespace Bicep.Core.UnitTests.Configuration
         [CreatePath("repo")] = new MockDirectoryData(),
         [CreatePath("repo/modules")] = new MockDirectoryData(),
         [CreatePath("repo/bicepconfig.json")] = /*lang=json,strict*/ """
-                {
-                  "cloud": {
-                    "currentProfile": "MyCloud",
-                    "profiles": {
-                      "MyCloud": {
-                        "resourceManagerEndpoint": "https://bicep.example.com",
-                        "activeDirectoryAuthority": "https://login.bicep.example.com"
-                      }
-                    },
-                    "credentialPrecedence": [
-                        "AzurePowerShell",
-                        "VisualStudioCode"
-                    ],
-                    "credentialOptions": {
-                      "managedIdentity": {
-                        "type": "UserAssigned",
-                        "clientId": "00000000-0000-0000-0000-000000000000"
-                      }
-                    }
-                  },
-                  "moduleAliases": {
-                    "ts": {
-                      "mySpecPath": {
-                        "subscription": "B34C8680-F688-48C2-A44F-E1EFF5E01173"
-                      }
-                    },
-                    "br": {
-                      "myRegistry": {
-                        "registry": "localhost:8000"
-                      },
-                      "myModulePath": {
-                        "registry": "test.invalid",
-                        "modulePath": "root/modules"
-                      }
-                    }
-                  },
-                  "providerAliases": {
-                    "br": {
-                      "public": {
-                        "registry": "mcr.microsoft.com",
-                        "providerPath": "bicep/providers"
-                      }
-                    }
-                  },
-                  "analyzers": {
-                    "core": {
-                      "enabled": false,
-                      "rules": {
-                        "no-hardcoded-env-urls": {
-                          "level": "warning",
-                          "disallowedhosts": [
-                            "datalake.azure.net",
-                            "azuredatalakestore.net",
-                            "azuredatalakeanalytics.net",
-                            "vault.azure.net",
-                            "api.loganalytics.io",
-                            "asazure.windows.net",
-                            "region.asazure.windows.net",
-                            "batch.core.windows.net"
-                          ]
-                        }
-                      }
-                    }
-                  },
-                  "cacheRootDirectory": "/home/username/.bicep/cache",
-                  "experimentalFeaturesEnabled": {
-                    "extensibility": true
-                  },
-                  "formatting": {
-                    "indentKind": "Space",
-                    "newlineKind": "LF",
-                    "insertFinalNewline": true,
-                    "indentSize": 2,
-                    "width": 80
-                  }
+        {
+          "cloud": {
+            "currentProfile": "MyCloud",
+            "profiles": {
+              "MyCloud": {
+                "resourceManagerEndpoint": "https://bicep.example.com",
+                "activeDirectoryAuthority": "https://login.bicep.example.com"
+              }
+            },
+            "credentialPrecedence": [
+                "AzurePowerShell",
+                "VisualStudioCode"
+            ],
+            "credentialOptions": {
+              "managedIdentity": {
+                "type": "UserAssigned",
+                "clientId": "00000000-0000-0000-0000-000000000000"
+              }
+            }
+          },
+          "moduleAliases": {
+            "ts": {
+              "mySpecPath": {
+                "subscription": "B34C8680-F688-48C2-A44F-E1EFF5E01173"
+              }
+            },
+            "br": {
+              "myRegistry": {
+                "registry": "localhost:8000"
+              },
+              "myModulePath": {
+                "registry": "test.invalid",
+                "modulePath": "root/modules"
+              }
+            }
+          },
+          "providerAliases": {
+            "br": {
+              "public": {
+                "registry": "mcr.microsoft.com",
+                "providerPath": "bicep/providers"
+              }
+            }
+          },
+          "analyzers": {
+            "core": {
+              "enabled": false,
+              "rules": {
+                "no-hardcoded-env-urls": {
+                  "level": "warning",
+                  "disallowedhosts": [
+                    "datalake.azure.net",
+                    "azuredatalakestore.net",
+                    "azuredatalakeanalytics.net",
+                    "vault.azure.net",
+                    "api.loganalytics.io",
+                    "asazure.windows.net",
+                    "region.asazure.windows.net",
+                    "batch.core.windows.net"
+                  ]
                 }
-                """
+              }
+            }
+          },
+          "cacheRootDirectory": "/home/username/.bicep/cache",
+          "experimentalFeaturesEnabled": {
+            "extensibility": true
+          },
+          "formatting": {
+            "indentKind": "Space",
+            "newlineKind": "LF",
+            "insertFinalNewline": true,
+            "indentSize": 2,
+            "width": 80
+          }
+        }
+        """
       });
 
       // Act.
@@ -648,117 +648,117 @@ namespace Bicep.Core.UnitTests.Configuration
 
       // Assert.
       configuration.Should().HaveContents(/*lang=json,strict*/ """
-                {
-                  "cloud": {
-                    "currentProfile": "MyCloud",
-                    "profiles": {
-                      "AzureChinaCloud": {
-                        "resourceManagerEndpoint": "https://management.chinacloudapi.cn",
-                        "activeDirectoryAuthority": "https://login.chinacloudapi.cn"
-                      },
-                      "AzureCloud": {
-                        "resourceManagerEndpoint": "https://management.azure.com",
-                        "activeDirectoryAuthority": "https://login.microsoftonline.com"
-                      },
-                      "AzureUSGovernment": {
-                        "resourceManagerEndpoint": "https://management.usgovcloudapi.net",
-                        "activeDirectoryAuthority": "https://login.microsoftonline.us"
-                      },
-                      "MyCloud": {
-                        "resourceManagerEndpoint": "https://bicep.example.com",
-                        "activeDirectoryAuthority": "https://login.bicep.example.com"
-                      }
-                    },
-                    "credentialPrecedence": [
-                      "AzurePowerShell",
-                      "VisualStudioCode"
-                    ],
-                    "credentialOptions": {
-                      "managedIdentity": {
-                        "type": "UserAssigned",
-                        "clientId": "00000000-0000-0000-0000-000000000000"
-                      }
-                    }
-                  },
-                  "moduleAliases": {
-                    "ts": {
-                      "mySpecPath": {
-                        "subscription": "B34C8680-F688-48C2-A44F-E1EFF5E01173"
-                      }
-                    },
-                    "br": {
-                      "myModulePath": {
-                        "registry": "test.invalid",
-                        "modulePath": "root/modules"
-                      },
-                      "myRegistry": {
-                        "registry": "localhost:8000"
-                      },
-                      "public": {
-                        "registry": "mcr.microsoft.com",
-                        "modulePath": "bicep"
-                      }
-                    }
-                  },
-                  "providerAliases": {
-                    "br": {
-                      "public": {
-                        "registry": "mcr.microsoft.com",
-                        "providerPath": "bicep/providers"
-                      }
-                    }
-                  },
-                  "analyzers": {
-                    "core": {
-                      "verbose": false,
-                      "enabled": false,
-                      "rules": {
-                        "no-hardcoded-env-urls": {
-                          "level": "warning",
-                          "disallowedhosts": [
-                            "datalake.azure.net",
-                            "azuredatalakestore.net",
-                            "azuredatalakeanalytics.net",
-                            "vault.azure.net",
-                            "api.loganalytics.io",
-                            "asazure.windows.net",
-                            "region.asazure.windows.net",
-                            "batch.core.windows.net"
-                          ],
-                          "excludedhosts": [
-                            "schema.management.azure.com"
-                          ]
-                        }
-                      }
-                    }
-                  },
-                  "cacheRootDirectory": "/home/username/.bicep/cache",
-                  "experimentalFeaturesEnabled": {
-                    "symbolicNameCodegen": false,
-                    "extensibility": true,
-                    "resourceTypedParamsAndOutputs": false,
-                    "sourceMapping": false,
-                    "userDefinedFunctions": false,
-                    "prettyPrinting": false,
-                    "testFramework": false,
-                    "assertions": false,
-                    "dynamicTypeLoading": false,
-                    "providerRegistry": false,
-                    "microsoftGraphPreview": false,
-                    "compileTimeImports": false,
-                    "publishSource": false,
-                    "optionalModuleNames": false,
-                    "resourceDerivedTypes": false
-                  },
-                  "formatting": {
-                    "indentKind": "Space",
-                    "newlineKind": "LF",
-                    "insertFinalNewline": true,
-                    "indentSize": 2,
-                    "width": 80
-                  }
-                }
-                """);
+      {
+        "cloud": {
+          "currentProfile": "MyCloud",
+          "profiles": {
+            "AzureChinaCloud": {
+              "resourceManagerEndpoint": "https://management.chinacloudapi.cn",
+              "activeDirectoryAuthority": "https://login.chinacloudapi.cn"
+            },
+            "AzureCloud": {
+              "resourceManagerEndpoint": "https://management.azure.com",
+              "activeDirectoryAuthority": "https://login.microsoftonline.com"
+            },
+            "AzureUSGovernment": {
+              "resourceManagerEndpoint": "https://management.usgovcloudapi.net",
+              "activeDirectoryAuthority": "https://login.microsoftonline.us"
+            },
+            "MyCloud": {
+              "resourceManagerEndpoint": "https://bicep.example.com",
+              "activeDirectoryAuthority": "https://login.bicep.example.com"
+            }
+          },
+          "credentialPrecedence": [
+            "AzurePowerShell",
+            "VisualStudioCode"
+          ],
+          "credentialOptions": {
+            "managedIdentity": {
+              "type": "UserAssigned",
+              "clientId": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        },
+        "moduleAliases": {
+          "ts": {
+            "mySpecPath": {
+              "subscription": "B34C8680-F688-48C2-A44F-E1EFF5E01173"
+            }
+          },
+          "br": {
+            "myModulePath": {
+              "registry": "test.invalid",
+              "modulePath": "root/modules"
+            },
+            "myRegistry": {
+              "registry": "localhost:8000"
+            },
+            "public": {
+              "registry": "mcr.microsoft.com",
+              "modulePath": "bicep"
+            }
+          }
+        },
+        "providerAliases": {
+          "br": {
+            "public": {
+              "registry": "mcr.microsoft.com",
+              "providerPath": "bicep/providers"
+            }
+          }
+        },
+        "analyzers": {
+          "core": {
+            "verbose": false,
+            "enabled": false,
+            "rules": {
+              "no-hardcoded-env-urls": {
+                "level": "warning",
+                "disallowedhosts": [
+                  "datalake.azure.net",
+                  "azuredatalakestore.net",
+                  "azuredatalakeanalytics.net",
+                  "vault.azure.net",
+                  "api.loganalytics.io",
+                  "asazure.windows.net",
+                  "region.asazure.windows.net",
+                  "batch.core.windows.net"
+                ],
+                "excludedhosts": [
+                  "schema.management.azure.com"
+                ]
+              }
+            }
+          }
+        },
+        "cacheRootDirectory": "/home/username/.bicep/cache",
+        "experimentalFeaturesEnabled": {
+          "symbolicNameCodegen": false,
+          "extensibility": true,
+          "resourceTypedParamsAndOutputs": false,
+          "sourceMapping": false,
+          "userDefinedFunctions": false,
+          "prettyPrinting": false,
+          "testFramework": false,
+          "assertions": false,
+          "dynamicTypeLoading": false,
+          "providerRegistry": false,
+          "microsoftGraphPreview": false,
+          "compileTimeImports": false,
+          "publishSource": false,
+          "optionalModuleNames": false,
+          "resourceDerivedTypes": false
+        },
+        "formatting": {
+          "indentKind": "Space",
+          "newlineKind": "LF",
+          "insertFinalNewline": true,
+          "indentSize": 2,
+          "width": 80
+        }
+      }
+      """);
     }
 
     [TestMethod]
@@ -772,38 +772,38 @@ namespace Bicep.Core.UnitTests.Configuration
       {
         [CreatePath("repo")] = new MockDirectoryData(),
         [CreatePath("repo/bicepconfig.json")] = """
-                {
-                  "moduleAliases": {
-                    "br": {
-                      "public": {
-                        "registry": "main.microsoft.com",
-                        "modulePath": "bicep"
-                      }
-                    }
-                  },
-                  "providerAliases": {
-                    "br": {
-                      "public": {
-                        "registry": "main.microsoft.com",
-                        "providerPath": "bicep/providers"
-                      }
-                    }
-                  }
-                }
-                """,
+        {
+          "moduleAliases": {
+            "br": {
+              "public": {
+                "registry": "main.microsoft.com",
+                "modulePath": "bicep"
+              }
+            }
+          },
+          "providerAliases": {
+            "br": {
+              "public": {
+                "registry": "main.microsoft.com",
+                "providerPath": "bicep/providers"
+              }
+            }
+          }
+        }
+        """,
         [CreatePath("repo/modules")] = new MockDirectoryData(),
         [CreatePath("repo/modules/bicepconfig.json")] = """
-                {
-                  "providerAliases": {
-                    "br": {
-                      "public": {
-                        "registry": "mod.microsoft.com",
-                        "providerPath": "bicep/providers"
-                      }
-                    }
-                  }
-                }
-                """
+        {
+          "providerAliases": {
+            "br": {
+              "public": {
+                "registry": "mod.microsoft.com",
+                "providerPath": "bicep/providers"
+              }
+            }
+          }
+        }
+        """
       });
       // Act.
       var sut = new ConfigurationManager(fileSystem);


### PR DESCRIPTION
## Overview

Literal strings use the last `"""` (triple-quote) as a margin indicator, reducing the indentation here makes the code easier to follow IMO since it allows a human to scan top to bottom vs having to go in the incline from right top to left bottom which is distracting.