### PR TITLE
Various changes to the `bicep jsonrpc` command

### DIFF
--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -37,5 +37,8 @@ Allows you to define your own custom functions. See [User-defined functions in B
 ### `publish-provider` CLI Command
 Command that allows the publishing of providers to container registries. For more information, see [Using the Publish Provider Command](./experimental/publish-provider-command.md).
 
+### `jsonrpc` CLI Command
+Command that launches the CLI in a JSONRPC server mode. Useful for invoking the CLI programatically to consume structured output, and to avoid cold-start delays when compiling multiple files. For more information, see [Using the JSONRPC Command](./experimental/jsonrpc-command.md).
+
 ### Deployment Pane
 The Deployment Pane is a UI panel in VSCode that allows you to connect to your Azure subscription and execute validate, deploy & whatif operations and get instant feedback without leaving the editor. For more information, see [Using the Deployment Pane](./experimental/deploy-ui.md).

--- a/docs/experimental/jsonrpc-command.md
+++ b/docs/experimental/jsonrpc-command.md
@@ -1,0 +1,203 @@
+# Using the `jsonrpc` command (Experimental!)
+
+## What is it?
+The `jsonrpc` command allows you to run the Bicep CLI in a JSONRPC server mode. This is useful for invoking the CLI programatically to consume structured output, and to avoid cold-start delays when compiling multiple files.
+
+This makes it possible to build libraries which interact with Bicep files programatically in non-.NET languages.
+
+## Usage (named pipe)
+`bicep jsonrpc --pipe <named_pipe>`
+
+Runs the JSONRPC server connected to a named pipe.
+
+### Arguments
+`<named_pipe>` A named pipe to connect the JSONRPC server to.
+
+### Examples
+#### Connecting to a named pipe (OSX/Linux)
+`bicep jsonrpc --pipe /tmp/bicep-81375a8084b474fa2eaedda1702a7aa40e2eaa24b3.sock`
+
+#### Connecting to a named pipe (Windows)
+`bicep jsonrpc --pipe \\.\pipe\\bicep-81375a8084b474fa2eaedda1702a7aa40e2eaa24b3.sock`
+
+## Usage (TCP socket)
+`bicep jsonrpc --socket <tcp_socket>`
+
+Runs the JSONRPC server connected to a TCP socket.
+
+### Arguments
+`<tcp_socket>` A socket number to connect the JSONRPC server to.
+
+### Examples
+#### Connecting to a TCP socket
+`bicep jsonrpc --socket 12345`
+
+## Usage (stdin/stdout)
+`bicep jsonrpc --stdio`
+
+Runs the JSONRPC server using stdin & stdout for messages.
+
+## JSONRPC Contract
+
+See [`ICliJsonRpcProtocol.cs`](../../src/Bicep.Cli/Rpc/ICliJsonRpcProtocol.cs) for the available methods & request/response bodies.
+
+See [`jsonrpc.test.ts`](../../src/Bicep.Cli.E2eTests/src/jsonrpc.test.ts) for an example of connecting to the server and interacting with Bicep files programatically using Node.
+
+## Example JSONRPC messages
+
+### `bicep/getVersion`
+#### Input
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 0,
+  "method": "bicep/version",
+  "params": {}
+}
+```
+#### Output
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 0,
+  "result": {
+    "version": "0.24.211"
+  }
+}
+```
+
+### `bicep/compile`
+#### Input
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "bicep/compile",
+  "params": {
+    "path": "/Users/ant/Code/bicep/src/Bicep.Cli.E2eTests/src/examples/101/aks.prod/main.bicep"
+  }
+}
+```
+#### Output
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "success": true,
+    "diagnostics": [],
+    "contents": "{\n  \"$schema\": \"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#\",\n  \"contentVersion\": \"1.0.0.0\",\n  \"metadata\": {\n    \"_generator\": {\n      \"name\": \"bicep\",\n      \"version\": \"0.24.211.59455\",\n      \"templateHash\": \"16887360739795423296\"\n    }\n  },\n  \"parameters\": {\n    \"dnsPrefix\": {\n      \"type\": \"string\"\n    },\n    \"linuxAdminUsername\": {\n      \"type\": \"string\"\n    },\n    \"sshRSAPublicKey\": {\n      \"type\": \"string\"\n    },\n    \"servicePrincipalClientId\": {\n      \"type\": \"string\"\n    },\n    \"servicePrincipalClientSecret\": {\n      \"type\": \"securestring\"\n    },\n    \"clusterName\": {\n      \"type\": \"string\",\n      \"defaultValue\": \"aks101cluster\"\n    },\n    \"location\": {\n      \"type\": \"string\",\n      \"defaultValue\": \"[resourceGroup().location]\"\n    },\n    \"osDiskSizeGB\": {\n      \"type\": \"int\",\n      \"defaultValue\": 0,\n      \"minValue\": 0,\n      \"maxValue\": 1023\n    },\n    \"agentCount\": {\n      \"type\": \"int\",\n      \"defaultValue\": 3,\n      \"minValue\": 1,\n      \"maxValue\": 50\n    },\n    \"agentVMSize\": {\n      \"type\": \"string\",\n      \"defaultValue\": \"Standard_DS2_v2\"\n    }\n  },\n  \"resources\": [\n    {\n      \"type\": \"Microsoft.ContainerService/managedClusters\",\n      \"apiVersion\": \"2020-09-01\",\n      \"name\": \"[parameters('clusterName')]\",\n      \"location\": \"[parameters('location')]\",\n      \"properties\": {\n        \"dnsPrefix\": \"[parameters('dnsPrefix')]\",\n        \"agentPoolProfiles\": [\n          {\n            \"name\": \"agentpool\",\n            \"osDiskSizeGB\": \"[parameters('osDiskSizeGB')]\",\n            \"count\": \"[parameters('agentCount')]\",\n            \"vmSize\": \"[parameters('agentVMSize')]\",\n            \"osType\": \"Linux\"\n          }\n        ],\n        \"linuxProfile\": {\n          \"adminUsername\": \"[parameters('linuxAdminUsername')]\",\n          \"ssh\": {\n            \"publicKeys\": [\n              {\n                \"keyData\": \"[parameters('sshRSAPublicKey')]\"\n              }\n            ]\n          }\n        },\n        \"servicePrincipalProfile\": {\n          \"clientId\": \"[parameters('servicePrincipalClientId')]\",\n          \"secret\": \"[parameters('servicePrincipalClientSecret')]\"\n        }\n      }\n    }\n  ],\n  \"outputs\": {\n    \"controlPlaneFQDN\": {\n      \"type\": \"string\",\n      \"value\": \"[reference(resourceId('Microsoft.ContainerService/managedClusters', parameters('clusterName')), '2020-09-01').fqdn]\"\n    }\n  }\n}"
+  }
+}
+```
+
+### `bicep/getDeploymentGraph`
+#### Input
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "bicep/getDeploymentGraph",
+  "params": {
+    "path": "/Users/ant/Code/bicep/src/Bicep.Cli.E2eTests/src/temp/jsonrpc/metadata.bicep"
+  }
+}
+```
+#### Output
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "nodes": [
+      {
+        "range": {
+          "start": {
+            "line": 5,
+            "char": 4
+          },
+          "end": {
+            "line": 8,
+            "char": 5
+          }
+        },
+        "name": "bar",
+        "type": "My.Rp/foo",
+        "isExisting": true
+      },
+      {
+        "range": {
+          "start": {
+            "line": 10,
+            "char": 4
+          },
+          "end": {
+            "line": 13,
+            "char": 5
+          }
+        },
+        "name": "baz",
+        "type": "My.Rp/foo",
+        "isExisting": false
+      },
+      {
+        "range": {
+          "start": {
+            "line": 1,
+            "char": 4
+          },
+          "end": {
+            "line": 3,
+            "char": 5
+          }
+        },
+        "name": "foo",
+        "type": "My.Rp/foo",
+        "isExisting": false
+      }
+    ],
+    "edges": [
+      {
+        "source": "bar",
+        "target": "foo"
+      },
+      {
+        "source": "baz",
+        "target": "bar"
+      }
+    ]
+  }
+}
+```
+
+### `bicep/getFileReferences`
+#### Input
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "method": "bicep/getFileReferences",
+  "params": {
+    "path": "/Users/ant/Code/bicep/src/Bicep.Cli.E2eTests/src/temp/jsonrpc/main.bicepparam"
+  }
+}
+```
+#### Output
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "result": {
+    "filePaths": [
+      "/Users/ant/Code/bicep/src/Bicep.Cli.E2eTests/src/temp/jsonrpc/bicepconfig.json",
+      "/Users/ant/Code/bicep/src/Bicep.Cli.E2eTests/src/temp/jsonrpc/invalid.txt",
+      "/Users/ant/Code/bicep/src/Bicep.Cli.E2eTests/src/temp/jsonrpc/main.bicep",
+      "/Users/ant/Code/bicep/src/Bicep.Cli.E2eTests/src/temp/jsonrpc/main.bicepparam",
+      "/Users/ant/Code/bicep/src/Bicep.Cli.E2eTests/src/temp/jsonrpc/valid.txt"
+    ]
+  }
+}
+```
+
+## Raising bugs or feature requests
+Please raise bug reports or feature requests under [Bicep Issues](https://github.com/Azure/bicep/issues) as usual.

--- a/src/Bicep.Cli.E2eTests/src/utils/jsonrpc.ts
+++ b/src/Bicep.Cli.E2eTests/src/utils/jsonrpc.ts
@@ -39,6 +39,14 @@ interface GetDeploymentGraphResponseEdge {
   target: string;
 }
 
+interface GetFileReferencesRequest {
+  path: string;
+}
+
+interface GetFileReferencesResponse {
+  filePaths: string[];
+}
+
 interface Position {
   line: number;
   char: number;
@@ -116,6 +124,12 @@ export const getDeploymentGraphRequestType = new RequestType<
   GetDeploymentGraphResponse,
   never
 >("bicep/getDeploymentGraph");
+
+export const getFileReferencesRequestType = new RequestType<
+  GetFileReferencesRequest,
+  GetFileReferencesResponse,
+  never
+>("bicep/getFileReferences");
 
 function generateRandomPipeName(): string {
   const randomSuffix = randomBytes(21).toString("hex");

--- a/src/Bicep.Cli.E2eTests/src/utils/jsonrpc.ts
+++ b/src/Bicep.Cli.E2eTests/src/utils/jsonrpc.ts
@@ -84,7 +84,13 @@ interface MetadataDefinition {
 interface ParamDefinition {
   range: Range;
   name: string;
+  type?: TypeDefinition;
   description?: string;
+}
+
+interface TypeDefinition {
+  range?: Range;
+  name: string;
 }
 
 export const versionRequestType = new RequestType<

--- a/src/Bicep.Cli.IntegrationTests/JsonRpcCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/JsonRpcCommandTests.cs
@@ -116,6 +116,16 @@ metadata description = 'my file'
 @description('foo param')
 param foo string
 
+param inlineType {
+  sdf: string
+}
+
+param declaredType asdf
+
+type asdf = {
+  foo: string
+}
+
 @description('bar output')
 output bar string = foo
 """,
@@ -130,10 +140,12 @@ output bar string = foo
                     new("description", "my file"),
                 });
                 response.Parameters.Should().Equal(new GetMetadataResponse.SymbolDefinition[] {
-                    new(new(new(2, 0), new(3, 16)), "foo", "foo param"),
+                    new(new(new(2, 0), new(3, 16)), "foo", new(null, "string"), "foo param"),
+                    new(new(new(5, 0), new(7, 1)), "inlineType", new(null, "{ sdf: string }"), null),
+                    new(new(new(9, 0), new(9, 23)), "declaredType", new(new(new(11, 0), new(13, 1)), "asdf"), null),
                 });
                 response.Outputs.Should().Equal(new GetMetadataResponse.SymbolDefinition[] {
-                    new(new(new(5, 0), new(6, 23)), "bar", "bar output"),
+                    new(new(new(15, 0), new(16, 23)), "bar", new(null, "string"), "bar output"),
                 });
             });
     }

--- a/src/Bicep.Cli/Commands/JsonRpcCommand.cs
+++ b/src/Bicep.Cli/Commands/JsonRpcCommand.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics;
+using System.IO;
 using System.IO.Pipes;
 using System.Net;
 using System.Net.Sockets;
@@ -10,6 +12,7 @@ using System.Threading.Tasks;
 using Bicep.Cli.Arguments;
 using Bicep.Cli.Rpc;
 using Bicep.Core;
+using Bicep.Core.Features;
 using Bicep.Core.Registry.Auth;
 using StreamJsonRpc;
 
@@ -40,9 +43,7 @@ public class JsonRpcCommand : ICommand
             using var clientPipe = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
 
             await clientPipe.ConnectAsync(cancellationToken);
-
-            using var rpc = new JsonRpc(CliJsonRpcServer.CreateMessageHandler(clientPipe, clientPipe));
-            await RunServer(rpc, cancellationToken);
+            await RunServer(clientPipe, clientPipe, cancellationToken);
         }
         else if (args.Socket is { } port)
         {
@@ -50,21 +51,25 @@ public class JsonRpcCommand : ICommand
 
             await tcpClient.ConnectAsync(IPAddress.Loopback, port, cancellationToken);
             using var tcpStream = tcpClient.GetStream();
-
-            using var rpc = new JsonRpc(CliJsonRpcServer.CreateMessageHandler(tcpStream, tcpStream));
-            await RunServer(rpc, cancellationToken);
+            await RunServer(tcpStream, tcpStream, cancellationToken);
         }
         else
         {
-            using var rpc = new JsonRpc(CliJsonRpcServer.CreateMessageHandler(Console.OpenStandardOutput(), Console.OpenStandardInput()));
-            await RunServer(rpc, cancellationToken);
+            await RunServer(Console.OpenStandardOutput(), Console.OpenStandardInput(), cancellationToken);
         }
 
         return 0;
     }
 
-    private async Task RunServer(JsonRpc jsonRpc, CancellationToken cancellationToken)
+    private async Task RunServer(Stream inputStream, Stream outputStream, CancellationToken cancellationToken)
     {
+        using var jsonRpc = new JsonRpc(CliJsonRpcServer.CreateMessageHandler(inputStream, outputStream));
+        if (FeatureProvider.TracingEnabled)
+        {
+            jsonRpc.TraceSource = new TraceSource("JsonRpc", SourceLevels.Verbose);
+            jsonRpc.TraceSource.Listeners.AddRange(Trace.Listeners);
+        }
+
         var server = new CliJsonRpcServer(compiler);
         jsonRpc.AddLocalRpcTarget<ICliJsonRpcProtocol>(server, null);
 

--- a/src/Bicep.Cli/Rpc/ICliJsonRpcProtocol.cs
+++ b/src/Bicep.Cli/Rpc/ICliJsonRpcProtocol.cs
@@ -49,7 +49,12 @@ public record GetMetadataResponse(
     public record SymbolDefinition(
         Range Range,
         string Name,
+        TypeDefinition? Type,
         string? Description);
+
+    public record TypeDefinition(
+        Range? Range,
+        string Name);
 
     public record MetadataDefinition(
         string Name,

--- a/src/Bicep.Cli/Rpc/ICliJsonRpcProtocol.cs
+++ b/src/Bicep.Cli/Rpc/ICliJsonRpcProtocol.cs
@@ -38,6 +38,12 @@ public record CompileResponse(
         string Message);
 }
 
+public record GetFileReferencesRequest(
+    string Path);
+
+public record GetFileReferencesResponse(
+    ImmutableArray<string> FilePaths);
+
 public record GetMetadataRequest(
     string Path);
 
@@ -93,4 +99,7 @@ public interface ICliJsonRpcProtocol
 
     [JsonRpcMethod("bicep/getDeploymentGraph", UseSingleObjectParameterDeserialization = true)]
     Task<GetDeploymentGraphResponse> GetDeploymentGraph(GetDeploymentGraphRequest request, CancellationToken cancellationToken);
+
+    [JsonRpcMethod("bicep/getFileReferences", UseSingleObjectParameterDeserialization = true)]
+    Task<GetFileReferencesResponse> GetFileReferences(GetFileReferencesRequest request, CancellationToken cancellationToken);
 }

--- a/src/Bicep.Core.UnitTests/BicepTestConstants.cs
+++ b/src/Bicep.Core.UnitTests/BicepTestConstants.cs
@@ -98,7 +98,7 @@ namespace Bicep.Core.UnitTests
 
         public static readonly IModuleRestoreScheduler ModuleRestoreScheduler = CreateMockModuleRestoreScheduler();
 
-        public static RootConfiguration CreateMockConfiguration(Dictionary<string, object>? customConfigurationData = null, string? configurationPath = null)
+        public static RootConfiguration CreateMockConfiguration(Dictionary<string, object>? customConfigurationData = null, Uri? configFileUri = null)
         {
             var configurationData = new Dictionary<string, object>
             {
@@ -128,7 +128,7 @@ namespace Bicep.Core.UnitTests
                 element = element.SetPropertyByPath(path, value);
             }
 
-            return RootConfiguration.Bind(element, configurationPath);
+            return RootConfiguration.Bind(element, configFileUri);
         }
 
         public static ConfigurationManager CreateFilesystemConfigurationManager() => new(new IOFileSystem());

--- a/src/Bicep.Core.UnitTests/Configuration/RootConfigurationTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/RootConfigurationTests.cs
@@ -26,7 +26,7 @@ public class RootConfigurationTests
                 cacheRootDirectory,
                 BicepTestConstants.BuiltInConfiguration.ExperimentalFeaturesEnabled,
                 BicepTestConstants.BuiltInConfiguration.Formatting,
-                BicepTestConstants.BuiltInConfiguration.ConfigurationPath,
+                BicepTestConstants.BuiltInConfiguration.ConfigFileUri,
                 BicepTestConstants.BuiltInConfiguration.DiagnosticBuilders);
 
         configuration.CacheRootDirectory.Should().Be(expectedExpandedDirectory);

--- a/src/Bicep.Core.UnitTests/Modules/OciArtifactModuleReferenceTests.cs
+++ b/src/Bicep.Core.UnitTests/Modules/OciArtifactModuleReferenceTests.cs
@@ -210,10 +210,10 @@ namespace Bicep.Core.UnitTests.Modules
 
         [DataTestMethod]
         [DataRow("myRegistry", "path/to/module:v1", null, "BCP213", "The OCI artifact module alias name \"myRegistry\" does not exist in the built-in Bicep configuration.")]
-        [DataRow("myModulePath", "myModule:v2", "bicepconfig.json", "BCP213", "The OCI artifact module alias name \"myModulePath\" does not exist in the Bicep configuration \"bicepconfig.json\".")]
+        [DataRow("myModulePath", "myModule:v2", "bicepconfig.json", "BCP213", "The OCI artifact module alias name \"myModulePath\" does not exist in the Bicep configuration \"/bicepconfig.json\".")]
         public void TryParse_AliasNotInConfiguration_ReturnsFalseAndSetsErrorDiagnostic(string aliasName, string referenceValue, string? configurationPath, string expectedCode, string expectedMessage)
         {
-            var configuration = BicepTestConstants.CreateMockConfiguration(configurationPath: configurationPath);
+            var configuration = BicepTestConstants.CreateMockConfiguration(configFileUri: configurationPath is {} ? new Uri($"file:///{configurationPath}") : null);
 
             OciArtifactReference.TryParse(ArtifactType.Module, aliasName, referenceValue, configuration, RandomFileUri()).IsSuccess(out var reference, out var errorBuilder).Should().BeFalse();
 
@@ -290,9 +290,9 @@ namespace Bicep.Core.UnitTests.Modules
                     {
                         ["moduleAliases.br.myModulePath2.modulePath"] = "path2",
                     },
-                    "bicepconfig.json"),
+                    new Uri("file:///bicepconfig.json")),
                 "BCP216",
-                "The OCI artifact module alias \"myModulePath2\" in the Bicep configuration \"bicepconfig.json\" is invalid. The \"registry\" property cannot be null or undefined.",
+                "The OCI artifact module alias \"myModulePath2\" in the Bicep configuration \"/bicepconfig.json\" is invalid. The \"registry\" property cannot be null or undefined.",
             };
         }
 
@@ -321,7 +321,7 @@ namespace Bicep.Core.UnitTests.Modules
                         ["moduleAliases.br.myModulePath2.registry"] = "localhost:8000",
                         ["moduleAliases.br.myModulePath2.modulePath"] = "root/parent",
                     },
-                    "bicepconfig.json"),
+                    new Uri("file:///bicepconfig.json")),
             };
         }
 

--- a/src/Bicep.Core.UnitTests/Modules/TemplateSpecModuleReferenceTests.cs
+++ b/src/Bicep.Core.UnitTests/Modules/TemplateSpecModuleReferenceTests.cs
@@ -69,10 +69,10 @@ namespace Bicep.Core.UnitTests.Modules
 
         [DataTestMethod]
         [DataRow("prodRG", "mySpec:v1", null, "BCP212", "The Template Spec module alias name \"prodRG\" does not exist in the built-in Bicep configuration.")]
-        [DataRow("testRG", "myModule:v2", "bicepconfig.json", "BCP212", "The Template Spec module alias name \"testRG\" does not exist in the Bicep configuration \"bicepconfig.json\".")]
+        [DataRow("testRG", "myModule:v2", "bicepconfig.json", "BCP212", "The Template Spec module alias name \"testRG\" does not exist in the Bicep configuration \"/bicepconfig.json\".")]
         public void TryParse_AliasNotInConfiguration_ReturnsFalseAndSetsError(string aliasName, string referenceValue, string? configurationPath, string expectedCode, string expectedMessage)
         {
-            var configuration = BicepTestConstants.CreateMockConfiguration(configurationPath: configurationPath);
+            var configuration = BicepTestConstants.CreateMockConfiguration(configFileUri: configurationPath is {} ? new Uri($"file:///{configurationPath}") : null);
 
             TemplateSpecModuleReference.TryParse(aliasName, referenceValue, configuration, RandomFileUri()).IsSuccess(out var reference, out var errorBuilder).Should().BeFalse();
 
@@ -183,9 +183,9 @@ namespace Bicep.Core.UnitTests.Modules
                 BicepTestConstants.CreateMockConfiguration(new()
                 {
                     ["moduleAliases.ts.prodRG.subscription"] = "1E7593D0-FCD1-4570-B132-51E4FD254967",
-                }, "bicepconfig.json"),
+                }, new Uri("file:///bicepconfig.json")),
                 "BCP215",
-                "The Template Spec module alias \"prodRG\" in the Bicep configuration \"bicepconfig.json\" is in valid. The \"resourceGroup\" property cannot be null or undefined.",
+                "The Template Spec module alias \"prodRG\" in the Bicep configuration \"/bicepconfig.json\" is in valid. The \"resourceGroup\" property cannot be null or undefined.",
             };
         }
 

--- a/src/Bicep.Core/Analyzers/Linter/LinterAnalyzer.cs
+++ b/src/Bicep.Core/Analyzers/Linter/LinterAnalyzer.cs
@@ -77,7 +77,7 @@ namespace Bicep.Core.Analyzers.Linter
                         TextSpan.TextDocumentStart,
                         DiagnosticLevel.Info,
                         "Linter Disabled",
-                        string.Format(CoreResources.LinterDisabledFormatMessage, semanticModel.Configuration.ConfigurationPath ?? IConfigurationManager.BuiltInConfigurationResourceName)));
+                        string.Format(CoreResources.LinterDisabledFormatMessage, semanticModel.Configuration.ConfigFileUri?.LocalPath ?? IConfigurationManager.BuiltInConfigurationResourceName)));
                 }
             }
 
@@ -88,7 +88,7 @@ namespace Bicep.Core.Analyzers.Linter
         {
             var configMessage = model.Configuration.IsBuiltIn
                 ? CoreResources.BicepConfigNoCustomSettingsMessage
-                : string.Format(CoreResources.BicepConfigCustomSettingsFoundFormatMessage, model.Configuration.ConfigurationPath);
+                : string.Format(CoreResources.BicepConfigCustomSettingsFoundFormatMessage, model.Configuration.ConfigFileUri?.LocalPath);
 
             return new AnalyzerDiagnostic(
                 AnalyzerName,

--- a/src/Bicep.Core/Configuration/AnalyzersConfigurationExtensions.cs
+++ b/src/Bicep.Core/Configuration/AnalyzersConfigurationExtensions.cs
@@ -31,7 +31,7 @@ namespace Bicep.Core.Configuration
                 analyzersConfiguration.CacheRootDirectory,
                 analyzersConfiguration.ExperimentalFeaturesEnabled,
                 analyzersConfiguration.Formatting,
-                analyzersConfiguration.ConfigurationPath,
+                analyzersConfiguration.ConfigFileUri,
                 analyzersConfiguration.DiagnosticBuilders);
         }
 
@@ -45,7 +45,7 @@ namespace Bicep.Core.Configuration
                 analyzersConfiguration.CacheRootDirectory,
                 analyzersConfiguration.ExperimentalFeaturesEnabled,
                 analyzersConfiguration.Formatting,
-                analyzersConfiguration.ConfigurationPath,
+                analyzersConfiguration.ConfigFileUri,
                 analyzersConfiguration.DiagnosticBuilders);
         }
     }

--- a/src/Bicep.Core/Configuration/CloudConfiguration.cs
+++ b/src/Bicep.Core/Configuration/CloudConfiguration.cs
@@ -54,16 +54,16 @@ namespace Bicep.Core.Configuration
         // this does not work with regional ARM endpoints
         public string ResourceManagerAudience => ResourceManagerEndpointUri.AbsoluteUri.TrimEnd('/');
 
-        public static CloudConfiguration Bind(JsonElement element, string? configurationPath)
+        public static CloudConfiguration Bind(JsonElement element)
         {
             var cloud = element.ToNonNullObject<Cloud>();
-            var (endpointUri, authorityUri) = ValidateCurrentProfile(cloud, configurationPath);
-            ValidateCredentialOptions(cloud, configurationPath);
+            var (endpointUri, authorityUri) = ValidateCurrentProfile(cloud);
+            ValidateCredentialOptions(cloud);
 
             return new(cloud, endpointUri, authorityUri);
         }
 
-        private static void ValidateCredentialOptions(Cloud cloud, string? configurationPath)
+        private static void ValidateCredentialOptions(Cloud cloud)
         {
             if (cloud.CredentialOptions is null ||
                 cloud.CredentialOptions.ManagedIdentity is null ||
@@ -96,7 +96,7 @@ namespace Bicep.Core.Configuration
             }
         }
 
-        private static (Uri resourceManagerEndpointUri, Uri activeDirectoryAuthorityUri) ValidateCurrentProfile(Cloud cloud, string? configurationPath)
+        private static (Uri resourceManagerEndpointUri, Uri activeDirectoryAuthorityUri) ValidateCurrentProfile(Cloud cloud)
         {
             static string ToCamelCase(string name) => char.ToLowerInvariant(name[0]) + name[1..];
 

--- a/src/Bicep.Core/Configuration/ConfigurationManager.cs
+++ b/src/Bicep.Core/Configuration/ConfigurationManager.cs
@@ -104,7 +104,7 @@ namespace Bicep.Core.Configuration
                     configuration.CacheRootDirectory,
                     configuration.ExperimentalFeaturesEnabled,
                     configuration.Formatting,
-                    configuration.ConfigurationPath,
+                    configuration.ConfigFileUri,
                     diagnostics);
             }
 
@@ -120,7 +120,7 @@ namespace Bicep.Core.Configuration
                 using var stream = fileSystem.FileStream.New(configurationUri.LocalPath, FileMode.Open, FileAccess.Read);
                 var element = IConfigurationManager.BuiltInConfigurationElement.Merge(JsonElementFactory.CreateElementFromStream(stream));
 
-                return (RootConfiguration.Bind(element, configurationUri.LocalPath), null);
+                return (RootConfiguration.Bind(element, configurationUri), null);
             }
             catch (ConfigurationException exception)
             {

--- a/src/Bicep.Core/Configuration/ModuleAliasesConfiguration.cs
+++ b/src/Bicep.Core/Configuration/ModuleAliasesConfiguration.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
@@ -43,15 +44,15 @@ namespace Bicep.Core.Configuration
 
     public partial class ModuleAliasesConfiguration : ConfigurationSection<ModuleAliases>
     {
-        private readonly string? configurationPath;
+        private readonly Uri? configFileUri;
 
-        private ModuleAliasesConfiguration(ModuleAliases data, string? configurationPath)
+        private ModuleAliasesConfiguration(ModuleAliases data, Uri? configFileUri)
             : base(data)
         {
-            this.configurationPath = configurationPath;
+            this.configFileUri = configFileUri;
         }
 
-        public static ModuleAliasesConfiguration Bind(JsonElement element, string? configurationPath) => new(element.ToNonNullObject<ModuleAliases>(), configurationPath);
+        public static ModuleAliasesConfiguration Bind(JsonElement element, Uri? configFileUri) => new(element.ToNonNullObject<ModuleAliases>(), configFileUri);
 
         public ImmutableSortedDictionary<string, OciArtifactModuleAlias> GetOciArtifactModuleAliases()
         {
@@ -72,17 +73,17 @@ namespace Bicep.Core.Configuration
 
             if (!this.Data.TemplateSpecModuleAliases.TryGetValue(aliasName, out var alias))
             {
-                return new(x => x.TemplateSpecModuleAliasNameDoesNotExistInConfiguration(aliasName, this.configurationPath));
+                return new(x => x.TemplateSpecModuleAliasNameDoesNotExistInConfiguration(aliasName, configFileUri));
             }
 
             if (alias.Subscription is null)
             {
-                return new(x => x.InvalidTemplateSpecAliasSubscriptionNullOrUndefined(aliasName, this.configurationPath));
+                return new(x => x.InvalidTemplateSpecAliasSubscriptionNullOrUndefined(aliasName, configFileUri));
             }
 
             if (alias.ResourceGroup is null)
             {
-                return new(x => x.InvalidTemplateSpecAliasResourceGroupNullOrUndefined(aliasName, this.configurationPath));
+                return new(x => x.InvalidTemplateSpecAliasResourceGroupNullOrUndefined(aliasName, configFileUri));
             }
 
             return new(alias);
@@ -97,12 +98,12 @@ namespace Bicep.Core.Configuration
 
             if (!this.Data.OciArtifactModuleAliases.TryGetValue(aliasName, out var alias))
             {
-                return new(x => x.OciArtifactModuleAliasNameDoesNotExistInConfiguration(aliasName, this.configurationPath));
+                return new(x => x.OciArtifactModuleAliasNameDoesNotExistInConfiguration(aliasName, configFileUri));
             }
 
             if (alias.Registry is null)
             {
-                return new(x => x.InvalidOciArtifactModuleAliasRegistryNullOrUndefined(aliasName, this.configurationPath));
+                return new(x => x.InvalidOciArtifactModuleAliasRegistryNullOrUndefined(aliasName, configFileUri));
             }
 
             return new(alias);

--- a/src/Bicep.Core/Configuration/ProviderAliasesConfiguration.cs
+++ b/src/Bicep.Core/Configuration/ProviderAliasesConfiguration.cs
@@ -34,14 +34,14 @@ namespace Bicep.Core.Configuration
 
     public partial class ProviderAliasesConfiguration : ConfigurationSection<ProviderAliases>
     {
-        private readonly string? configurationPath;
+        private readonly Uri? configFileUri;
 
-        private ProviderAliasesConfiguration(ProviderAliases data, string? configurationPath)
+        private ProviderAliasesConfiguration(ProviderAliases data, Uri? configFileUri)
             : base(data)
         {
-            this.configurationPath = configurationPath;
+            this.configFileUri = configFileUri;
         }
-        public static ProviderAliasesConfiguration Bind(JsonElement element, string? configurationPath) => new(element.ToNonNullObject<ProviderAliases>(), configurationPath);
+        public static ProviderAliasesConfiguration Bind(JsonElement element, Uri? configFileUri) => new(element.ToNonNullObject<ProviderAliases>(), configFileUri);
 
         public ImmutableSortedDictionary<string, OciArtifactProviderAlias> GetOciArtifactProviderAliases()
         {
@@ -57,12 +57,12 @@ namespace Bicep.Core.Configuration
 
             if (!this.Data.OciArtifactProviderAliases.TryGetValue(aliasName, out var alias))
             {
-                return new(x => x.OciArtifactProviderAliasNameDoesNotExistInConfiguration(aliasName, this.configurationPath));
+                return new(x => x.OciArtifactProviderAliasNameDoesNotExistInConfiguration(aliasName, configFileUri));
             }
 
             if (alias.Registry is null)
             {
-                return new(x => x.InvalidOciArtifactProviderAliasRegistryNullOrUndefined(aliasName, this.configurationPath));
+                return new(x => x.InvalidOciArtifactProviderAliasRegistryNullOrUndefined(aliasName, configFileUri));
             }
 
             return new(alias);

--- a/src/Bicep.Core/Configuration/ProviderAliasesConfigurationExtensions.cs
+++ b/src/Bicep.Core/Configuration/ProviderAliasesConfigurationExtensions.cs
@@ -25,7 +25,7 @@ public static class ProviderAliasesConfigurationExtensions
             rootConfiguration.CacheRootDirectory,
             rootConfiguration.ExperimentalFeaturesEnabled,
             rootConfiguration.Formatting,
-            rootConfiguration.ConfigurationPath,
+            rootConfiguration.ConfigFileUri,
             rootConfiguration.DiagnosticBuilders);
     }
 }

--- a/src/Bicep.Core/Configuration/RootConfiguration.cs
+++ b/src/Bicep.Core/Configuration/RootConfiguration.cs
@@ -35,7 +35,7 @@ namespace Bicep.Core.Configuration
             string? cacheRootDirectory,
             ExperimentalFeaturesEnabled experimentalFeaturesEnabled,
             FormattingConfiguration formatting,
-            string? configurationPath,
+            Uri? configFileUri,
             IEnumerable<DiagnosticBuilder.DiagnosticBuilderDelegate>? diagnosticBuilders)
         {
             this.Cloud = cloud;
@@ -45,21 +45,21 @@ namespace Bicep.Core.Configuration
             this.CacheRootDirectory = ExpandCacheRootDirectory(cacheRootDirectory);
             this.ExperimentalFeaturesEnabled = experimentalFeaturesEnabled;
             this.Formatting = formatting;
-            this.ConfigurationPath = configurationPath;
+            this.ConfigFileUri = configFileUri;
             this.DiagnosticBuilders = diagnosticBuilders?.ToImmutableArray() ?? ImmutableArray<DiagnosticBuilder.DiagnosticBuilderDelegate>.Empty;
         }
 
-        public static RootConfiguration Bind(JsonElement element, string? configurationPath = null, IEnumerable<DiagnosticBuilder.DiagnosticBuilderDelegate>? diagnosticBuilders = null)
+        public static RootConfiguration Bind(JsonElement element, Uri? configFileUri = null, IEnumerable<DiagnosticBuilder.DiagnosticBuilderDelegate>? diagnosticBuilders = null)
         {
-            var cloud = CloudConfiguration.Bind(element.GetProperty(CloudKey), configurationPath);
-            var moduleAliases = ModuleAliasesConfiguration.Bind(element.GetProperty(ModuleAliasesKey), configurationPath);
-            var providerAliases = ProviderAliasesConfiguration.Bind(element.GetProperty(ProviderAliasesKey), configurationPath);
+            var cloud = CloudConfiguration.Bind(element.GetProperty(CloudKey));
+            var moduleAliases = ModuleAliasesConfiguration.Bind(element.GetProperty(ModuleAliasesKey), configFileUri);
+            var providerAliases = ProviderAliasesConfiguration.Bind(element.GetProperty(ProviderAliasesKey), configFileUri);
             var analyzers = new AnalyzersConfiguration(element.GetProperty(AnalyzersKey));
             var cacheRootDirectory = element.TryGetProperty(CacheRootDirectoryKey, out var e) ? e.GetString() : default;
             var experimentalFeaturesEnabled = ExperimentalFeaturesEnabled.Bind(element.GetProperty(ExperimentalFeaturesEnabledKey));
             var formatting = FormattingConfiguration.Bind(element.GetProperty(FormattingKey));
 
-            return new(cloud, moduleAliases, providerAliases, analyzers, cacheRootDirectory, experimentalFeaturesEnabled, formatting, configurationPath, diagnosticBuilders);
+            return new(cloud, moduleAliases, providerAliases, analyzers, cacheRootDirectory, experimentalFeaturesEnabled, formatting, configFileUri, diagnosticBuilders);
         }
 
         public CloudConfiguration Cloud { get; }
@@ -76,11 +76,11 @@ namespace Bicep.Core.Configuration
 
         public FormattingConfiguration Formatting { get; }
 
-        public string? ConfigurationPath { get; }
+        public Uri? ConfigFileUri { get; }
 
         public ImmutableArray<DiagnosticBuilder.DiagnosticBuilderDelegate> DiagnosticBuilders { get; }
 
-        public bool IsBuiltIn => ConfigurationPath is null;
+        public bool IsBuiltIn => ConfigFileUri is null;
 
         public string ToUtf8Json()
         {

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -70,8 +70,8 @@ namespace Bicep.Core.Diagnostics
                 ? $"The Template Spec reference \"{referenceValue}\" after resolving alias \"{aliasName}\" is not valid."
                 : $"The specified Template Spec reference \"{referenceValue}\" is not valid.";
 
-            private static string BuildBicepConfigurationClause(string? configurationPath) => configurationPath is not null
-                ? $"Bicep configuration \"{configurationPath}\""
+            private static string BuildBicepConfigurationClause(Uri? configFileUri) => configFileUri is not null
+                ? $"Bicep configuration \"{configFileUri.LocalPath}\""
                 : $"built-in Bicep configuration";
 
             public ErrorDiagnostic UnrecognizedToken(string token) => new(
@@ -1274,30 +1274,30 @@ namespace Bicep.Core.Diagnostics
                 "BCP211",
                 $"The module alias name \"{aliasName}\" is invalid. Valid characters are alphanumeric, \"_\", or \"-\".");
 
-            public ErrorDiagnostic TemplateSpecModuleAliasNameDoesNotExistInConfiguration(string aliasName, string? configurationPath) => new(
+            public ErrorDiagnostic TemplateSpecModuleAliasNameDoesNotExistInConfiguration(string aliasName, Uri? configFileUri) => new(
                 TextSpan,
                 "BCP212",
-                $"The Template Spec module alias name \"{aliasName}\" does not exist in the {BuildBicepConfigurationClause(configurationPath)}.");
+                $"The Template Spec module alias name \"{aliasName}\" does not exist in the {BuildBicepConfigurationClause(configFileUri)}.");
 
-            public ErrorDiagnostic OciArtifactModuleAliasNameDoesNotExistInConfiguration(string aliasName, string? configurationPath) => new(
+            public ErrorDiagnostic OciArtifactModuleAliasNameDoesNotExistInConfiguration(string aliasName, Uri? configFileUri) => new(
                 TextSpan,
                 "BCP213",
-                $"The OCI artifact module alias name \"{aliasName}\" does not exist in the {BuildBicepConfigurationClause(configurationPath)}.");
+                $"The OCI artifact module alias name \"{aliasName}\" does not exist in the {BuildBicepConfigurationClause(configFileUri)}.");
 
-            public ErrorDiagnostic InvalidTemplateSpecAliasSubscriptionNullOrUndefined(string aliasName, string? configurationPath) => new(
+            public ErrorDiagnostic InvalidTemplateSpecAliasSubscriptionNullOrUndefined(string aliasName, Uri? configFileUri) => new(
                 TextSpan,
                 "BCP214",
-                $"The Template Spec module alias \"{aliasName}\" in the {BuildBicepConfigurationClause(configurationPath)} is in valid. The \"subscription\" property cannot be null or undefined.");
+                $"The Template Spec module alias \"{aliasName}\" in the {BuildBicepConfigurationClause(configFileUri)} is in valid. The \"subscription\" property cannot be null or undefined.");
 
-            public ErrorDiagnostic InvalidTemplateSpecAliasResourceGroupNullOrUndefined(string aliasName, string? configurationPath) => new(
+            public ErrorDiagnostic InvalidTemplateSpecAliasResourceGroupNullOrUndefined(string aliasName, Uri? configFileUri) => new(
                 TextSpan,
                 "BCP215",
-                $"The Template Spec module alias \"{aliasName}\" in the {BuildBicepConfigurationClause(configurationPath)} is in valid. The \"resourceGroup\" property cannot be null or undefined.");
+                $"The Template Spec module alias \"{aliasName}\" in the {BuildBicepConfigurationClause(configFileUri)} is in valid. The \"resourceGroup\" property cannot be null or undefined.");
 
-            public ErrorDiagnostic InvalidOciArtifactModuleAliasRegistryNullOrUndefined(string aliasName, string? configurationPath) => new(
+            public ErrorDiagnostic InvalidOciArtifactModuleAliasRegistryNullOrUndefined(string aliasName, Uri? configFileUri) => new(
                 TextSpan,
                 "BCP216",
-                $"The OCI artifact module alias \"{aliasName}\" in the {BuildBicepConfigurationClause(configurationPath)} is invalid. The \"registry\" property cannot be null or undefined.");
+                $"The OCI artifact module alias \"{aliasName}\" in the {BuildBicepConfigurationClause(configFileUri)} is invalid. The \"registry\" property cannot be null or undefined.");
 
             public ErrorDiagnostic InvalidTemplateSpecReferenceInvalidSubscirptionId(string? aliasName, string subscriptionId, string referenceValue) => new(
                 TextSpan,
@@ -2059,15 +2059,15 @@ namespace Bicep.Core.Diagnostics
                 "BCP377",
                 $"The provider alias name \"{aliasName}\" is invalid. Valid characters are alphanumeric, \"_\", or \"-\".");
 
-            public ErrorDiagnostic InvalidOciArtifactProviderAliasRegistryNullOrUndefined(string aliasName, string? configurationPath) => new(
+            public ErrorDiagnostic InvalidOciArtifactProviderAliasRegistryNullOrUndefined(string aliasName, Uri? configFileUri) => new(
                 TextSpan,
                 "BCP378",
-                $"The OCI artifact provider alias \"{aliasName}\" in the {BuildBicepConfigurationClause(configurationPath)} is invalid. The \"registry\" property cannot be null or undefined.");
+                $"The OCI artifact provider alias \"{aliasName}\" in the {BuildBicepConfigurationClause(configFileUri)} is invalid. The \"registry\" property cannot be null or undefined.");
 
-            public ErrorDiagnostic OciArtifactProviderAliasNameDoesNotExistInConfiguration(string aliasName, string? configurationPath) => new(
+            public ErrorDiagnostic OciArtifactProviderAliasNameDoesNotExistInConfiguration(string aliasName, Uri? configFileUri) => new(
                 TextSpan,
                 "BCP379",
-                $"The OCI artifact provider alias name \"{aliasName}\" does not exist in the {BuildBicepConfigurationClause(configurationPath)}.");
+                $"The OCI artifact provider alias name \"{aliasName}\" does not exist in the {BuildBicepConfigurationClause(configFileUri)}.");
 
             public ErrorDiagnostic UnsupportedArtifactType(ArtifactType artifactType) => new(
                 TextSpan,

--- a/src/Bicep.Core/Semantics/SemanticModel.cs
+++ b/src/Bicep.Core/Semantics/SemanticModel.cs
@@ -188,9 +188,9 @@ namespace Bicep.Core.Semantics
                 sb.Append($"Experimental features enabled: {string.Join(',', experimentalFeatures)}. ");
             }
 
-            if (configuration.ConfigurationPath is { } configPath)
+            if (configuration.ConfigFileUri is { } configFileUri)
             {
-                sb.Append($"Using bicepConfig from path {configPath}.");
+                sb.Append($"Using bicepConfig from {configFileUri}.");
             }
             else
             {

--- a/src/Bicep.LangServer/Handlers/BicepCodeActionHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepCodeActionHandler.cs
@@ -116,7 +116,7 @@ namespace Bicep.LanguageServer.Handlers
                         analyzerDiagnostic.Span.ContainsInclusive(requestEndOffset) ||
                         (requestStartOffset <= analyzerDiagnostic.Span.Position && analyzerDiagnostic.GetEndPosition() <= requestEndOffset))
                     .OfType<AnalyzerDiagnostic>()
-                    .Select(analyzerDiagnostic => CreateEditLinterRuleAction(documentUri, analyzerDiagnostic.Code, semanticModel.Configuration.ConfigurationPath));
+                    .Select(analyzerDiagnostic => CreateEditLinterRuleAction(documentUri, analyzerDiagnostic.Code, semanticModel.Configuration.ConfigFileUri?.LocalPath));
                 commandOrCodeActions.AddRange(editLinterRuleActions);
             }
 


### PR DESCRIPTION
* Add type information to JSONRPC `bicep/getMetadata` parameters & outputs
* Add new method `bicep/getFileReferences` to obtain a list of files that are referenced by a given file.
* Set up tracing so that `BICEP_TRACING_ENABLED` configures verbose JSONRPC logging
* Add JSONRPC command documentation.

May help with the implementation for #5715
Closes #12650

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/13051)