### PR TITLE
Fit and finish handling source paths in archive

### DIFF
--- a/src/Bicep.Cli/Commands/PublishCommand.cs
+++ b/src/Bicep.Cli/Commands/PublishCommand.cs
@@ -99,7 +99,7 @@ namespace Bicep.Cli.Commands
 
                 await ioContext.Output.WriteLineAsync(string.Format(CliResources.ExperimentalFeaturesDisclaimerMessage, PublishSourceFeatureName));
 
-                sourcesStream = SourceArchive.PackSourcesIntoStream(compilation.SourceFileGrouping);
+                sourcesStream = SourceArchive.PackSourcesIntoStream(compilation.SourceFileGrouping, features.CacheRootDirectory);
                 Trace.WriteLine("Publishing Bicep module with source");
             }
             else

--- a/src/Bicep.Core.Samples/DataSetsExtensions.cs
+++ b/src/Bicep.Core.Samples/DataSetsExtensions.cs
@@ -158,10 +158,11 @@ namespace Bicep.Core.Samples
             var result = CompilationHelper.Compile(moduleSource);
             if (result.Template is null)
             {
-                throw new InvalidOperationException($"Module {moduleName} failed to procuce a template.");
+                throw new InvalidOperationException($"Module {moduleName} failed to produce a template.");
             }
 
-            BinaryData? sourcesStream = publishSource ? BinaryData.FromStream(SourceArchive.PackSourcesIntoStream(result.Compilation.SourceFileGrouping)) : null;
+            var features = featureProviderFactory.GetFeatureProvider(result.BicepFile.FileUri);
+            BinaryData? sourcesStream = publishSource ? BinaryData.FromStream(SourceArchive.PackSourcesIntoStream(result.Compilation.SourceFileGrouping, features.CacheRootDirectory)) : null;
             await dispatcher.PublishModule(targetReference, BinaryData.FromString(result.Template.ToString()), sourcesStream, documentationUri);
         }
 

--- a/src/Bicep.Core.UnitTests/Assertions/CachedModuleExtensions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/CachedModuleExtensions.cs
@@ -58,7 +58,7 @@ namespace Bicep.Core.UnitTests.Assertions
 
             if (Subject.HasSourceLayer)
             {
-                expectedFiles.Add("source.tar.gz");
+                expectedFiles.Add("source.tgz");
             }
 
             var files = new DirectoryInfo(Subject.ModuleCacheFolder).EnumerateFiles().Select(file => file.Name).ToImmutableArray();

--- a/src/Bicep.Core.UnitTests/Registry/CachedModules.cs
+++ b/src/Bicep.Core.UnitTests/Registry/CachedModules.cs
@@ -84,7 +84,7 @@ public record CachedModule(
 
     public ResultWithException<SourceArchive> TryGetSource()
     {
-        var sourceArchivePath = Path.Combine(ModuleCacheFolder, $"source.tar.gz");
+        var sourceArchivePath = Path.Combine(ModuleCacheFolder, $"source.tgz");
         if (File.Exists(sourceArchivePath))
         {
             return SourceArchive.UnpackFromStream(File.OpenRead(sourceArchivePath));

--- a/src/Bicep.Core.UnitTests/Registry/OciModuleRegistryTests.cs
+++ b/src/Bicep.Core.UnitTests/Registry/OciModuleRegistryTests.cs
@@ -662,7 +662,7 @@ namespace Bicep.Core.UnitTests.Registry
             if (publishSource)
             {
                 var uri = new Uri("file://path/to/bicep.bicep", UriKind.Absolute);
-                var stream = SourceArchive.PackSourcesIntoStream(uri, new ISourceFile[] { SourceFileFactory.CreateBicepFile(uri, "// contents") });
+                var stream = SourceArchive.PackSourcesIntoStream(uri, cacheRoot: null, new ISourceFile[] { SourceFileFactory.CreateBicepFile(uri, "// contents") });
                 sources = BinaryData.FromStream(stream);
             }
 
@@ -684,8 +684,7 @@ namespace Bicep.Core.UnitTests.Registry
 
             if (sources is { })
             {
-                actualSourceResult.TryUnwrap().Should().NotBeNull();
-                actualSourceResult.Unwrap().Should().BeEquivalentTo(SourceArchive.UnpackFromStream(sources.ToStream()).Unwrap());
+                actualSourceResult.UnwrapOrThrow().Should().BeEquivalentTo(SourceArchive.UnpackFromStream(sources.ToStream()).UnwrapOrThrow());
             }
             else
             {

--- a/src/Bicep.Core.UnitTests/Registry/SourceArchiveTests.cs
+++ b/src/Bicep.Core.UnitTests/Registry/SourceArchiveTests.cs
@@ -482,7 +482,7 @@ public class SourceArchiveTests
     {
         var zip = CreateGzippedTarredFileStream(
             (
-                "metadata.json",
+                "__metadata.json",
                 @"
                 {
                   ""metadataVersion"": 1,
@@ -520,7 +520,7 @@ public class SourceArchiveTests
         // OLD FILE VERSIONS WITH MINIMAL DATA
         var zip = CreateGzippedTarredFileStream(
             (
-                "metadata.json",
+                "__metadata.json",
                 @"
                 {
                   ""entryPoint"": ""main.bicep"",
@@ -554,7 +554,7 @@ public class SourceArchiveTests
     {
         var zip = CreateGzippedTarredFileStream(
             (
-                "metadata.json",
+                "__metadata.json",
                 @"
                 {
                   ""entryPoint"": ""main.bicep"",
@@ -598,7 +598,7 @@ public class SourceArchiveTests
     {
         var zip = CreateGzippedTarredFileStream(
             (
-                "metadata.json",
+                "__metadata.json",
                 @"
                 {
                   ""entryPoint"": ""file:///main.bicep"",
@@ -630,7 +630,7 @@ public class SourceArchiveTests
     {
         var zip = CreateGzippedTarredFileStream(
             (
-                "metadata.json",
+                "__metadata.json",
                 @"
                 {
                   ""entryPoint"": ""file:///main.bicep"",

--- a/src/Bicep.Core.UnitTests/Registry/SourceArchiveTests.cs
+++ b/src/Bicep.Core.UnitTests/Registry/SourceArchiveTests.cs
@@ -5,6 +5,7 @@ using System.Formats.Tar;
 using System.IO.Abstractions.TestingHelpers;
 using System.IO.Compression;
 using System.Text;
+using Bicep.Core.FileSystem;
 using Bicep.Core.SourceCode;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Utils;
@@ -13,6 +14,7 @@ using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.WindowsAzure.ResourceStack.Common.Extensions;
 using OmniSharp.Extensions.LanguageServer.Protocol;
+using static Microsoft.SRM.DecisionTree;
 
 namespace Bicep.Core.UnitTests.SourceCode;
 
@@ -20,6 +22,14 @@ namespace Bicep.Core.UnitTests.SourceCode;
 public class SourceArchiveTests
 {
     public TestContext? TestContext { get; set; }
+
+    string CacheRoot = $"{ROOT}Users/username/.bicep";
+
+#if WINDOWS_BUILD
+    private const string ROOT = "c:\\";
+#else
+    private const string ROOT = "/";
+#endif
 
     private const string MainDotBicepSource = @"
         targetScope = 'subscription'
@@ -131,7 +141,7 @@ public class SourceArchiveTests
     [TestMethod]
     public void CanPackAndUnpackSourceFiles()
     {
-        Uri projectFolder = new("file:///my project/my sources/", UriKind.Absolute);
+        Uri projectFolder = new($"file://{ROOT}my project/my sources/", UriKind.Absolute);
         var fs = new MockFileSystem();
         fs.AddDirectory(projectFolder.LocalPath);
 
@@ -141,146 +151,326 @@ public class SourceArchiveTests
         var templateSpecMainJson = CreateSourceFile(fs, projectFolder, "Main template.json", SourceArchive.SourceKind_TemplateSpec, TemplateSpecJsonSource);
         var localModuleJson = CreateSourceFile(fs, projectFolder, "localModule.json", SourceArchive.SourceKind_ArmTemplate, LocalModuleDotJsonSource);
 
-        using var stream = SourceArchive.PackSourcesIntoStream(mainBicep.FileUri, mainBicep, mainJson, standaloneJson, templateSpecMainJson, localModuleJson);
+        using var stream = SourceArchive.PackSourcesIntoStream(mainBicep.FileUri, CacheRoot, mainBicep, mainJson, standaloneJson, templateSpecMainJson, localModuleJson);
         stream.Length.Should().BeGreaterThan(0);
 
-        SourceArchive? sourceArchive = SourceArchive.UnpackFromStream(stream).TryUnwrap();
-        sourceArchive.Should().NotBeNull();
+        SourceArchive? sourceArchive = SourceArchive.UnpackFromStream(stream).UnwrapOrThrow();
         sourceArchive!.EntrypointRelativePath.Should().Be("main.bicep");
 
 
         var archivedFiles = sourceArchive.SourceFiles.ToArray();
         archivedFiles.Should().BeEquivalentTo(
             new SourceArchive.SourceFileInfo[] {
-                new ("main.bicep", "main.bicep", SourceArchive.SourceKind_Bicep, MainDotBicepSource),
-                new ("main.json", "main.json", SourceArchive.SourceKind_ArmTemplate, MainDotJsonSource ),
-                new ("standalone.json", "standalone.json", SourceArchive.SourceKind_ArmTemplate, StandaloneJsonSource),
-                new ("Main template.json", "Main template.json", SourceArchive.SourceKind_TemplateSpec,  TemplateSpecJsonSource),
-                new ("localModule.json", "localModule.json", SourceArchive.SourceKind_ArmTemplate,  LocalModuleDotJsonSource),
+                new ("main.bicep", "files/main.bicep", SourceArchive.SourceKind_Bicep, MainDotBicepSource),
+                new ("main.json", "files/main.json", SourceArchive.SourceKind_ArmTemplate, MainDotJsonSource ),
+                new ("standalone.json", "files/standalone.json", SourceArchive.SourceKind_ArmTemplate, StandaloneJsonSource),
+                new ("Main template.json", "files/Main template.json", SourceArchive.SourceKind_TemplateSpec,  TemplateSpecJsonSource),
+                new ("localModule.json", "files/localModule.json", SourceArchive.SourceKind_ArmTemplate,  LocalModuleDotJsonSource),
             });
     }
 
     [TestMethod]
     public void CanPackAndUnpackDocumentLinks()
     {
-        Uri projectFolder = new("file:///my project/my sources/", UriKind.Absolute);
+        Uri projectFolder = new($"file://{ROOT}my project/my sources/", UriKind.Absolute);
         var fs = new MockFileSystem();
         fs.AddDirectory(projectFolder.LocalPath);
-
-        var mainBicep = CreateSourceFile(fs, projectFolder, "main.bicep", SourceArchive.SourceKind_Bicep, MainDotBicepSource);
+        var mainBicep = CreateSourceFile(fs, projectFolder, "main&.bicep", SourceArchive.SourceKind_Bicep, MainDotBicepSource);
         var mainJson = CreateSourceFile(fs, projectFolder, "main.json", SourceArchive.SourceKind_ArmTemplate, MainDotJsonSource);
         var standaloneJson = CreateSourceFile(fs, projectFolder, "standalone.json", SourceArchive.SourceKind_ArmTemplate, StandaloneJsonSource);
         var templateSpecMainJson = CreateSourceFile(fs, projectFolder, "Main template.json", SourceArchive.SourceKind_TemplateSpec, TemplateSpecJsonSource);
-        var localModuleJson = CreateSourceFile(fs, projectFolder, "localModule.json", SourceArchive.SourceKind_ArmTemplate, LocalModuleDotJsonSource);
+        var localModuleJson = CreateSourceFile(fs, projectFolder, "modules/localJsonModule.json", SourceArchive.SourceKind_ArmTemplate, LocalModuleDotJsonSource);
+        var localModuleBicep = CreateSourceFile(fs, projectFolder, "modules/localBicepModule.bicep", SourceArchive.SourceKind_ArmTemplate, LocalModuleDotJsonSource);
 
-        var dict = new Dictionary<Uri, SourceCodeDocumentUriLink[]>()
+        var linksInput = new Dictionary<Uri, SourceCodeDocumentUriLink[]>()
         {
             {
-                new Uri("file:///my project/my sources/main.bicep", UriKind.Absolute),
+                new Uri($"file://{ROOT}my project/my sources/main&.bicep", UriKind.Absolute),
                 new SourceCodeDocumentUriLink[]
                 {
-                    new(new SourceCodeRange(1, 2, 1, 3), new Uri("file:///my project/my sources/modules/module1.bicep", UriKind.Absolute)),
+                    new(new SourceCodeRange(1, 2, 1, 3), new Uri($"file://{ROOT}my project/my sources/modules/localJsonModule.json", UriKind.Absolute)),
+                    new(new SourceCodeRange(11, 2, 11, 3), new Uri($"file://{ROOT}my project/my sources/modules/localBicepModule.bicep", UriKind.Absolute)),
                 }
             },
             {
-                new Uri("file:///my project/my sources/modules/module1.bicep", UriKind.Absolute),
+                new Uri($"file://{ROOT}my project/my sources/modules/localBicepModule.bicep", UriKind.Absolute),
                 new SourceCodeDocumentUriLink[]
                 {
-                    new(new SourceCodeRange(123, 124, 234, 235), new Uri("file:///my project/my sources/main.bicep", UriKind.Absolute)),
-                    new(new SourceCodeRange(234, 235, 345, 346), new Uri("file:///my project/my sources/remote/main.json", UriKind.Absolute)),
-                    new(new SourceCodeRange(123, 456, 234, 567), new Uri("file:///my project/my sources/main.bicep", UriKind.Absolute)),
+                    new(new SourceCodeRange(123, 124, 234, 235), new Uri($"file://{ROOT}my project/my sources/main&.bicep", UriKind.Absolute)),
+                    new(new SourceCodeRange(234, 235, 345, 346), new Uri($"file://{ROOT}my project/my sources/main.json", UriKind.Absolute)),
+                    new(new SourceCodeRange(123, 456, 234, 567), new Uri($"file://{ROOT}my project/my sources/main&.bicep", UriKind.Absolute)),
+                    new(new SourceCodeRange(345, 2, 345, 3), new Uri($"file://{ROOT}my project/my sources/modules/localJsonModule.json", UriKind.Absolute)),
                 }
             },
         };
-
-        using var stream = SourceArchive.PackSourcesIntoStream(mainBicep.FileUri, dict, mainBicep, mainJson, standaloneJson, templateSpecMainJson, localModuleJson);
+        using var stream = SourceArchive.PackSourcesIntoStream(mainBicep.FileUri, CacheRoot, linksInput, mainBicep, mainJson, standaloneJson, templateSpecMainJson, localModuleJson, localModuleBicep);
         stream.Length.Should().BeGreaterThan(0);
 
         SourceArchive? sourceArchive = SourceArchive.UnpackFromStream(stream).TryUnwrap();
         sourceArchive.Should().NotBeNull();
 
-        var links = sourceArchive!.DocumentLinks;
+        var archivedLinks = sourceArchive!.DocumentLinks;
 
         var expected = new Dictionary<string, SourceCodeDocumentPathLink[]>()
         {
             {
-                "main.bicep",
+                "main&.bicep",
                 new SourceCodeDocumentPathLink[]
                 {
-                    new(new SourceCodeRange(1, 2, 1, 3), "modules/module1.bicep"),
+                    new(new SourceCodeRange(1, 2, 1, 3), "modules/localJsonModule.json"),
+                    new(new SourceCodeRange(11, 2, 11, 3), "modules/localBicepModule.bicep"),
                 }
             },
             {
-                "modules/module1.bicep",
+                "modules/localBicepModule.bicep",
                 new SourceCodeDocumentPathLink[]
                 {
-                    new(new SourceCodeRange(123, 124, 234, 235), "main.bicep"),
-                    new(new SourceCodeRange(234, 235, 345, 346), "remote/main.json"),
-                    new(new SourceCodeRange(123, 456, 234, 567), "main.bicep"),
+                    new(new SourceCodeRange(123, 124, 234, 235), "main&.bicep"),
+                    new(new SourceCodeRange(234, 235, 345, 346), "main.json"),
+                    new(new SourceCodeRange(123, 456, 234, 567), "main&.bicep"),
+                    new(new SourceCodeRange(345, 2, 345, 3), "modules/localJsonModule.json"),
                 }
             },
         };
 
-        links.Should().BeEquivalentTo(expected);
+        archivedLinks.Should().BeEquivalentTo(expected);
     }
 
-    [DataTestMethod]
     [DataRow(
-        "my other.bicep",
-        "my other.bicep",
+        new string[] { $"{ROOT}my root/my project/my main.bicep", $"{ROOT}my other.bicep" },
+        new string[] { "my root/my project/my main.bicep", "my other.bicep" },
+        new string[] { "files/my root/my project/my main.bicep", "files/my other.bicep" },
         DisplayName = "HandlesPathsCorrectly: spaces")]
     [DataRow(
-        "/my root/my project/sub folder/my other bicep.bicep",
-        "sub folder/my other bicep.bicep",
+        new string[] { $"{ROOT}my root\\my project\\my main.bicep", $"{ROOT}my other.bicep" },
+        new string[] { "my root/my project/my main.bicep", "my other.bicep" },
+        new string[] { "files/my root/my project/my main.bicep", "files/my other.bicep" },
+        DisplayName = "HandlesPathsCorrectly: backslashes")]
+    [DataRow(
+        new string[] { $"{ROOT}my#project\\sub#folder\\my#main.bicep", $"{ROOT}my#project\\my#main.bicep" },
+        new string[] { "sub#folder/my#main.bicep", "my#main.bicep" },
+        new string[] { "files/sub_folder/my_main.bicep", "files/my_main.bicep" },
+        DisplayName = "HandlesPathsCorrectly: #")]
+    [DataRow(
+        new string[] { $"{ROOT}my root\\my project\\my main.bicep", $"{ROOT}my root/my project/sub folder/my other bicep.bicep" },
+        new string[] { "my main.bicep", "sub folder/my other bicep.bicep" },
+        new string[] { "files/my main.bicep", "files/sub folder/my other bicep.bicep" },
         DisplayName = "HandlesPathsCorrectly: subfolder")]
     [DataRow(
-        "/my root/my project/sub folder/sub folder 2/my other bicep.bicep",
-        "sub folder/sub folder 2/my other bicep.bicep",
+        new string[] { $"{ROOT}my main.bicep", $"{ROOT}sub folder\\my other bicep.bicep" },
+        new string[] { "my main.bicep", "sub folder/my other bicep.bicep" },
+        new string[] { "files/my main.bicep", "files/sub folder/my other bicep.bicep" },
+        DisplayName = "HandlesPathsCorrectly: in root")]
+    [DataRow(
+        new string[] { $"{ROOT}my root/my project/my main.bicep", $"{ROOT}my root/my project/sub folder/sub folder 2/my other bicep.bicep" },
+        new string[] { "my main.bicep", "sub folder/sub folder 2/my other bicep.bicep" },
+        new string[] { "files/my main.bicep", "files/sub folder/sub folder 2/my other bicep.bicep" },
         DisplayName = "HandlesPathsCorrectly: sub-subfolder")]
     [DataRow(
-        "/my root/my other bicep.bicep",
-        "../my other bicep.bicep",
-        DisplayName = "HandlesPathsCorrectly: ..")]
+        new string[] { $"{ROOT}my root/my project/my main.bicep", $"{ROOT}my root/my other bicep.bicep" },
+        new string[] { "my project/my main.bicep", "my other bicep.bicep" },
+        new string[] { "files/my project/my main.bicep", "files/my other bicep.bicep" },
+        DisplayName = "HandlesPathsCorrectly: main.bicep in subfolder")]
     [DataRow(
-        "/my other bicep.bicep",
-        "../../my other bicep.bicep",
-        DisplayName = "HandlesPathsCorrectly: ../..")]
+        new string[] { $"{ROOT}my root/folder1/folder2/my main.bicep", $"{ROOT}my root/my other bicep.bicep" },
+        new string[] { "folder1/folder2/my main.bicep", "my other bicep.bicep" },
+        new string[] { "files/folder1/folder2/my main.bicep", "files/my other bicep.bicep" },
+        DisplayName = "HandlesPathsCorrectly: main.bicep in sub-subfolder")]
     [DataRow(
-        "/folder/my other bicep.bicep",
-        "../../folder/my other bicep.bicep",
-        DisplayName = "HandlesPathsCorrectly: ../../folder")]
+        new string[] { $"{ROOT}my root/my project/my main.bicep", $"{ROOT}my root/my other project/my other bicep.bicep" },
+        new string[] { "my main.bicep", "<root2>/my other bicep.bicep" },
+        new string[] { "files/my main.bicep", "files/_root2_/my other bicep.bicep" },
+        DisplayName = "HandlesPathsCorrectly: main.bicep in different folder")]
     [DataRow(
-        "/my root/my project/my other bicep.bicep",
-        "my other bicep.bicep",
-        DisplayName = "HandlesPathsCorrectly: separate drives")]
+        new string[] { $"{ROOT}folder1/my project/my main.bicep", $"{ROOT}folder2/my other project/my other bicep.bicep", $"{ROOT}folder2/my other project 2/my other bicep.bicep" },
+        new string[] { "my main.bicep", "<root2>/my other bicep.bicep", "<root3>/my other bicep.bicep" },
+        new string[] { "files/my main.bicep", "files/_root2_/my other bicep.bicep", "files/_root3_/my other bicep.bicep" },
+        DisplayName = "HandlesPathsCorrectly: 3 roots")]
+    [DataRow(
+        new string[] { $"{ROOT}repos/bicep/deployment/my main.bicep", $"{ROOT}repos/bicep/deployment/subfolder1/module1.bicep", $"{ROOT}repos/bicep/deployment/subfolder2/module2.bicep" },
+        new string[] { "my main.bicep", "subfolder1/module1.bicep", "subfolder2/module2.bicep" },
+        new string[] { "files/my main.bicep", "files/subfolder1/module1.bicep", "files/subfolder2/module2.bicep" },
+        DisplayName = "HandlesPathsCorrectly: Two subfolders")]
+    [DataRow(
+        new string[] { $"{ROOT}repos/bicep/my main.bicep", $"{ROOT}repos/bicep/..deployment../subfolder1/..module1..bicep" },
+        new string[] { "my main.bicep", "..deployment../subfolder1/..module1..bicep" },
+        new string[] { "files/my main.bicep", "files/..deployment../subfolder1/..module1..bicep" },
+        DisplayName = "HandlesPathsCorrectly: .. in names")]
+    [DataRow(
+        new string[] { $"{ROOT}my root/my project/my main bicep.bicep", $"{ROOT}my other root/my project/my other bicep.bicep" },
+        new string[] { "my main bicep.bicep", "<root2>/my other bicep.bicep" },
+        new string[] { "files/my main bicep.bicep", "files/_root2_/my other bicep.bicep" },
+        DisplayName = "HandlesPathsCorrectly: no folders in common")]
+#if WINDOWS_BUILD
+    [DataRow(
+        // This shouldn't ever happen, with the exception of when the cache root path is on another drive, because local module
+        // files must be relative to the referencing file.
+        new string[] { "c:\\my root\\my project\\my main.bicep", "d:\\my root\\my project\\my other bicep.bicep" },
+        new string[] { "my main.bicep", "<root2>/my other bicep.bicep" },
+        new string[] { "files/my main.bicep", "files/_root2_/my other bicep.bicep" },
+        DisplayName = "HandlesPathsCorrectly: separate drives on Windows")]
+    [DataRow(
+        new string[] { "c:\\my ROOT\\my project\\my main.bicep", "C:\\My root\\My project\\My main 2.bicep", },
+        new string[] { "my main.bicep", "My main 2.bicep" },
+        new string[] { "files/my main.bicep", "files/My main 2.bicep" },
+        DisplayName = "HandlesPathsCorrectly: case insensitive on Windows 2")]
+    [DataRow(
+        new string[] { "c:\\my ROOT\\my Project\\sub Folder\\my main.bicep", "C:\\My root\\My project\\My main 2.bicep", "C:\\My root\\My project 2\\My main 2.bicep", },
+        new string[] { "sub Folder/my main.bicep", "My main 2.bicep", "<root2>/My main 2.bicep" },
+        new string[] { "files/sub Folder/my main.bicep", "files/My main 2.bicep", "files/_root2_/My main 2.bicep" },
+        DisplayName = "HandlesPathsCorrectly: case insensitive on Windows 3")]
+    [DataRow(
+        new string[] { "c:\\Deployment/a.txt", "c:\\deployment/b&.txt", "c:\\Deployment/B_.txt", },
+        new string[] { "a.txt", "b&.txt", "B_.txt" },
+        new string[] { "files/a.txt", "files/b_.txt", "files/B_.txt(2)" },
+        DisplayName = "HandlesPathsCorrectly: case insensitive on Windows 4")]
+#endif
+    [DataRow(
+        new string[] {
+            $"{ROOT}my root/my project/my main.bicep",
+            $"{ROOT}Users/username/.bicep/br/mcr.microsoft.com/bicep$storage$storage-account/1.0.1$/main.json" },
+        new string[] { "my main.bicep", "<cache>/br/mcr.microsoft.com/bicep$storage$storage-account/1.0.1$/main.json" },
+        new string[] { "files/my main.bicep", "files/_cache_/br/mcr.microsoft.com/bicep$storage$storage-account/1.0.1$/main.json" },
+        DisplayName = "HandlesPathsCorrectly: external module (in cache)")]
+    [DataRow(
+        new string[] {
+            $"{ROOT}my root/my project/my main.bicep",
+            $"{ROOT}Users/username/.bicep/br/mcr.microsoft.com/bicep$storage$storage-account/1.0.1$/main.json",
+            $"{ROOT}Users/username/.bicep/br/mcr.microsoft.com/bicep$storage$storage-account/1.0.2$/main.json",
+            $"{ROOT}Users/username/.bicep/br/mcr.microsoft.com/bicep$compute$virtual-machine/1.0.1$/main.json" },
+        new string[] {
+            "my main.bicep",
+            "<cache>/br/mcr.microsoft.com/bicep$storage$storage-account/1.0.1$/main.json",
+            "<cache>/br/mcr.microsoft.com/bicep$storage$storage-account/1.0.2$/main.json",
+            "<cache>/br/mcr.microsoft.com/bicep$compute$virtual-machine/1.0.1$/main.json",
+        },
+        new string[] {
+            "files/my main.bicep",
+            "files/_cache_/br/mcr.microsoft.com/bicep$storage$storage-account/1.0.1$/main.json",
+            "files/_cache_/br/mcr.microsoft.com/bicep$storage$storage-account/1.0.2$/main.json",
+            "files/_cache_/br/mcr.microsoft.com/bicep$compute$virtual-machine/1.0.1$/main.json",
+        },
+        DisplayName = "HandlesPathsCorrectly: multiple external modules (in cache)")]
+    [DataRow(
+        new string[] { $"{ROOT}my & root/my&main.bicep", $"{ROOT}my & root/my [&] mainProject/my &[] main.bicep" },
+        new string[] { "my&main.bicep", "my [&] mainProject/my &[] main.bicep" },
+        new string[] { "files/my_main.bicep", "files/my ___ mainProject/my ___ main.bicep" },
+        DisplayName = "HandlesPathsCorrectly:  Characters to avoid")]
+    [DataRow(
+        new string[] { $"{ROOT}ποταμός/Fluß im Regen.bicep", $"{ROOT}my other root/אמא שלי/אבא שלי.bicep" },
+        new string[] { "Fluß im Regen.bicep", "<root2>/אבא שלי.bicep" },
+        new string[] { "files/Fluß im Regen.bicep", "files/_root2_/אבא שלי.bicep" },
+        DisplayName = "HandlesPathsCorrectly:  International characters")]
+    [DataTestMethod]
     public void HandlesPathsCorrectly(
-        string pathRelativeToMainBicepLocation,
-        string expecteArchivedUri,
-        string? expecteArchivePath = null)
+        string[] inputPaths,
+        string[] expectedPaths,
+        string[] expectedArchivePaths
+    )
     {
-        string mainBicepPath = MockUnixSupport.Path("c:/my root/my project/my main.bicep");
-        expecteArchivePath ??= expecteArchivedUri;
-
-        Uri entrypointUri = DocumentUri.FromFileSystemPath(mainBicepPath).ToUriEncoded();
         var fs = new MockFileSystem();
 
-        var mainBicepFolder = new Uri(Path.GetDirectoryName(mainBicepPath)! + "/", UriKind.Absolute);
-        fs.AddDirectory(mainBicepFolder.LocalPath);
+        var entrypointPath = inputPaths[0];
 
-        var mainBicep = CreateSourceFile(fs, mainBicepFolder, Path.GetFileName(mainBicepPath), SourceArchive.SourceKind_Bicep, MainDotBicepSource);
-        var testFile = CreateSourceFile(fs, mainBicepFolder, pathRelativeToMainBicepLocation, SourceArchive.SourceKind_Bicep, SecondaryDotBicepSource);
+        var entrypointFolder = Path.GetDirectoryName(entrypointPath)!;
+        if (entrypointFolder[^1] != '/' && entrypointFolder[^1] != '\\')
+        {
+            entrypointFolder += Path.DirectorySeparatorChar;
+        }
+        var rootBicepFolder = PathHelper.FilePathToFileUrl(entrypointFolder);
+        fs.AddDirectory(rootBicepFolder.LocalPath);
 
-        using var stream = SourceArchive.PackSourcesIntoStream(mainBicep.FileUri, mainBicep, testFile);
+        var files = inputPaths.Select(path => CreateSourceFile(fs, rootBicepFolder, path, SourceArchive.SourceKind_Bicep, $"// {path}")).ToArray();
 
-        SourceArchive? sourceArchive = SourceArchive.UnpackFromStream(stream).TryUnwrap();
+        using var stream = SourceArchive.PackSourcesIntoStream(files[0].FileUri, CacheRoot, files);
+        SourceArchive sourceArchive = SourceArchive.UnpackFromStream(stream).UnwrapOrThrow();
 
-        sourceArchive.Should().NotBeNull();
-        sourceArchive!.EntrypointRelativePath.Should().Be("my main.bicep");
+        sourceArchive.EntrypointRelativePath.Should().Be(expectedPaths[0], "entrypoint path should be correct");
 
-        var archivedTestFile = sourceArchive.SourceFiles.Single(f => f.Path != "my main.bicep");
-        archivedTestFile.Path.Should().Be(expecteArchivedUri);
-        archivedTestFile.ArchivePath.Should().Be(expecteArchivePath);
-        archivedTestFile.Contents.Should().Be(SecondaryDotBicepSource);
+        sourceArchive.EntrypointRelativePath.Should().NotContain("username", "shouldn't have username in source paths");
+        foreach (var file in sourceArchive.SourceFiles)
+        {
+            file.Path.Should().NotContain("username", "shouldn't have username in source paths");
+            file.ArchivePath.Should().NotContain("username", "shouldn't have username in source paths");
+        }
+
+        for (int i = 0; i < inputPaths.Length; ++i)
+        {
+            var archivedTestFile = sourceArchive.SourceFiles.Single(f => f.Contents.Equals(files[i].GetOriginalSource()));
+            archivedTestFile.Path.Should().Be(expectedPaths[i]);
+            archivedTestFile.ArchivePath.Should().Be(expectedArchivePaths[i]);
+        }
+    }
+
+    [DataRow(
+        $"{ROOT}my root/my project/my_.bicep", "my_.bicep", "files/my_.bicep",
+        $"{ROOT}my root/my project/my&.bicep", "my&.bicep", "files/my_.bicep(2)",
+        $"{ROOT}my root/my project/my[.bicep", "my[.bicep", "files/my_.bicep(3)",
+        DisplayName = "DuplicateNamesAfterMunging_ShouldHaveSeparateEntries: &")]
+    [DataRow(
+        $"{ROOT}my root\\my project\\123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789\\a.txt",
+            "123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789/a.txt",
+            "files/123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123__path_too_long__.txt",
+        $"{ROOT}my root\\my project\\123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789\\b.txt",
+            "123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789/b.txt",
+            "files/123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123__path_too_long__.txt(2)",
+        $"{ROOT}my root\\my project\\123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 extra characters here that get truncated\\a.txt",
+            "123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 extra characters here that get truncated/a.txt",
+            "files/123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123__path_too_long__.txt(3)",
+        DisplayName = "DuplicateNamesAfterMunging_ShouldHaveSeparateEntries: truncated")]
+#if WINDOWS_BUILD
+    [DataRow(
+        "c:/my root/my.bicep", "my.bicep", "files/my.bicep",
+        "d:/my root/my project/parent/m&.bicep", "<root2>/m&.bicep", "files/_root2_/m_.bicep",
+        "d:/my root/my project/parent/m[.bicep", "<root2>/m[.bicep", "files/_root2_/m_.bicep(2)",
+        DisplayName = "DuplicateNamesAfterMunging_ShouldHaveSeparateEntries: different drives")]
+#endif
+    [DataTestMethod]
+    public void DuplicateNamesAfterMunging_ShouldHaveSeparateEntries(
+        string inputBicepPath1, string expectedPath1, string expectedArchivePath1, // 1st bicep path, plus its expected path and archive path
+        string inputBicepPath2, string expectedPath2, string expectedArchivePath2, // 2st bicep path, plus its expected path and archive path
+        string? inputBicepPath3 = null, string? expectedPath3 = null, string? expectedArchivePath3 = null  // 3rd bicep path, plus its expected path and archive path
+    )
+    {
+        string entrypointPath = $"{ROOT}my root/my project/my entrypoint.bicep";
+        var fs = new MockFileSystem();
+
+        var rootBicepFolder = new Uri(Path.GetDirectoryName(entrypointPath)! + "/", UriKind.Absolute);
+        fs.AddDirectory(rootBicepFolder.LocalPath);
+
+        var entrypointFile = CreateSourceFile(fs, rootBicepFolder, Path.GetFileName(entrypointPath), SourceArchive.SourceKind_Bicep, MainDotBicepSource);
+        var sutFile1 = CreateSourceFile(fs, rootBicepFolder, inputBicepPath1, SourceArchive.SourceKind_Bicep, SecondaryDotBicepSource);
+        var sutFile2 = CreateSourceFile(fs, rootBicepFolder, inputBicepPath2, SourceArchive.SourceKind_Bicep, SecondaryDotBicepSource);
+        var sutFile3 = inputBicepPath3 is null ? null : CreateSourceFile(fs, rootBicepFolder, inputBicepPath3, SourceArchive.SourceKind_Bicep, SecondaryDotBicepSource);
+
+        using var stream = sutFile3 is null ?
+            SourceArchive.PackSourcesIntoStream(entrypointFile.FileUri, CacheRoot, entrypointFile, sutFile1, sutFile2) :
+            SourceArchive.PackSourcesIntoStream(entrypointFile.FileUri, CacheRoot, entrypointFile, sutFile1, sutFile2, sutFile3);
+
+        SourceArchive sourceArchive = SourceArchive.UnpackFromStream(stream).UnwrapOrThrow();
+
+        var archivedFile1 = sourceArchive.SourceFiles.SingleOrDefault(f => f.Path == expectedPath1);
+        var archivedFile2 = sourceArchive.SourceFiles.SingleOrDefault(f => f.Path == expectedPath2);
+        var archivedFile3 = sourceArchive.SourceFiles.SingleOrDefault(f => f.Path == expectedPath3);
+
+        archivedFile1.Should().NotBeNull($"Couldn't find source file \"{inputBicepPath1}\" in archive");
+        archivedFile2.Should().NotBeNull($"Couldn't find source file \"{inputBicepPath2}\" in archive");
+        if (inputBicepPath3 is not null)
+        {
+            archivedFile3.Should().NotBeNull($"Couldn't find source file \"{inputBicepPath3}\" in archive");
+        }
+
+        archivedFile1!.Path.Should().Be(expectedPath1);
+        archivedFile1.ArchivePath.Should().Be(expectedArchivePath1);
+
+        archivedFile2!.Path.Should().Be(expectedPath2);
+        archivedFile2.ArchivePath.Should().Be(expectedArchivePath2);
+
+        if (inputBicepPath3 is not null)
+        {
+            archivedFile3!.Path.Should().Be(expectedPath3);
+            archivedFile3.ArchivePath.Should().Be(expectedArchivePath3);
+        }
     }
 
     [TestMethod]
@@ -288,15 +478,17 @@ public class SourceArchiveTests
     {
         var zip = CreateGzippedTarredFileStream(
             (
-                "__metadata.json",
+                "metadata.json",
                 @"
                 {
+                  ""metadataVersion"": 1,
                   ""entryPoint"": ""file:///main.bicep"",
                   ""I am an unrecognized property name"": {},
+                  ""bicepVersion"": ""0.18.19"",
                   ""sourceFiles"": [
                     {
                       ""path"": ""file:///main.bicep"",
-                      ""archivePath"": ""main.bicep"",
+                      ""archivePath"": ""files/main.bicep"",
                       ""kind"": ""bicep"",
                       ""I am also recognition challenged"": ""Hi, Mom!""
                     }
@@ -304,12 +496,12 @@ public class SourceArchiveTests
                 }"
             ),
             (
-                "main.bicep",
+                "files/main.bicep",
                 @"bicep contents"
             )
         );
 
-        var sut = SourceArchive.UnpackFromStream(zip).Unwrap();
+        var sut = SourceArchive.UnpackFromStream(zip).UnwrapOrThrow();
         var file = sut.SourceFiles.Single();
 
         file.Kind.Should().Be("bicep");
@@ -324,31 +516,33 @@ public class SourceArchiveTests
         // OLD FILE VERSIONS WITH MINIMAL DATA
         var zip = CreateGzippedTarredFileStream(
             (
-                "__metadata.json",
+                "metadata.json",
                 @"
                 {
-                  ""entryPoint"": ""file:///main.bicep"",
+                  ""entryPoint"": ""main.bicep"",
+                  ""bicepVersion"": ""0.1.2"",
+                  ""metadataVersion"": 1,
                   ""sourceFiles"": [
                     {
-                      ""path"": ""file:///main.bicep"",
-                      ""archivePath"": ""main.bicep"",
+                      ""path"": ""main.bicep"",
+                      ""archivePath"": ""files/main.bicep"",
                       ""kind"": ""bicep""
                     }
                   ]
                 }"
             ),
             (
-                "main.bicep",
-                @"bicep contents"
+                "files/main.bicep",
+                "bicep contents"
             )
         );
 
-        var sut = SourceArchive.UnpackFromStream(zip).Unwrap();
+        var sut = SourceArchive.UnpackFromStream(zip).UnwrapOrThrow();
         var file = sut.SourceFiles.Single();
 
         file.Kind.Should().Be("bicep");
         file.Contents.Should().Be("bicep contents");
-        file.Path.Should().Contain("main.bicep");
+        file.Path.Should().Be("main.bicep");
     }
 
     [TestMethod]
@@ -356,19 +550,21 @@ public class SourceArchiveTests
     {
         var zip = CreateGzippedTarredFileStream(
             (
-                "__metadata.json",
+                "metadata.json",
                 @"
                 {
-                  ""entryPoint"": ""file:///main.bicep"",
+                  ""entryPoint"": ""main.bicep"",
                   ""I am an unrecognized property name"": {},
                   ""sourceFiles"": [
                     {
-                      ""path"": ""file:///main.bicep"",
-                      ""archivePath"": ""main.bicep"",
+                      ""path"": ""main.bicep"",
+                      ""archivePath"": ""files/main.bicep"",
                       ""kind"": ""bicep"",
                       ""I am also recognition challenged"": ""Hi, Mom!""
                     }
-                  ]
+                  ],
+                  ""bicepVersion"": ""0.1.2"",
+                  ""metadataVersion"": 1
                 }"
             ),
             (
@@ -376,12 +572,16 @@ public class SourceArchiveTests
                 @"unmentioned contents"
             ),
             (
-                "main.bicep",
+                "files/Nor am I.bicep",
+                @"unmentioned contents 2"
+            ),
+            (
+                "files/main.bicep",
                 @"bicep contents"
             )
         );
 
-        var sut = SourceArchive.UnpackFromStream(zip).Unwrap();
+        var sut = SourceArchive.UnpackFromStream(zip).UnwrapOrThrow();
         var file = sut.SourceFiles.Single();
 
         file.Kind.Should().Be("bicep");
@@ -394,7 +594,7 @@ public class SourceArchiveTests
     {
         var zip = CreateGzippedTarredFileStream(
             (
-                "__metadata.json",
+                "metadata.json",
                 @"
                 {
                   ""entryPoint"": ""file:///main.bicep"",
@@ -426,7 +626,7 @@ public class SourceArchiveTests
     {
         var zip = CreateGzippedTarredFileStream(
             (
-                "__metadata.json",
+                "metadata.json",
                 @"
                 {
                   ""entryPoint"": ""file:///main.bicep"",

--- a/src/Bicep.Core.UnitTests/SourceCode/SourceCodePathHelperTests.cs
+++ b/src/Bicep.Core.UnitTests/SourceCode/SourceCodePathHelperTests.cs
@@ -1,0 +1,312 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Reflection;
+using Bicep.Core.SourceCode;
+using Bicep.Core.UnitTests.Assertions;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.WindowsAzure.ResourceStack.Common.Extensions;
+
+namespace Bicep.Core.UnitTests.SourceCode;
+
+[TestClass]
+public class SourceCodePathHelperTests
+{
+    private static string RootC(string relativePath) => Environment.OSVersion.Platform == PlatformID.Win32NT ?
+        $"c:/{relativePath}"
+        : $"/c{(relativePath == "" ? "" : "/")}{relativePath}";
+
+    private static string RootD(string relativePath) => Environment.OSVersion.Platform == PlatformID.Win32NT ?
+        $"d:/{relativePath}"
+        : $"/d{(relativePath == "" ? "" : "/")}{relativePath}";
+
+    [DataRow(
+        "",
+        ""
+    )]
+    [DataRow(
+        "c:\\",
+        "c:\\"
+    )]
+    [DataRow(
+        // 250 chars
+        "c:\\123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 1\\a.txt",
+        "c:\\123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 1\\a.txt"
+    )]
+    [DataRow(
+        // 251 chars
+        "c:\\123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 12\\a.txt",
+        "c:\\123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456__path_too_long__.txt"
+    )]
+    [DataRow(
+        // long extension
+        "c:\\a.123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 txt",
+        "c:\\a.123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 12345678__path_too_long__.123456789"
+    )]
+    [DataTestMethod]
+    public void ShortenTest(string input, string expected)
+    {
+        var actual = SourceCodePathHelper.Shorten(input, 250);
+        actual.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public void GetUniquePathRoots_ShouldVerifyNormalized()
+    {
+        var cacheRoot = RootC("Users/username/.bicep");
+        ((Action)(() => SourceCodePathHelper.MapPathsToDistinctRoots(cacheRoot, new[] { RootC("a.txt"), RootC("b.txt"), RootC("folder/c.txt") }))).Should().NotThrow();
+        ((Action)(() => SourceCodePathHelper.MapPathsToDistinctRoots(cacheRoot, new[] { RootC("a.txt"), RootD("b.txt"), RootC("folder\\c.txt") }))).Should().Throw<ArgumentException>().WithMessage("*normalized*");
+    }
+
+    [TestMethod]
+    public void GetUniquePathRoots_ShouldThrowIfNotFullyQualified()
+    {
+        var cacheRoot = RootC("Users/username/.bicep");
+        ((Action)(() => SourceCodePathHelper.MapPathsToDistinctRoots(cacheRoot, new[] { RootC("a.txt"), RootC("dir/b.txt"), RootC("c.txt") }))).Should().NotThrow();
+        ((Action)(() => SourceCodePathHelper.MapPathsToDistinctRoots(cacheRoot, new[] { RootC("a.txt"), RootC("dir/b.txt"), "" }))).Should().Throw<ArgumentException>().WithMessage("*qualified*");
+        ((Action)(() => SourceCodePathHelper.MapPathsToDistinctRoots(cacheRoot, new[] { RootC("a.txt"), RootC("dir/b.txt"), "/" }))).Should().Throw<ArgumentException>().WithMessage("*qualified*");
+        ((Action)(() => SourceCodePathHelper.MapPathsToDistinctRoots(cacheRoot, new[] { RootC("a.txt"), RootC("dir/b.txt"), "c.txt" }))).Should().Throw<ArgumentException>().WithMessage("*qualified*");
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(GetGetUniquePathRootsTestcases), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(GetGetUniquePathRootsDisplayName))]
+    public void GetUniquePathRootsTest(object[] objects)
+    {
+        var cacheRoot = RootC("Users/username/.bicep");
+        var data = ((string[] paths, string[] expectedRoots))objects[0];
+        var paths = data.paths;
+        var expectedRoots = data.expectedRoots;
+
+        var actualRootsMapping = SourceCodePathHelper.MapPathsToDistinctRoots(cacheRoot, paths);
+
+        actualRootsMapping.Select(r => r.Value).Distinct().Should().BeEquivalentTo(expectedRoots);
+    }
+
+    public static String GetGetUniquePathRootsDisplayName(MethodInfo _, object[] objects)
+    {
+        var data = ((string[] paths, string[] expectedRoots))objects[0];
+        var paths = data.paths;
+
+        return string.Join(", ", paths);
+    }
+
+    public static IEnumerable<object[]> GetGetUniquePathRootsTestcases()
+    {
+        object[] data(string[] paths, string[] expectedRoots) => new object[] { (paths, expectedRoots) };
+
+        yield return data(
+            new string[]
+            {
+            },
+            new string[]
+            {
+            });
+
+        yield return data(
+            new string[]
+            {
+                RootC("a.txt")
+            },
+            new string[]
+            {
+                    RootC("")
+            });
+
+        yield return data(
+            new string[]
+            {
+                RootC("a.txt"),
+                RootC("b.txt")
+            },
+            new string[]
+            {
+                RootC("")
+            });
+
+        yield return data(
+            new string[]
+            {
+                RootC("folder/a.txt")
+            },
+            new string[]
+            {
+                RootC("folder")
+            });
+
+        yield return data(
+            new string[]
+            {
+                RootC("a.txt"),
+                RootC("folder/a.txt"),
+            },
+            new string[]
+            {
+                    RootC("")
+            });
+
+        yield return data(
+            new string[]
+            {
+                RootC("folder/a.txt"),
+                RootC("a.txt"),
+            },
+            new string[]
+            {
+                RootC("")
+            });
+
+        yield return data(
+            new string[]
+            {
+                RootC("folder/a.txt"),
+                RootC("a.txt"),
+                RootC("folder/b.txt"),
+                RootC("folder/a.bicep"),
+                RootD("folder/sub1/a.txt"),
+                RootD("folder/sub1/b.txt"),
+                RootD("folder/sub1/sub2/a.txt"),
+                RootD("folder/sub1/sub2/b.txt"),
+                RootD("folder/sub1/sub2/c.txt"),
+                RootD("folder2/sub1/sub2/b.txt"),
+            },
+            new string[]
+            {
+                RootC(""),
+                RootD("folder/sub1"),
+                RootD("folder2/sub1/sub2"),
+            });
+
+        yield return data(
+            new string[]
+            {
+                RootC("folder/a.txt"),
+                RootC("folder2/abc/def/ghi/a.txt"),
+                RootC("folder/b.txt"),
+                RootC("folder/a.bicep"),
+                RootD("folder/sub1/a.txt"),
+                RootD("folder/sub1/b.txt"),
+                RootD("folder/sub1/sub2/a.txt"),
+                RootC("folder2/abc/a.txt"),
+                RootD("folder/sub1/sub2/b.txt"),
+                RootD("folder/sub1/sub2/c.txt"),
+                RootD("folder2/sub1/sub2/b.txt"),
+            },
+            new string[]
+            {
+                RootC("folder"),
+                RootC("folder2/abc"),
+                RootD("folder/sub1"),
+                RootD("folder2/sub1/sub2"),
+            });
+
+        yield return data(
+            new string[]
+            {
+                RootC("users/username/repos/deployment/src/main.bicep"),
+                RootC("users/username/repos/deployment/src/modules/module1.bicep"),
+                RootC("users/username/repos/deployment/src/modules/module2.bicep"),
+                RootC("users/username/repos/deployment/shared/shared1.bicep"),
+                RootD("bicepcacheroot/br/example.azurecr.io/test$provider$http/1.2.3$/main.json"),
+                },
+            new string[]
+            {
+                RootC("users/username/repos/deployment/src"),
+                RootC("users/username/repos/deployment/shared"),
+                RootD("bicepcacheroot/br/example.azurecr.io/test$provider$http/1.2.3$"),
+            });
+
+        yield return data(
+            new string[]
+            {
+                RootC("a.txt"),
+                RootC("Users/username/.bicep/br/mcr.microsoft.com/bicep$compute$virtual-machine/1.0.1$/main.json"),
+            },
+            new string[]
+            {
+                RootC(""),
+                RootC("Users/username/.bicep"),
+            });
+
+        yield return data(
+            new string[]
+            {
+                RootC("deployment/a.txt"),
+                RootC("deployment/b.txt"),
+                RootC("Users/username/.bicep/br/mcr.microsoft.com/bicep$compute$virtual-machine/1.0.1$/main.json"),
+                RootC("Users/username/.bicep/br/mcr.microsoft.com/bicep$compute$virtual-machine/1.0.2$/main.json"),
+                RootC("Users/username/.bicep/br/mcr.microsoft.com/bicep$compute$virtual-machine/1.0.3$/main.json"),
+            },
+            new string[]
+            {
+                RootC("deployment"),
+                RootC("Users/username/.bicep"),
+            });
+
+        yield return data(
+            new string[]
+            {
+                RootC("deployment/a.txt"),
+                RootC("deployment/b.txt"),
+                RootC("Users/username/.bicep/br/mcr.microsoft.com/bicep$storage$account/1.0.1$/main.json"),
+                RootC("Users/username/.bicep/br/mcr.microsoft.com/bicep$compute$virtual-machine/1.0.1$/main.json"),
+            },
+            new string[]
+            {
+                RootC("deployment"),
+                RootC("Users/username/.bicep"),
+            });
+
+#if WINDOWS_BUILD
+
+        yield return data(
+            new string[]
+            {
+                RootC("deployment/a.txt"),
+                RootC("Deployment/b&.txt"),
+                RootC("DeployMENT/B|.txt"),
+                RootC("Users/USERNAME/.bicep/br/mcr.microsoft.com/bicep$storage$account/1.0.1$/main.json"),
+                RootC("Users/username/.bicep/br/mcr.microsoft.com/bicep$compute$virtual-machine/1.0.1$/main.json"),
+            },
+            new string[]
+            {
+                RootC("deployment"),
+                RootC("Users/username/.bicep"),
+            });
+
+#endif
+
+#if !WINDOWS_BUILD
+
+        yield return data(
+            new string[]
+            {
+                $"/a.txt",
+                $"/b.txt",
+                $"/c/b.txt",
+            },
+            new string[]
+            {
+                $"/"
+            });
+
+        yield return data(
+            new string[]
+            {
+                "/a/a.txt",
+                "/a/b.txt",
+                "/c/b.txt",
+            },
+            new string[]
+            {
+                $"/a",
+                "/c",
+            });
+#endif
+
+    }
+}

--- a/src/Bicep.Core/Diagnostics/ResultWithException.cs
+++ b/src/Bicep.Core/Diagnostics/ResultWithException.cs
@@ -11,4 +11,7 @@ public class ResultWithException<TSuccess> : Result<TSuccess, Exception>
     public ResultWithException(TSuccess success) : base(success) { }
 
     public ResultWithException(Exception exception) : base(exception) { }
+
+    public TSuccess UnwrapOrThrow()
+    => IsSuccess(out var success, out var exception) ? success : throw exception;
 }

--- a/src/Bicep.Core/Registry/OciArtifactRegistry.cs
+++ b/src/Bicep.Core/Registry/OciArtifactRegistry.cs
@@ -365,12 +365,11 @@ namespace Bicep.Core.Registry
             if (result is OciModuleArtifactResult moduleArtifact)
             {
                 // write source archive file
-                // TODO: do we need to delete this file if there is no source layer?
                 if (this.features.PublishSourceEnabled && result.TryGetSingleLayerByMediaType(BicepModuleMediaTypes.BicepSourceV1Layer) is BinaryData sourceData)
                 {
-                    // TODO: Write all layers as separate binary files instead of separate files for source.tar.gz and provider files.
+                    // CONSIDER: Write all layers as separate binary files instead of separate files for source.tgz and provider files.
                     // We should do this rather than writing individual files we know about,
-                    //   (e.g. "source.tar.gz") because this way we can restore all layers even if we don't know what they're for.
+                    //   (e.g. "source.tgz") because this way we can restore all layers even if we don't know what they're for.
                     //   If an optional layer is added, we don't need to version the cache because all versions have the same complete
                     //   info on disk and can handle the layer data as they want to.
                     // The manifest can be used to determine what's in each layer file.
@@ -485,7 +484,7 @@ namespace Bicep.Core.Registry
                 ArtifactFileType.Manifest => "manifest",
                 ArtifactFileType.Metadata => "metadata",
                 ArtifactFileType.Provider => "types.tgz",
-                ArtifactFileType.Source => "source.tar.gz",
+                ArtifactFileType.Source => "source.tgz",
                 _ => throw new NotImplementedException($"Unexpected artifact file type '{fileType}'.")
             };
 

--- a/src/Bicep.Core/SourceCode/SourceArchive.cs
+++ b/src/Bicep.Core/SourceCode/SourceArchive.cs
@@ -54,7 +54,7 @@ namespace Bicep.Core.SourceCode
         public const string SourceKind_ArmTemplate = "armTemplate";
         public const string SourceKind_TemplateSpec = "templateSpec";
 
-        private const string MetadataFileName = "metadata.json";
+        private const string MetadataFileName = "__metadata.json";
         private const string FilesFolderName = "files";
 
         private static readonly ImmutableHashSet<char> PathCharsToAvoid = Path.GetInvalidFileNameChars()
@@ -66,7 +66,7 @@ namespace Bicep.Core.SourceCode
         private const int MaxLegalPathLength = 260; // Limit for Windows
         private const int MaxArchivePathLength = MaxLegalPathLength - 10; // ... this gives us some extra room to deduplicate paths
 
-        /* Example metadata.json:
+        /* Example __metadata.json:
         {
             "metadataVersion": 0,
             "entryPoint": "my entrypoint.bicep",
@@ -108,7 +108,7 @@ namespace Bicep.Core.SourceCode
         [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
         private partial class MetadataSerializationContext : JsonSerializerContext { }
 
-        // Metadata for the entire archive (stored in metadata.json file in archive)
+        // Metadata for the entire archive (stored in __metadata.json file in archive)
         private record ArchiveMetadata(
             int MetadataVersion,
             string? BicepVersion,

--- a/src/Bicep.Core/SourceCode/SourceCodeDocumentLink.cs
+++ b/src/Bicep.Core/SourceCode/SourceCodeDocumentLink.cs
@@ -8,7 +8,7 @@ namespace Bicep.Core.SourceCode;
 /// </summary>
 /// <typeparam name="TTarget"></typeparam>
 /// <param name="Range">Span of the origin of this link in the source file (e.g. the module path of a module declaration syntax line)</param>
-/// <param name="Target">The target file for this link (e.g. the path of the source file pointed to by the module path inside the source.tar.gz file)</param>
+/// <param name="Target">The target file for this link (e.g. the path of the source file pointed to by the module path inside the source.tgz file)</param>
 public record SourceCodeDocumentLink<TTarget>(
     SourceCodeRange Range,
     TTarget Target
@@ -24,7 +24,7 @@ public record SourceCodeDocumentUriLink : SourceCodeDocumentLink<Uri>
     { }
 }
 
-// Refers to the target via the relative path used inside a source.tar.gz file
+// Refers to the target via the relative path used inside a source.tgz file
 public record SourceCodeDocumentPathLink : SourceCodeDocumentLink<string>
 {
     public SourceCodeDocumentPathLink(

--- a/src/Bicep.Core/SourceCode/SourceCodePathHelper.cs
+++ b/src/Bicep.Core/SourceCode/SourceCodePathHelper.cs
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Bicep.Core.FileSystem;
+using Microsoft.WindowsAzure.ResourceStack.Common.Extensions;
+
+namespace Bicep.Core.SourceCode
+{
+    public static class SourceCodePathHelper
+    {
+        public static string Shorten(string path, int maxLength)
+        {
+            if (path.Length <= maxLength)
+            {
+                return path;
+            }
+
+            var extension = Path.GetExtension(path) ?? string.Empty;
+            var tail = "__path_too_long__" + extension.Substring(0, Math.Min(10, extension.Length));
+            var shortPath = path.Substring(0, maxLength - tail.Length) + tail;
+            Debug.Assert(shortPath.Length == maxLength);
+            return shortPath;
+        }
+
+        /// <summary>
+        /// Finds the list of all distinctFolders in the given pathsArray that are not subfolders of any path,
+        /// i.e. the smallest set of distinctFolders so that you can express any of the pathsArray as relative
+        /// to one of the roots, without having to use "..".
+        ///
+        /// Excluding then handling of files under the cache root, each given path will be under one and only one root.
+        ///
+        /// The intention is to keep only the portion of the source user paths that is necessary.
+        /// <returns>
+        /// A mapping of the original paths to the root path that they should be relative to.
+        /// </returns>
+        /// </summary>
+        /// <example>
+        ///
+        ///   c:/users/username/repos/deployment/src/main.bicep
+        ///   c:/users/username/repos/deployment/src/modules/module1.bicep
+        ///   c:/users/username/repos/deployment/src/modules/module2.bicep
+        ///   c:/users/username/repos/deployment/shared/shared1.bicep
+        ///   d:/repos/deployment/main.json
+        ///
+        /// the calculated distinct roots are:
+        ///
+        ///   c:/users/username/repos/deployment/src
+        ///   c:/users/username/repos/deployment/shared
+        ///   d:/repos/deployment
+        ///
+        /// so the returned map is:
+        ///
+        ///   c:/users/username/repos/deployment/src/main.bicep            => c:/users/username/repos/deployment/src
+        ///   c:/users/username/repos/deployment/src/modules/module1.bicep => c:/users/username/repos/deployment/src
+        ///   c:/users/username/repos/deployment/src/modules/module2.bicep => c:/users/username/repos/deployment/src
+        ///   c:/users/username/repos/deployment/shared/shared1.bicep      => c:/users/username/repos/deployment/shared
+        ///   d:/repos/deployment/main.json                                => d:/repos/deployment
+        ///   
+        /// </example>
+        public static IDictionary<string, string> MapPathsToDistinctRoots(string? cacheRoot, string[] filePaths)
+        {
+            if (filePaths.Distinct().Count() != filePaths.Length)
+            {
+                throw new ArgumentException($"Paths should be distinct before calling {nameof(MapPathsToDistinctRoots)}");
+            }
+
+            if (filePaths.Any(p => p.Contains('\\')))
+            {
+                throw new ArgumentException($"Paths should be normalized before calling {nameof(MapPathsToDistinctRoots)}");
+            }
+
+            string[] folders = filePaths.Select(path =>
+            {
+                if (!Path.IsPathFullyQualified(path) || Path.GetDirectoryName(path) is not string folder)
+                {
+                    throw new ArgumentException($"Path '{path}' should be a valid fully qualified path");
+                }
+
+                return folder;
+            })
+            .Select(NormalizeSlashes).ToArray();
+
+            var distinctFolders = folders.Distinct(PathHelper.PathComparer).ToArray();
+
+            var distinctRoots = distinctFolders.Where(path =>
+                !distinctFolders.Any(path2 => path != path2 && IsDescendentOf(path, path2))
+            ).ToArray();
+
+            // Map path -> root to return
+            var rootMapping = filePaths.Select(
+                    filePath =>
+                    {
+                        var fileFolder = Path.GetDirectoryName(filePath)!; // (GetDirectoryName should always return non-null for a file path)
+                        if (!string.IsNullOrEmpty(cacheRoot) && IsSameOrIsDescendentOf(fileFolder, cacheRoot))
+                        {
+                            // Treat everything under cacheRoot the same as cacheRoot to avoid having a root for each referenced module and for better source viewing
+                            return (filePath, cacheRoot);
+                        }
+
+                        var matchingRoots = distinctRoots.Where(r => IsSameOrIsDescendentOf(fileFolder, r)).ToArray();
+                        if (matchingRoots.Length != 1)
+                        {
+                            throw new ArgumentException($"{nameof(MapPathsToDistinctRoots)}: Path '{filePath}' should be under exactly one root");
+                        }
+
+                        return (filePath, matchingRoots.Single());
+                    }
+                );
+
+            return rootMapping.ToDictionary(pair => pair.Item1, pair => pair.Item2);
+        }
+
+        public static string NormalizeSlashes(string path)
+        {
+            return path.Replace('\\', '/');
+        }
+
+        private static bool IsDescendentOf(string folder, string possibleParentFolder)
+        {
+            return folder != possibleParentFolder
+                && IsSameOrIsDescendentOf(folder, possibleParentFolder);
+        }
+
+        private static bool IsSameOrIsDescendentOf(string folder, string possibleParentFolder)
+        {
+            var relativePath = NormalizeSlashes(Path.GetRelativePath(possibleParentFolder, folder));
+            return relativePath != ".."
+                && !relativePath.StartsWith("../")
+                && PathHelper.PathComparer.Equals(Path.GetPathRoot(folder), Path.GetPathRoot(possibleParentFolder));
+        }
+    }
+}

--- a/src/Bicep.LangServer.IntegrationTests/CodeLensTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CodeLensTests.cs
@@ -33,6 +33,12 @@ namespace Bicep.LangServer.IntegrationTests
         [NotNull]
         public TestContext? TestContext { get; set; }
 
+#if WINDOWS_BUILD
+    private const string ROOT = "c:\\";
+#else
+        private const string ROOT = "/";
+#endif
+
         public static string GetDisplayName(MethodInfo info, object[] row)
         {
             row.Should().HaveCount(3);
@@ -79,13 +85,13 @@ namespace Bicep.LangServer.IntegrationTests
         }
 
         [DataTestMethod]
-        [DataRow("file://path/to/localfile.bicep")]
-        [DataRow("file://path/to/localfile.json")]
-        [DataRow("file://path/to/localfile.bicepparam")]
+        [DataRow($"file://{ROOT}path/to/localfile.bicep")]
+        [DataRow($"file://{ROOT}path/to/localfile.json")]
+        [DataRow($"file://{ROOT}path/to/localfile.bicepparam")]
         [DataRow("untitled:Untitled-1")]
         public async Task DisplayingLocalFile_NotExtSourceScheme_ShouldNotHaveCodeLens(string fileName)
         {
-            var uri = DocumentUri.From($"/{this.TestContext.TestName}");
+            var uri = DocumentUri.From($"{ROOT}{this.TestContext.TestName}");
 
             await using var server = CreateServer(null, null);
             var helper = await server.GetAsync();
@@ -101,8 +107,8 @@ namespace Bicep.LangServer.IntegrationTests
         [TestMethod]
         public async Task DisplayingExternalModuleSource_EntrypointFile_ShouldHaveCodeLens_ToShowModuleCompiledJson()
         {
-            var uri = DocumentUri.From($"/{this.TestContext.TestName}");
-            var moduleEntrypointUri = DocumentUri.From($"/module entrypoint.bicep");
+            var uri = DocumentUri.From($"{ROOT}{this.TestContext.TestName}");
+            var moduleEntrypointUri = DocumentUri.From($"{ROOT}module entrypoint.bicep");
 
             await using var server = CreateServer(moduleEntrypointUri.ToUriEncoded(), "// module entrypoint");
             var helper = await server.GetAsync();
@@ -123,8 +129,8 @@ namespace Bicep.LangServer.IntegrationTests
         [TestMethod]
         public async Task DisplayingExternalModuleSource_BicepButNotEntrypointFile_ShouldHaveCodeLens_ToShowModuleCompiledJson()
         {
-            var uri = DocumentUri.From($"/{this.TestContext.TestName}");
-            var moduleEntrypointUri = DocumentUri.From($"/module entrypoint.bicep");
+            var uri = DocumentUri.From($"{ROOT}{this.TestContext.TestName}");
+            var moduleEntrypointUri = DocumentUri.From($"{ROOT}module entrypoint.bicep");
 
             await using var server = CreateServer(moduleEntrypointUri.ToUriEncoded(), "// module entrypoint");
             var helper = await server.GetAsync();
@@ -145,8 +151,8 @@ namespace Bicep.LangServer.IntegrationTests
         [TestMethod]
         public async Task DisplayingExternalModuleSource_JsonFileThatIsIncludedInSources_ShouldHaveCodeLens_ToShowCompiledJson_ForTheWholeModule()
         {
-            var uri = DocumentUri.From($"/{this.TestContext.TestName}");
-            var moduleEntrypointUri = DocumentUri.From($"/module entrypoint.bicep");
+            var uri = DocumentUri.From($"{ROOT}{this.TestContext.TestName}");
+            var moduleEntrypointUri = DocumentUri.From($"{ROOT}module entrypoint.bicep");
 
             await using var server = CreateServer(moduleEntrypointUri.ToUriEncoded(), "// module entrypoint");
             var helper = await server.GetAsync();
@@ -167,8 +173,8 @@ namespace Bicep.LangServer.IntegrationTests
         [TestMethod]
         public async Task DisplayingModuleCompiledJsonFile_AndSourceIsAvailable_ShouldHaveCodeLens_ToShowBicepEntrypointFile()
         {
-            var uri = DocumentUri.From($"/{this.TestContext.TestName}");
-            var moduleEntrypointUri = DocumentUri.From($"/module entrypoint.bicep");
+            var uri = DocumentUri.From($"{ROOT}{this.TestContext.TestName}");
+            var moduleEntrypointUri = DocumentUri.From($"{ROOT}module entrypoint.bicep");
 
             await using var server = CreateServer(moduleEntrypointUri.ToUriEncoded(), "// module entrypoint");
             var helper = await server.GetAsync();
@@ -190,8 +196,8 @@ namespace Bicep.LangServer.IntegrationTests
         [TestMethod]
         public async Task DisplayingModuleCompiledJsonFile_AndSourceNotAvailable_ShouldHaveCodeLens_ToExplainWhyNoSources()
         {
-            var uri = DocumentUri.From($"/{this.TestContext.TestName}");
-            var moduleEntrypointUri = DocumentUri.From($"/module entrypoint.bicep");
+            var uri = DocumentUri.From($"{ROOT}{this.TestContext.TestName}");
+            var moduleEntrypointUri = DocumentUri.From($"{ROOT}module entrypoint.bicep");
 
             await using var server = CreateServer(moduleEntrypointUri.ToUriEncoded(), null);
             var helper = await server.GetAsync();
@@ -211,8 +217,8 @@ namespace Bicep.LangServer.IntegrationTests
         [TestMethod]
         public async Task HasBadUri_ShouldHaveCodeLens_ToExplainError()
         {
-            var uri = DocumentUri.From($"/{this.TestContext.TestName}");
-            var moduleEntrypointUri = DocumentUri.From($"/module entrypoint.bicep");
+            var uri = DocumentUri.From($"{ROOT}{this.TestContext.TestName}");
+            var moduleEntrypointUri = DocumentUri.From($"{ROOT}module entrypoint.bicep");
 
             await using var server = CreateServer(moduleEntrypointUri.ToUriEncoded(), "// module entrypoint");
             var helper = await server.GetAsync();
@@ -232,8 +238,8 @@ namespace Bicep.LangServer.IntegrationTests
         [TestMethod]
         public async Task SourceArchiveHasError_ShouldHaveCodeLensWithError()
         {
-            var uri = DocumentUri.From($"/{this.TestContext.TestName}");
-            var moduleEntrypointUri = DocumentUri.From($"/module entrypoint.bicep");
+            var uri = DocumentUri.From($"{ROOT}{this.TestContext.TestName}");
+            var moduleEntrypointUri = DocumentUri.From($"{ROOT}module entrypoint.bicep");
 
             var sourceArchiveResult = new ResultWithException<SourceArchive>(new Exception("Source archive is incompatible with this version of Bicep."));
             await using var server = CreateServer(moduleEntrypointUri.ToUriEncoded(), "// module entrypoint", sourceArchiveResult);

--- a/src/Bicep.LangServer.IntegrationTests/CodeLensTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CodeLensTests.cs
@@ -50,7 +50,7 @@ namespace Bicep.LangServer.IntegrationTests
             if (bicepModuleEntrypoint is not null && entrypointSource is not null)
             {
                 BicepFile moduleEntrypointFile = SourceFileFactory.CreateBicepFile(bicepModuleEntrypoint, entrypointSource);
-                sourceArchiveResult ??= SourceArchive.UnpackFromStream(SourceArchive.PackSourcesIntoStream(moduleEntrypointFile.FileUri, moduleEntrypointFile));
+                sourceArchiveResult ??= SourceArchive.UnpackFromStream(SourceArchive.PackSourcesIntoStream(moduleEntrypointFile.FileUri, cacheRoot: null , moduleEntrypointFile));
             }
             sourceArchiveResult ??= new(new SourceNotAvailableException());
             moduleRegistry.Setup(m => m.TryGetSource(It.IsAny<ArtifactReference>())).Returns(sourceArchiveResult);


### PR DESCRIPTION
Fixes part of https://github.com/Azure/bicep/issues/12132

1) Break compatibility with previous versions by:
  ~a) changing source.tar.gzip to source.tgz (this also makes modules consistent with type providers)~
  b) updating CurrentMetadataVersion to 1 (this was always intended before shipping anyway)
  ~These will keep previous versions of Bicep from attempting to read the source files of modules published with newer versions, 
in preparation for removing the experimental flag~
  Unfortunately we can't easily keep earlier versions from seeing the source code, but it didn't actually change enough to cause problems, except for the "metadata.json" rename, which I changed back to "__metadata.json".  
2) Handle paths that are too long
3) Handle case-insensitivity on Windows
4) Moved source files inside source.tgz into a new folder "files/" and renamed top-level __metadata.json to "metadata.json"
5) Handle multiple drives and ".." in paths (these can be created in a zip file, but neither Mac nor Windows will display the files in the UI)
6) Avoid writing out user file paths that are above the actual source file path (e.g. if there's a source file "c:\users\sw\repos\deployment\main.bicep", we'll try to avoid exposing "c:\users\sw\repos\deployment" in the source archive
7) Handle possibly troublesome characters in paths


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/13081)