### PR TITLE
Update MS Graph types and typeloader

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Cli.IntegrationTests/packages.lock.json
@@ -459,8 +459,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-preview",
-        "contentHash": "PBUH2KmCkJdFYD7DgcDuAUZ/iOMzBZRe8uKG/V8v6mmc1kBr5c9+5cQ0Zd559DQzkT+41OuNZNoFS7uzxpW/4w==",
+        "resolved": "0.1.1-mypreview",
+        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -2102,7 +2102,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.Cli.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Cli.IntegrationTests/packages.lock.json
@@ -459,8 +459,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-mypreview",
-        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
+        "resolved": "0.1.2-preview",
+        "contentHash": "K47L051GXYs9y5OdKt8+wcobJOn6dLGQjsBiegoZN9BdbCQtP0gI/PP8HxP9iO+Yx1K0LnDLgK9qZUO0WbLApQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -2102,7 +2102,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.2-preview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.Cli.UnitTests/packages.lock.json
+++ b/src/Bicep.Cli.UnitTests/packages.lock.json
@@ -394,8 +394,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-preview",
-        "contentHash": "PBUH2KmCkJdFYD7DgcDuAUZ/iOMzBZRe8uKG/V8v6mmc1kBr5c9+5cQ0Zd559DQzkT+41OuNZNoFS7uzxpW/4w==",
+        "resolved": "0.1.1-mypreview",
+        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -1950,7 +1950,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.Cli.UnitTests/packages.lock.json
+++ b/src/Bicep.Cli.UnitTests/packages.lock.json
@@ -394,8 +394,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-mypreview",
-        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
+        "resolved": "0.1.2-preview",
+        "contentHash": "K47L051GXYs9y5OdKt8+wcobJOn6dLGQjsBiegoZN9BdbCQtP0gI/PP8HxP9iO+Yx1K0LnDLgK9qZUO0WbLApQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -1950,7 +1950,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.2-preview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.Cli/packages.lock.json
+++ b/src/Bicep.Cli/packages.lock.json
@@ -393,8 +393,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-mypreview",
-        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
+        "resolved": "0.1.2-preview",
+        "contentHash": "K47L051GXYs9y5OdKt8+wcobJOn6dLGQjsBiegoZN9BdbCQtP0gI/PP8HxP9iO+Yx1K0LnDLgK9qZUO0WbLApQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -1889,7 +1889,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.2-preview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.Cli/packages.lock.json
+++ b/src/Bicep.Cli/packages.lock.json
@@ -393,8 +393,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-preview",
-        "contentHash": "PBUH2KmCkJdFYD7DgcDuAUZ/iOMzBZRe8uKG/V8v6mmc1kBr5c9+5cQ0Zd559DQzkT+41OuNZNoFS7uzxpW/4w==",
+        "resolved": "0.1.1-mypreview",
+        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -1889,7 +1889,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.Core.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Core.IntegrationTests/packages.lock.json
@@ -431,8 +431,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-mypreview",
-        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
+        "resolved": "0.1.2-preview",
+        "contentHash": "K47L051GXYs9y5OdKt8+wcobJOn6dLGQjsBiegoZN9BdbCQtP0gI/PP8HxP9iO+Yx1K0LnDLgK9qZUO0WbLApQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -2034,7 +2034,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.2-preview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.Core.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Core.IntegrationTests/packages.lock.json
@@ -431,8 +431,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-preview",
-        "contentHash": "PBUH2KmCkJdFYD7DgcDuAUZ/iOMzBZRe8uKG/V8v6mmc1kBr5c9+5cQ0Zd559DQzkT+41OuNZNoFS7uzxpW/4w==",
+        "resolved": "0.1.1-mypreview",
+        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -2034,7 +2034,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.Core.Samples/Files/user_submitted/extensibility/microsoftGraph/main.bicep
+++ b/src/Bicep.Core.Samples/Files/user_submitted/extensibility/microsoftGraph/main.bicep
@@ -4,7 +4,7 @@ param appRoleId string = 'bc76c90e-eb7f-4a29-943b-49e88762d09d'
 param scopeId string = 'f761933c-643b-424f-a169-f9313d23a913'
 
 resource resourceApp 'Microsoft.Graph/applications@beta' = {
-  name: 'resourceApp'
+  uniqueName: 'resourceApp'
   displayName: 'My Resource App'
   appRoles: [
     {
@@ -35,7 +35,7 @@ resource resourceSp 'Microsoft.Graph/servicePrincipals@beta' = {
 }
 
 resource clientApp 'Microsoft.Graph/applications@beta' = {
-  name: 'clientApp'
+  uniqueName: 'clientApp'
   displayName: 'My Client App'
 }
 
@@ -57,7 +57,7 @@ resource appRoleAssignedTo 'Microsoft.Graph/appRoleAssignedTo@beta' = {
 }
 
 resource group 'Microsoft.Graph/groups@beta' = {
-  name: 'myGroup'
+  uniqueName: 'myGroup'
   displayName: 'My Group'
   mailEnabled: false
   mailNickname: 'myGroupMailNickname'

--- a/src/Bicep.Core.Samples/Files/user_submitted/extensibility/microsoftGraph/main.existing.bicep
+++ b/src/Bicep.Core.Samples/Files/user_submitted/extensibility/microsoftGraph/main.existing.bicep
@@ -1,0 +1,9 @@
+provider 'microsoftGraph@1.0.0'
+
+resource resourceApp 'Microsoft.Graph/applications@beta' existing = {
+  uniqueName: 'resourceApp'
+}
+
+resource group 'Microsoft.Graph/applications@beta' existing = {
+  uniqueName: 'myGroup'
+}

--- a/src/Bicep.Core.Samples/Files/user_submitted/extensibility/microsoftGraph/main.existing.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/extensibility/microsoftGraph/main.existing.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.1-experimental",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+    "_EXPERIMENTAL_FEATURES_ENABLED": [
+      "Extensibility",
+      "MicrosoftGraph Preview"
+    ],
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "15625412334658089454"
+    }
+  },
+  "imports": {
+    "microsoftGraph": {
+      "provider": "MicrosoftGraph",
+      "version": "1.0.0"
+    }
+  },
+  "resources": {
+    "resourceApp": {
+      "existing": true,
+      "import": "microsoftGraph",
+      "type": "Microsoft.Graph/applications@beta",
+      "properties": {
+        "uniqueName": "resourceApp"
+      }
+    },
+    "group": {
+      "existing": true,
+      "import": "microsoftGraph",
+      "type": "Microsoft.Graph/applications@beta",
+      "properties": {
+        "uniqueName": "myGroup"
+      }
+    }
+  }
+}

--- a/src/Bicep.Core.Samples/Files/user_submitted/extensibility/microsoftGraph/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/extensibility/microsoftGraph/main.json
@@ -11,7 +11,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17939497564815214686"
+      "templateHash": "2462067839436922243"
     }
   },
   "parameters": {
@@ -35,7 +35,7 @@
       "import": "graph",
       "type": "Microsoft.Graph/applications@beta",
       "properties": {
-        "name": "resourceApp",
+        "uniqueName": "resourceApp",
         "displayName": "My Resource App",
         "appRoles": [
           {
@@ -78,7 +78,7 @@
       "import": "graph",
       "type": "Microsoft.Graph/applications@beta",
       "properties": {
-        "name": "clientApp",
+        "uniqueName": "clientApp",
         "displayName": "My Client App"
       }
     },
@@ -123,7 +123,7 @@
       "import": "graph",
       "type": "Microsoft.Graph/groups@beta",
       "properties": {
-        "name": "myGroup",
+        "uniqueName": "myGroup",
         "displayName": "My Group",
         "mailEnabled": false,
         "mailNickname": "myGroupMailNickname",

--- a/src/Bicep.Core.Samples/packages.lock.json
+++ b/src/Bicep.Core.Samples/packages.lock.json
@@ -431,8 +431,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-mypreview",
-        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
+        "resolved": "0.1.2-preview",
+        "contentHash": "K47L051GXYs9y5OdKt8+wcobJOn6dLGQjsBiegoZN9BdbCQtP0gI/PP8HxP9iO+Yx1K0LnDLgK9qZUO0WbLApQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -2034,7 +2034,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.2-preview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.Core.Samples/packages.lock.json
+++ b/src/Bicep.Core.Samples/packages.lock.json
@@ -431,8 +431,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-preview",
-        "contentHash": "PBUH2KmCkJdFYD7DgcDuAUZ/iOMzBZRe8uKG/V8v6mmc1kBr5c9+5cQ0Zd559DQzkT+41OuNZNoFS7uzxpW/4w==",
+        "resolved": "0.1.1-mypreview",
+        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -2034,7 +2034,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.Core.UnitTests/packages.lock.json
+++ b/src/Bicep.Core.UnitTests/packages.lock.json
@@ -451,8 +451,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-preview",
-        "contentHash": "PBUH2KmCkJdFYD7DgcDuAUZ/iOMzBZRe8uKG/V8v6mmc1kBr5c9+5cQ0Zd559DQzkT+41OuNZNoFS7uzxpW/4w==",
+        "resolved": "0.1.1-mypreview",
+        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -2038,7 +2038,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.Core.UnitTests/packages.lock.json
+++ b/src/Bicep.Core.UnitTests/packages.lock.json
@@ -451,8 +451,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-mypreview",
-        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
+        "resolved": "0.1.2-preview",
+        "contentHash": "K47L051GXYs9y5OdKt8+wcobJOn6dLGQjsBiegoZN9BdbCQtP0gI/PP8HxP9iO+Yx1K0LnDLgK9qZUO0WbLApQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -2038,7 +2038,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.2-preview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.Core/Bicep.Core.csproj
+++ b/src/Bicep.Core/Bicep.Core.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Graph.Bicep.Types" Version="0.1.1-preview" />
+    <PackageReference Include="Microsoft.Graph.Bicep.Types" Version="0.1.2-preview" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SharpYaml" Version="2.1.0" />
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />

--- a/src/Bicep.Core/packages.lock.json
+++ b/src/Bicep.Core/packages.lock.json
@@ -186,9 +186,9 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Direct",
-        "requested": "[0.1.1-mypreview, )",
-        "resolved": "0.1.1-mypreview",
-        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
+        "requested": "[0.1.2-preview, )",
+        "resolved": "0.1.2-preview",
+        "contentHash": "K47L051GXYs9y5OdKt8+wcobJOn6dLGQjsBiegoZN9BdbCQtP0gI/PP8HxP9iO+Yx1K0LnDLgK9qZUO0WbLApQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }

--- a/src/Bicep.Core/packages.lock.json
+++ b/src/Bicep.Core/packages.lock.json
@@ -186,9 +186,9 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Direct",
-        "requested": "[0.1.1-preview, )",
-        "resolved": "0.1.1-preview",
-        "contentHash": "PBUH2KmCkJdFYD7DgcDuAUZ/iOMzBZRe8uKG/V8v6mmc1kBr5c9+5cQ0Zd559DQzkT+41OuNZNoFS7uzxpW/4w==",
+        "requested": "[0.1.1-mypreview, )",
+        "resolved": "0.1.1-mypreview",
+        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }

--- a/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
@@ -431,8 +431,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-mypreview",
-        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
+        "resolved": "0.1.2-preview",
+        "contentHash": "K47L051GXYs9y5OdKt8+wcobJOn6dLGQjsBiegoZN9BdbCQtP0gI/PP8HxP9iO+Yx1K0LnDLgK9qZUO0WbLApQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -2034,7 +2034,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.2-preview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
@@ -431,8 +431,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-preview",
-        "contentHash": "PBUH2KmCkJdFYD7DgcDuAUZ/iOMzBZRe8uKG/V8v6mmc1kBr5c9+5cQ0Zd559DQzkT+41OuNZNoFS7uzxpW/4w==",
+        "resolved": "0.1.1-mypreview",
+        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -2034,7 +2034,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.Decompiler.UnitTests/packages.lock.json
+++ b/src/Bicep.Decompiler.UnitTests/packages.lock.json
@@ -431,8 +431,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-mypreview",
-        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
+        "resolved": "0.1.2-preview",
+        "contentHash": "K47L051GXYs9y5OdKt8+wcobJOn6dLGQjsBiegoZN9BdbCQtP0gI/PP8HxP9iO+Yx1K0LnDLgK9qZUO0WbLApQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -2034,7 +2034,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.2-preview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.Decompiler.UnitTests/packages.lock.json
+++ b/src/Bicep.Decompiler.UnitTests/packages.lock.json
@@ -431,8 +431,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-preview",
-        "contentHash": "PBUH2KmCkJdFYD7DgcDuAUZ/iOMzBZRe8uKG/V8v6mmc1kBr5c9+5cQ0Zd559DQzkT+41OuNZNoFS7uzxpW/4w==",
+        "resolved": "0.1.1-mypreview",
+        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -2034,7 +2034,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.Decompiler/packages.lock.json
+++ b/src/Bicep.Decompiler/packages.lock.json
@@ -303,8 +303,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-mypreview",
-        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
+        "resolved": "0.1.2-preview",
+        "contentHash": "K47L051GXYs9y5OdKt8+wcobJOn6dLGQjsBiegoZN9BdbCQtP0gI/PP8HxP9iO+Yx1K0LnDLgK9qZUO0WbLApQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -1757,7 +1757,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.2-preview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.Decompiler/packages.lock.json
+++ b/src/Bicep.Decompiler/packages.lock.json
@@ -303,8 +303,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-preview",
-        "contentHash": "PBUH2KmCkJdFYD7DgcDuAUZ/iOMzBZRe8uKG/V8v6mmc1kBr5c9+5cQ0Zd559DQzkT+41OuNZNoFS7uzxpW/4w==",
+        "resolved": "0.1.1-mypreview",
+        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -1757,7 +1757,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.LangServer.IntegrationTests/packages.lock.json
+++ b/src/Bicep.LangServer.IntegrationTests/packages.lock.json
@@ -465,8 +465,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-preview",
-        "contentHash": "PBUH2KmCkJdFYD7DgcDuAUZ/iOMzBZRe8uKG/V8v6mmc1kBr5c9+5cQ0Zd559DQzkT+41OuNZNoFS7uzxpW/4w==",
+        "resolved": "0.1.1-mypreview",
+        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -2048,7 +2048,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.LangServer.IntegrationTests/packages.lock.json
+++ b/src/Bicep.LangServer.IntegrationTests/packages.lock.json
@@ -465,8 +465,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-mypreview",
-        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
+        "resolved": "0.1.2-preview",
+        "contentHash": "K47L051GXYs9y5OdKt8+wcobJOn6dLGQjsBiegoZN9BdbCQtP0gI/PP8HxP9iO+Yx1K0LnDLgK9qZUO0WbLApQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -2048,7 +2048,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.2-preview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.LangServer.UnitTests/packages.lock.json
+++ b/src/Bicep.LangServer.UnitTests/packages.lock.json
@@ -467,8 +467,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-preview",
-        "contentHash": "PBUH2KmCkJdFYD7DgcDuAUZ/iOMzBZRe8uKG/V8v6mmc1kBr5c9+5cQ0Zd559DQzkT+41OuNZNoFS7uzxpW/4w==",
+        "resolved": "0.1.1-mypreview",
+        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -2062,7 +2062,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.LangServer.UnitTests/packages.lock.json
+++ b/src/Bicep.LangServer.UnitTests/packages.lock.json
@@ -467,8 +467,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-mypreview",
-        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
+        "resolved": "0.1.2-preview",
+        "contentHash": "K47L051GXYs9y5OdKt8+wcobJOn6dLGQjsBiegoZN9BdbCQtP0gI/PP8HxP9iO+Yx1K0LnDLgK9qZUO0WbLApQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -2062,7 +2062,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.2-preview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.LangServer/packages.lock.json
+++ b/src/Bicep.LangServer/packages.lock.json
@@ -395,8 +395,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-mypreview",
-        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
+        "resolved": "0.1.2-preview",
+        "contentHash": "K47L051GXYs9y5OdKt8+wcobJOn6dLGQjsBiegoZN9BdbCQtP0gI/PP8HxP9iO+Yx1K0LnDLgK9qZUO0WbLApQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -1929,7 +1929,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.2-preview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.LangServer/packages.lock.json
+++ b/src/Bicep.LangServer/packages.lock.json
@@ -395,8 +395,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-preview",
-        "contentHash": "PBUH2KmCkJdFYD7DgcDuAUZ/iOMzBZRe8uKG/V8v6mmc1kBr5c9+5cQ0Zd559DQzkT+41OuNZNoFS7uzxpW/4w==",
+        "resolved": "0.1.1-mypreview",
+        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -1929,7 +1929,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
@@ -607,8 +607,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-mypreview",
-        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
+        "resolved": "0.1.2-preview",
+        "contentHash": "K47L051GXYs9y5OdKt8+wcobJOn6dLGQjsBiegoZN9BdbCQtP0gI/PP8HxP9iO+Yx1K0LnDLgK9qZUO0WbLApQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -2274,7 +2274,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.2-preview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
@@ -607,8 +607,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-preview",
-        "contentHash": "PBUH2KmCkJdFYD7DgcDuAUZ/iOMzBZRe8uKG/V8v6mmc1kBr5c9+5cQ0Zd559DQzkT+41OuNZNoFS7uzxpW/4w==",
+        "resolved": "0.1.1-mypreview",
+        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -2274,7 +2274,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
@@ -590,8 +590,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-preview",
-        "contentHash": "PBUH2KmCkJdFYD7DgcDuAUZ/iOMzBZRe8uKG/V8v6mmc1kBr5c9+5cQ0Zd559DQzkT+41OuNZNoFS7uzxpW/4w==",
+        "resolved": "0.1.1-mypreview",
+        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -2268,7 +2268,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
@@ -590,8 +590,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-mypreview",
-        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
+        "resolved": "0.1.2-preview",
+        "contentHash": "K47L051GXYs9y5OdKt8+wcobJOn6dLGQjsBiegoZN9BdbCQtP0gI/PP8HxP9iO+Yx1K0LnDLgK9qZUO0WbLApQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -2268,7 +2268,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.2-preview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
@@ -607,8 +607,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-mypreview",
-        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
+        "resolved": "0.1.2-preview",
+        "contentHash": "K47L051GXYs9y5OdKt8+wcobJOn6dLGQjsBiegoZN9BdbCQtP0gI/PP8HxP9iO+Yx1K0LnDLgK9qZUO0WbLApQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -2274,7 +2274,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.2-preview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
@@ -607,8 +607,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-preview",
-        "contentHash": "PBUH2KmCkJdFYD7DgcDuAUZ/iOMzBZRe8uKG/V8v6mmc1kBr5c9+5cQ0Zd559DQzkT+41OuNZNoFS7uzxpW/4w==",
+        "resolved": "0.1.1-mypreview",
+        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -2274,7 +2274,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.RegistryModuleTool/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool/packages.lock.json
@@ -592,8 +592,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-mypreview",
-        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
+        "resolved": "0.1.2-preview",
+        "contentHash": "K47L051GXYs9y5OdKt8+wcobJOn6dLGQjsBiegoZN9BdbCQtP0gI/PP8HxP9iO+Yx1K0LnDLgK9qZUO0WbLApQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -2048,7 +2048,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.2-preview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.RegistryModuleTool/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool/packages.lock.json
@@ -592,8 +592,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-preview",
-        "contentHash": "PBUH2KmCkJdFYD7DgcDuAUZ/iOMzBZRe8uKG/V8v6mmc1kBr5c9+5cQ0Zd559DQzkT+41OuNZNoFS7uzxpW/4w==",
+        "resolved": "0.1.1-mypreview",
+        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -2048,7 +2048,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.Tools.Benchmark/packages.lock.json
+++ b/src/Bicep.Tools.Benchmark/packages.lock.json
@@ -494,8 +494,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-mypreview",
-        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
+        "resolved": "0.1.2-preview",
+        "contentHash": "K47L051GXYs9y5OdKt8+wcobJOn6dLGQjsBiegoZN9BdbCQtP0gI/PP8HxP9iO+Yx1K0LnDLgK9qZUO0WbLApQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -2135,7 +2135,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.2-preview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.Tools.Benchmark/packages.lock.json
+++ b/src/Bicep.Tools.Benchmark/packages.lock.json
@@ -494,8 +494,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-preview",
-        "contentHash": "PBUH2KmCkJdFYD7DgcDuAUZ/iOMzBZRe8uKG/V8v6mmc1kBr5c9+5cQ0Zd559DQzkT+41OuNZNoFS7uzxpW/4w==",
+        "resolved": "0.1.1-mypreview",
+        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -2135,7 +2135,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.Wasm/packages.lock.json
+++ b/src/Bicep.Wasm/packages.lock.json
@@ -393,8 +393,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-preview",
-        "contentHash": "PBUH2KmCkJdFYD7DgcDuAUZ/iOMzBZRe8uKG/V8v6mmc1kBr5c9+5cQ0Zd559DQzkT+41OuNZNoFS7uzxpW/4w==",
+        "resolved": "0.1.1-mypreview",
+        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -1874,7 +1874,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",

--- a/src/Bicep.Wasm/packages.lock.json
+++ b/src/Bicep.Wasm/packages.lock.json
@@ -393,8 +393,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.1-mypreview",
-        "contentHash": "J7AnEwgp0DTcYTmTXbxRo7GuszNyLXa11nbzyu91CateHnqhISYHxxRR7Piz1R7lyRh0+OVpyHfTvnqRV+cEnA==",
+        "resolved": "0.1.2-preview",
+        "contentHash": "K47L051GXYs9y5OdKt8+wcobJOn6dLGQjsBiegoZN9BdbCQtP0gI/PP8HxP9iO+Yx1K0LnDLgK9qZUO0WbLApQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.4.1"
         }
@@ -1874,7 +1874,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.1-mypreview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.2-preview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.0, )",
           "System.Collections.Immutable": "[8.0.0, )",


### PR DESCRIPTION
Updating typeloader version for MS Graph Preview, which updates identifier from `name` to `uniqueName` on MS Graph Bicep types for applications and groups.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/13091)