### PR TITLE
MAINT: Add c# devkit to github codespace config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,8 @@
         "ms-dotnettools.csharp",
         "ms-azuretools.vscode-docker",
         "editorconfig.editorconfig",
-        "github.vscode-pull-request-github"
+        "github.vscode-pull-request-github",
+        "ms-dotnettools.csdevkit"
       ]
     }
   },


### PR DESCRIPTION
## Overview
- Adds the C# devkit official extension to assist authors instead of prompting to install each time
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/13107)