### PR TITLE
BugFix: Fixes default config so it validates against the bicepconfig JSON schema

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Cli.IntegrationTests/packages.lock.json
@@ -729,6 +729,14 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
+      "Newtonsoft.Json.Schema": {
+        "type": "Transitive",
+        "resolved": "3.0.15",
+        "contentHash": "O/RBoXYm93pJy/JF3vRJxISALxup8CxKrBGXAyd/pFGrCa9hnSeHq/rQqkTnnpOcvtQwcEDfMZ+R5h871XEO5A==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
       "NuGet.Frameworks": {
         "type": "Transitive",
         "resolved": "6.5.0",
@@ -2180,6 +2188,7 @@
           "MSTest.TestFramework": "[3.1.1, )",
           "Microsoft.NET.Test.Sdk": "[17.8.0, )",
           "Moq": "[4.18.4, )",
+          "Newtonsoft.Json.Schema": "[3.0.15, )",
           "System.IO.Abstractions.TestingHelpers": "[20.0.4, )"
         }
       },

--- a/src/Bicep.Core.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Core.IntegrationTests/packages.lock.json
@@ -692,6 +692,14 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
+      "Newtonsoft.Json.Schema": {
+        "type": "Transitive",
+        "resolved": "3.0.15",
+        "contentHash": "O/RBoXYm93pJy/JF3vRJxISALxup8CxKrBGXAyd/pFGrCa9hnSeHq/rQqkTnnpOcvtQwcEDfMZ+R5h871XEO5A==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
       "NuGet.Frameworks": {
         "type": "Transitive",
         "resolved": "6.5.0",
@@ -2089,6 +2097,7 @@
           "MSTest.TestFramework": "[3.1.1, )",
           "Microsoft.NET.Test.Sdk": "[17.8.0, )",
           "Moq": "[4.18.4, )",
+          "Newtonsoft.Json.Schema": "[3.0.15, )",
           "System.IO.Abstractions.TestingHelpers": "[20.0.4, )"
         }
       },

--- a/src/Bicep.Core.Samples/packages.lock.json
+++ b/src/Bicep.Core.Samples/packages.lock.json
@@ -692,6 +692,14 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
+      "Newtonsoft.Json.Schema": {
+        "type": "Transitive",
+        "resolved": "3.0.15",
+        "contentHash": "O/RBoXYm93pJy/JF3vRJxISALxup8CxKrBGXAyd/pFGrCa9hnSeHq/rQqkTnnpOcvtQwcEDfMZ+R5h871XEO5A==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
       "NuGet.Frameworks": {
         "type": "Transitive",
         "resolved": "6.5.0",
@@ -2078,6 +2086,7 @@
           "MSTest.TestFramework": "[3.1.1, )",
           "Microsoft.NET.Test.Sdk": "[17.8.0, )",
           "Moq": "[4.18.4, )",
+          "Newtonsoft.Json.Schema": "[3.0.15, )",
           "System.IO.Abstractions.TestingHelpers": "[20.0.4, )"
         }
       },

--- a/src/Bicep.Core.UnitTests/Bicep.Core.UnitTests.csproj
+++ b/src/Bicep.Core.UnitTests/Bicep.Core.UnitTests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.15" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Bicep.Core.UnitTests/packages.lock.json
+++ b/src/Bicep.Core.UnitTests/packages.lock.json
@@ -91,6 +91,15 @@
         "resolved": "3.6.133",
         "contentHash": "VZWMd5YAeDxpjWjAP/X6bAxnRMiEf6tES/ITN0X5CHJgkWLLeHGmEALivmTAfYM6P+P/3Szy6VCITUAkqjcHVw=="
       },
+      "Newtonsoft.Json.Schema": {
+        "type": "Direct",
+        "requested": "[3.0.15, )",
+        "resolved": "3.0.15",
+        "contentHash": "O/RBoXYm93pJy/JF3vRJxISALxup8CxKrBGXAyd/pFGrCa9hnSeHq/rQqkTnnpOcvtQwcEDfMZ+R5h871XEO5A==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
       "System.IO.Abstractions.TestingHelpers": {
         "type": "Direct",
         "requested": "[20.0.4, )",

--- a/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
@@ -692,6 +692,14 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
+      "Newtonsoft.Json.Schema": {
+        "type": "Transitive",
+        "resolved": "3.0.15",
+        "contentHash": "O/RBoXYm93pJy/JF3vRJxISALxup8CxKrBGXAyd/pFGrCa9hnSeHq/rQqkTnnpOcvtQwcEDfMZ+R5h871XEO5A==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
       "NuGet.Frameworks": {
         "type": "Transitive",
         "resolved": "6.5.0",
@@ -2078,6 +2086,7 @@
           "MSTest.TestFramework": "[3.1.1, )",
           "Microsoft.NET.Test.Sdk": "[17.8.0, )",
           "Moq": "[4.18.4, )",
+          "Newtonsoft.Json.Schema": "[3.0.15, )",
           "System.IO.Abstractions.TestingHelpers": "[20.0.4, )"
         }
       },

--- a/src/Bicep.Decompiler.UnitTests/packages.lock.json
+++ b/src/Bicep.Decompiler.UnitTests/packages.lock.json
@@ -692,6 +692,14 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
+      "Newtonsoft.Json.Schema": {
+        "type": "Transitive",
+        "resolved": "3.0.15",
+        "contentHash": "O/RBoXYm93pJy/JF3vRJxISALxup8CxKrBGXAyd/pFGrCa9hnSeHq/rQqkTnnpOcvtQwcEDfMZ+R5h871XEO5A==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
       "NuGet.Frameworks": {
         "type": "Transitive",
         "resolved": "6.5.0",
@@ -2078,6 +2086,7 @@
           "MSTest.TestFramework": "[3.1.1, )",
           "Microsoft.NET.Test.Sdk": "[17.8.0, )",
           "Moq": "[4.18.4, )",
+          "Newtonsoft.Json.Schema": "[3.0.15, )",
           "System.IO.Abstractions.TestingHelpers": "[20.0.4, )"
         }
       },

--- a/src/Bicep.LangServer.IntegrationTests/packages.lock.json
+++ b/src/Bicep.LangServer.IntegrationTests/packages.lock.json
@@ -706,6 +706,14 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
+      "Newtonsoft.Json.Schema": {
+        "type": "Transitive",
+        "resolved": "3.0.15",
+        "contentHash": "O/RBoXYm93pJy/JF3vRJxISALxup8CxKrBGXAyd/pFGrCa9hnSeHq/rQqkTnnpOcvtQwcEDfMZ+R5h871XEO5A==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
       "NuGet.Frameworks": {
         "type": "Transitive",
         "resolved": "6.5.0",
@@ -2103,6 +2111,7 @@
           "MSTest.TestFramework": "[3.1.1, )",
           "Microsoft.NET.Test.Sdk": "[17.8.0, )",
           "Moq": "[4.18.4, )",
+          "Newtonsoft.Json.Schema": "[3.0.15, )",
           "System.IO.Abstractions.TestingHelpers": "[20.0.4, )"
         }
       },

--- a/src/Bicep.LangServer.UnitTests/packages.lock.json
+++ b/src/Bicep.LangServer.UnitTests/packages.lock.json
@@ -720,6 +720,14 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
+      "Newtonsoft.Json.Schema": {
+        "type": "Transitive",
+        "resolved": "3.0.15",
+        "contentHash": "O/RBoXYm93pJy/JF3vRJxISALxup8CxKrBGXAyd/pFGrCa9hnSeHq/rQqkTnnpOcvtQwcEDfMZ+R5h871XEO5A==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
       "NuGet.Frameworks": {
         "type": "Transitive",
         "resolved": "6.5.0",
@@ -2117,6 +2125,7 @@
           "MSTest.TestFramework": "[3.1.1, )",
           "Microsoft.NET.Test.Sdk": "[17.8.0, )",
           "Moq": "[4.18.4, )",
+          "Newtonsoft.Json.Schema": "[3.0.15, )",
           "System.IO.Abstractions.TestingHelpers": "[20.0.4, )"
         }
       },

--- a/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
@@ -858,6 +858,14 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
+      "Newtonsoft.Json.Schema": {
+        "type": "Transitive",
+        "resolved": "3.0.15",
+        "contentHash": "O/RBoXYm93pJy/JF3vRJxISALxup8CxKrBGXAyd/pFGrCa9hnSeHq/rQqkTnnpOcvtQwcEDfMZ+R5h871XEO5A==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
       "NuGet.Frameworks": {
         "type": "Transitive",
         "resolved": "6.5.0",
@@ -2329,6 +2337,7 @@
           "MSTest.TestFramework": "[3.1.1, )",
           "Microsoft.NET.Test.Sdk": "[17.8.0, )",
           "Moq": "[4.18.4, )",
+          "Newtonsoft.Json.Schema": "[3.0.15, )",
           "System.IO.Abstractions.TestingHelpers": "[20.0.4, )"
         }
       },

--- a/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
@@ -852,6 +852,14 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
+      "Newtonsoft.Json.Schema": {
+        "type": "Transitive",
+        "resolved": "3.0.15",
+        "contentHash": "O/RBoXYm93pJy/JF3vRJxISALxup8CxKrBGXAyd/pFGrCa9hnSeHq/rQqkTnnpOcvtQwcEDfMZ+R5h871XEO5A==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
       "NuGet.Frameworks": {
         "type": "Transitive",
         "resolved": "6.5.0",
@@ -2323,6 +2331,7 @@
           "MSTest.TestFramework": "[3.1.1, )",
           "Microsoft.NET.Test.Sdk": "[17.8.0, )",
           "Moq": "[4.18.4, )",
+          "Newtonsoft.Json.Schema": "[3.0.15, )",
           "System.IO.Abstractions.TestingHelpers": "[20.0.4, )"
         }
       },

--- a/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
@@ -858,6 +858,14 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
+      "Newtonsoft.Json.Schema": {
+        "type": "Transitive",
+        "resolved": "3.0.15",
+        "contentHash": "O/RBoXYm93pJy/JF3vRJxISALxup8CxKrBGXAyd/pFGrCa9hnSeHq/rQqkTnnpOcvtQwcEDfMZ+R5h871XEO5A==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
       "NuGet.Frameworks": {
         "type": "Transitive",
         "resolved": "6.5.0",
@@ -2329,6 +2337,7 @@
           "MSTest.TestFramework": "[3.1.1, )",
           "Microsoft.NET.Test.Sdk": "[17.8.0, )",
           "Moq": "[4.18.4, )",
+          "Newtonsoft.Json.Schema": "[3.0.15, )",
           "System.IO.Abstractions.TestingHelpers": "[20.0.4, )"
         }
       },

--- a/src/Bicep.Tools.Benchmark/packages.lock.json
+++ b/src/Bicep.Tools.Benchmark/packages.lock.json
@@ -774,6 +774,14 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
+      "Newtonsoft.Json.Schema": {
+        "type": "Transitive",
+        "resolved": "3.0.15",
+        "contentHash": "O/RBoXYm93pJy/JF3vRJxISALxup8CxKrBGXAyd/pFGrCa9hnSeHq/rQqkTnnpOcvtQwcEDfMZ+R5h871XEO5A==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
       "NuGet.Frameworks": {
         "type": "Transitive",
         "resolved": "6.5.0",
@@ -2190,6 +2198,7 @@
           "MSTest.TestFramework": "[3.1.1, )",
           "Microsoft.NET.Test.Sdk": "[17.8.0, )",
           "Moq": "[4.18.4, )",
+          "Newtonsoft.Json.Schema": "[3.0.15, )",
           "System.IO.Abstractions.TestingHelpers": "[20.0.4, )"
         }
       },

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -704,9 +704,6 @@
         "microsoftGraphPreview": {
           "type": "boolean"
         },
-        "assertions": {
-          "type": "boolean"
-        },
         "symbolicNameCodegen": {
           "type": "boolean"
         },
@@ -728,7 +725,7 @@
         "testFramework": {
           "type": "boolean"
         },
-        "asserts": {
+        "assertions": {
           "type": "boolean"
         },
         "dynamicTypeLoading": {

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -13,7 +13,12 @@
       "title": "Diagnostic Level",
       "description": "Type of diagnostic to display, most rules default to warning",
       "type": "string",
-      "enum": ["off", "info", "warning", "error"]
+      "enum": [
+        "off",
+        "info",
+        "warning",
+        "error"
+      ]
     },
     "rule-def-level-warning": {
       "type": "object",
@@ -25,7 +30,9 @@
           "$ref": "#/definitions/level"
         }
       },
-      "required": ["level"]
+      "required": [
+        "level"
+      ]
     },
     "rule-def-level-error": {
       "type": "object",
@@ -37,7 +44,9 @@
           "$ref": "#/definitions/level"
         }
       },
-      "required": ["level"]
+      "required": [
+        "level"
+      ]
     },
     "rule-def-level-off": {
       "type": "object",
@@ -49,12 +58,17 @@
           "$ref": "#/definitions/level"
         }
       },
-      "required": ["level"]
+      "required": [
+        "level"
+      ]
     },
     "cloudProfile": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["resourceManagerEndpoint", "activeDirectoryAuthority"],
+      "required": [
+        "resourceManagerEndpoint",
+        "activeDirectoryAuthority"
+      ],
       "properties": {
         "resourceManagerEndpoint": {
           "title": "Resource Manager Endpoint",
@@ -84,7 +98,10 @@
     "templateSpecModuleAlias": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["subscription", "resourceGroup"],
+      "required": [
+        "subscription",
+        "resourceGroup"
+      ],
       "properties": {
         "subscription": {
           "title": "Subscription ID",
@@ -105,7 +122,9 @@
     "bicepRegistryModuleAlias": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["registry"],
+      "required": [
+        "registry"
+      ],
       "properties": {
         "registry": {
           "title": "Registry",
@@ -125,7 +144,9 @@
     "bicepRegistryProviderAlias": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["registry"],
+      "required": [
+        "registry"
+      ],
       "properties": {
         "registry": {
           "title": "Registry",
@@ -150,14 +171,20 @@
       "title": "Cloud",
       "type": "object",
       "additionalProperties": false,
-      "required": ["currentProfile"],
+      "required": [
+        "currentProfile"
+      ],
       "properties": {
         "currentProfile": {
           "title": "Current Profile",
           "description": "The current cloud profile",
           "anyOf": [
             {
-              "enum": ["AzureCloud", "AzureChinaCloud", "AzureUSGovernment"]
+              "enum": [
+                "AzureCloud",
+                "AzureChinaCloud",
+                "AzureUSGovernment"
+              ]
             },
             {
               "type": "string"
@@ -199,7 +226,10 @@
                   "title": "Managed Identity Type",
                   "description": "The managed identity type",
                   "type": "string",
-                  "enum": ["SystemAssigned", "UserAssigned"],
+                  "enum": [
+                    "SystemAssigned",
+                    "UserAssigned"
+                  ],
                   "default": "SystemAssigned",
                   "enumDescriptions": [
                     "Use a system-assigned managed identity",
@@ -441,7 +471,9 @@
                         "excludedhosts": {
                           "description": "Customize the list of hosts to allow even if they contain an excluded host as a substring",
                           "type": "array",
-                          "default": ["schema.management.azure.com"],
+                          "default": [
+                            "schema.management.azure.com"
+                          ],
                           "items": {
                             "$id": "#/analyzers/core/rules/no-hardcoded-env-urls/excludedhosts/items",
                             "title": "Items",
@@ -697,9 +729,16 @@
       "description": "The directory in which Bicep may cache templates downloaded from remote registries"
     },
     "experimentalFeaturesEnabled": {
+      "_comment": "Documentation for these features can be found at https://github.com/Azure/bicep/blob/main/docs/experimental-features.md",
       "type": "object",
       "description": "The experimental Bicep features that should be enabled or disabled for templates using this configuration file",
       "properties": {
+        "microsoftGraphPreview": {
+          "type": "boolean"
+        },
+        "assertions": {
+          "type": "boolean"
+        },
         "symbolicNameCodegen": {
           "type": "boolean"
         },
@@ -752,12 +791,19 @@
         "indentKind": {
           "type": "string",
           "description": "The indentation kind",
-          "enum": ["Space", "Tab"]
+          "enum": [
+            "Space",
+            "Tab"
+          ]
         },
         "newlineKind": {
           "type": "string",
           "description": "The newline kind",
-          "enum": ["LF", "CRLF", "CR"]
+          "enum": [
+            "LF",
+            "CRLF",
+            "CR"
+          ]
         },
         "indentSize": {
           "type": "integer",

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -13,12 +13,7 @@
       "title": "Diagnostic Level",
       "description": "Type of diagnostic to display, most rules default to warning",
       "type": "string",
-      "enum": [
-        "off",
-        "info",
-        "warning",
-        "error"
-      ]
+      "enum": ["off", "info", "warning", "error"]
     },
     "rule-def-level-warning": {
       "type": "object",
@@ -30,9 +25,7 @@
           "$ref": "#/definitions/level"
         }
       },
-      "required": [
-        "level"
-      ]
+      "required": ["level"]
     },
     "rule-def-level-error": {
       "type": "object",
@@ -44,9 +37,7 @@
           "$ref": "#/definitions/level"
         }
       },
-      "required": [
-        "level"
-      ]
+      "required": ["level"]
     },
     "rule-def-level-off": {
       "type": "object",
@@ -58,17 +49,12 @@
           "$ref": "#/definitions/level"
         }
       },
-      "required": [
-        "level"
-      ]
+      "required": ["level"]
     },
     "cloudProfile": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "resourceManagerEndpoint",
-        "activeDirectoryAuthority"
-      ],
+      "required": ["resourceManagerEndpoint", "activeDirectoryAuthority"],
       "properties": {
         "resourceManagerEndpoint": {
           "title": "Resource Manager Endpoint",
@@ -98,10 +84,7 @@
     "templateSpecModuleAlias": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "subscription",
-        "resourceGroup"
-      ],
+      "required": ["subscription", "resourceGroup"],
       "properties": {
         "subscription": {
           "title": "Subscription ID",
@@ -122,9 +105,7 @@
     "bicepRegistryModuleAlias": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "registry"
-      ],
+      "required": ["registry"],
       "properties": {
         "registry": {
           "title": "Registry",
@@ -144,9 +125,7 @@
     "bicepRegistryProviderAlias": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "registry"
-      ],
+      "required": ["registry"],
       "properties": {
         "registry": {
           "title": "Registry",
@@ -171,20 +150,14 @@
       "title": "Cloud",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "currentProfile"
-      ],
+      "required": ["currentProfile"],
       "properties": {
         "currentProfile": {
           "title": "Current Profile",
           "description": "The current cloud profile",
           "anyOf": [
             {
-              "enum": [
-                "AzureCloud",
-                "AzureChinaCloud",
-                "AzureUSGovernment"
-              ]
+              "enum": ["AzureCloud", "AzureChinaCloud", "AzureUSGovernment"]
             },
             {
               "type": "string"
@@ -226,10 +199,7 @@
                   "title": "Managed Identity Type",
                   "description": "The managed identity type",
                   "type": "string",
-                  "enum": [
-                    "SystemAssigned",
-                    "UserAssigned"
-                  ],
+                  "enum": ["SystemAssigned", "UserAssigned"],
                   "default": "SystemAssigned",
                   "enumDescriptions": [
                     "Use a system-assigned managed identity",
@@ -471,9 +441,7 @@
                         "excludedhosts": {
                           "description": "Customize the list of hosts to allow even if they contain an excluded host as a substring",
                           "type": "array",
-                          "default": [
-                            "schema.management.azure.com"
-                          ],
+                          "default": ["schema.management.azure.com"],
                           "items": {
                             "$id": "#/analyzers/core/rules/no-hardcoded-env-urls/excludedhosts/items",
                             "title": "Items",
@@ -791,19 +759,12 @@
         "indentKind": {
           "type": "string",
           "description": "The indentation kind",
-          "enum": [
-            "Space",
-            "Tab"
-          ]
+          "enum": ["Space", "Tab"]
         },
         "newlineKind": {
           "type": "string",
           "description": "The newline kind",
-          "enum": [
-            "LF",
-            "CRLF",
-            "CR"
-          ]
+          "enum": ["LF", "CRLF", "CR"]
         },
         "indentSize": {
           "type": "integer",


### PR DESCRIPTION
## Overview
- Adds a test that checks default config so it validates against the bicepconfig JSON schema
- Fixes the bicepconfig schema to account for the experimentalFeatures that are missing
- Moves the BicepConfigSchemaTests.cs to the UnitTests.Config namespace since its not specific to Diagnostics

Related to https://github.com/Azure/bicep/issues/13109
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/13111)