### PR TITLE
Ensure safe access of output guards against missing `value` property

### DIFF
--- a/src/Bicep.Core.IntegrationTests/SafeDereferenceTests.cs
+++ b/src/Bicep.Core.IntegrationTests/SafeDereferenceTests.cs
@@ -183,43 +183,43 @@ output outputData object = {
     public void Safe_dereference_of_module_output_properties_converts_correctly()
     {
         var result = CompilationHelper.Compile(ServicesWithResourceTypedParamsAndOutputsEnabled,
-            ("mod.bicep", @"
-output outputData object = {
-  key: 'value'
-  nested: {
-    key: 'value'
-  }
-}
-"),
-            ("main.bicep", @"
-module mod './mod.bicep' = {
-  name: 'mod'
-}
+            ("mod.bicep", """
+                output outputData object? = {
+                  key: 'value'
+                  nested: {
+                    key: 'value'
+                  }
+                }
+                """),
+            ("main.bicep", """
+                module mod './mod.bicep' = {
+                  name: 'mod'
+                }
 
-output outputData object = {
-  output: mod.outputs.outputData
-  maybeOutput: mod.outputs.?outputData
-  topLevelProperty: mod.outputs.outputData.key
-  maybeTopLevelProperty: mod.outputs.outputData.?key
-  maybeOutputTopLevelProperty: mod.outputs.?outputData.key
-  maybeOutputMaybeTopLevelProperty: mod.outputs.?outputData.?key
-  nestedProperty: mod.outputs.outputData.nested.key
-  maybeNestedProperty: mod.outputs.outputData.?nested.key
-  maybeOutputNestedProperty: mod.outputs.?outputData.nested.key
-}
-"));
+                output outputData object = {
+                  output: mod.outputs.outputData
+                  maybeOutput: mod.outputs.?outputData
+                  topLevelProperty: mod.outputs.outputData.key
+                  maybeTopLevelProperty: mod.outputs.outputData.?key
+                  maybeOutputTopLevelProperty: mod.outputs.?outputData.key
+                  maybeOutputMaybeTopLevelProperty: mod.outputs.?outputData.?key
+                  nestedProperty: mod.outputs.outputData.nested.key
+                  maybeNestedProperty: mod.outputs.outputData.?nested.key
+                  maybeOutputNestedProperty: mod.outputs.?outputData.nested.key
+                }
+                """));
         var compiledOutputData = result.Template?["outputs"]?["outputData"]?["value"];
         compiledOutputData.Should().NotBeNull();
 
         compiledOutputData!["output"].Should().DeepEqual("[reference(resourceId('Microsoft.Resources/deployments', 'mod'), '2022-09-01').outputs.outputData.value]");
-        compiledOutputData!["maybeOutput"].Should().DeepEqual("[tryGet(reference(resourceId('Microsoft.Resources/deployments', 'mod'), '2022-09-01').outputs, 'outputData', 'value')]");
+        compiledOutputData!["maybeOutput"].Should().DeepEqual("[tryGet(tryGet(reference(resourceId('Microsoft.Resources/deployments', 'mod'), '2022-09-01').outputs, 'outputData'), 'value')]");
         compiledOutputData!["topLevelProperty"].Should().DeepEqual("[reference(resourceId('Microsoft.Resources/deployments', 'mod'), '2022-09-01').outputs.outputData.value.key]");
         compiledOutputData!["maybeTopLevelProperty"].Should().DeepEqual("[tryGet(reference(resourceId('Microsoft.Resources/deployments', 'mod'), '2022-09-01').outputs.outputData.value, 'key')]");
-        compiledOutputData!["maybeOutputTopLevelProperty"].Should().DeepEqual("[tryGet(reference(resourceId('Microsoft.Resources/deployments', 'mod'), '2022-09-01').outputs, 'outputData', 'value', 'key')]");
-        compiledOutputData!["maybeOutputMaybeTopLevelProperty"].Should().DeepEqual("[tryGet(tryGet(reference(resourceId('Microsoft.Resources/deployments', 'mod'), '2022-09-01').outputs, 'outputData', 'value'), 'key')]");
+        compiledOutputData!["maybeOutputTopLevelProperty"].Should().DeepEqual("[tryGet(tryGet(reference(resourceId('Microsoft.Resources/deployments', 'mod'), '2022-09-01').outputs, 'outputData'), 'value', 'key')]");
+        compiledOutputData!["maybeOutputMaybeTopLevelProperty"].Should().DeepEqual("[tryGet(tryGet(tryGet(reference(resourceId('Microsoft.Resources/deployments', 'mod'), '2022-09-01').outputs, 'outputData'), 'value'), 'key')]");
         compiledOutputData!["nestedProperty"].Should().DeepEqual("[reference(resourceId('Microsoft.Resources/deployments', 'mod'), '2022-09-01').outputs.outputData.value.nested.key]");
         compiledOutputData!["maybeNestedProperty"].Should().DeepEqual("[tryGet(reference(resourceId('Microsoft.Resources/deployments', 'mod'), '2022-09-01').outputs.outputData.value, 'nested', 'key')]");
-        compiledOutputData!["maybeOutputNestedProperty"].Should().DeepEqual("[tryGet(reference(resourceId('Microsoft.Resources/deployments', 'mod'), '2022-09-01').outputs, 'outputData', 'value', 'nested', 'key')]");
+        compiledOutputData!["maybeOutputNestedProperty"].Should().DeepEqual("[tryGet(tryGet(reference(resourceId('Microsoft.Resources/deployments', 'mod'), '2022-09-01').outputs, 'outputData'), 'value', 'nested', 'key')]");
     }
 
     [TestMethod]

--- a/src/Bicep.Core/Emit/ExpressionConverter.cs
+++ b/src/Bicep.Core/Emit/ExpressionConverter.cs
@@ -234,7 +234,18 @@ namespace Bicep.Core.Emit
 
             if (expression is ModuleOutputPropertyAccessExpression)
             {
-                properties = properties.Append(new JTokenExpression("value"));
+                if (safeAccess)
+                {
+                    // there are two scenarios we want to handle in this case:
+                    //   - conditional outputs (where the accessed property will be omitted from the `outputs` object)
+                    //   - outputs with a null value (where the accessed property will be present in the `outputs` object, but its `value` property will be omitted)
+                    @base = CreateFunction("tryGet", @base.AsEnumerable().Concat(properties));
+                    properties = new[] { new JTokenExpression("value") };
+                }
+                else
+                {
+                    properties = properties.Append(new JTokenExpression("value"));
+                }
             }
 
             return (@base, properties, safeAccess);


### PR DESCRIPTION
Resolves #13160 

Safe dereference of a module output (`mod.outputs.?foo`) is currently written to guard against conditional outputs with a `false` condition (i.e., it would be equivalent to writing `mod.outputs.?foo.value` if Bicep didn't automatically inject the `.value` into module output reference expressions). It currently doesn't guard against outputs whose value is `null` (which will cause the ARM engine to omit the `.value` property).

This PR updates the expression converter to make `mod.outputs.?foo` compile to something like `[tryGet(tryGet(reference('mod').outputs, 'foo'), 'value')]` to ensure both cases described above evaluate to `null` when evaluated by the ARM engine.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/13162)