### PR TITLE
Upgraded SDK to 8.0.1

### DIFF
--- a/global.json
+++ b/global.json
@@ -4,7 +4,7 @@
   },
   "sdk": {
     "allowPrerelease": false,
-    "version": "8.0.100",
+    "version": "8.0.101",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
We have an official build failure due to the Microsoft.NET.ILLink.Tasks (pulled in by the Bicep.Wasm project) having version 8.0.1 in the lock file but 8.0.0 on the build machine. This seems to correlate with the official build machine picking up SDK 8.0.0 during the failed build. At the same time, my local dev machine is using 8.0.1 and force regenerating lock files results in no changes.

Let's see if upgrading the SDK to 8.0.1 fixes it.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/13183)