### PR TITLE
Deprecate v1 formatter in linter rules and tests

### DIFF
--- a/src/Bicep.Cli/Commands/FormatCommand.cs
+++ b/src/Bicep.Cli/Commands/FormatCommand.cs
@@ -59,11 +59,11 @@ public class FormatCommand : ICommand
         if (featureProvider.PrettyPrintingEnabled)
         {
             var v2Options = this.configurationManager.GetConfiguration(inputUri).Formatting.Data;
-            var printerV2Context = PrettyPrinterV2Context.Create(program, v2Options, parser.LexingErrorLookup, parser.ParsingErrorLookup);
+            var printerV2Context = PrettyPrinterV2Context.Create(v2Options, parser.LexingErrorLookup, parser.ParsingErrorLookup);
 
             if (args.OutputToStdOut)
             {
-                PrettyPrinterV2.PrintTo(io.Output, printerV2Context);
+                PrettyPrinterV2.PrintTo(io.Output, program, printerV2Context);
                 io.Output.Flush();
             }
             else
@@ -71,7 +71,7 @@ public class FormatCommand : ICommand
                 var outputPath = PathHelper.ResolveDefaultOutputPath(inputUri.LocalPath, args.OutputDir, args.OutputFile, path => path);
                 using var writer = new StreamWriter(outputPath);
 
-                PrettyPrinterV2.PrintTo(writer, printerV2Context);
+                PrettyPrinterV2.PrintTo(writer, program, printerV2Context);
             }
 
             return 0;

--- a/src/Bicep.Cli/Helpers/ParamsFileHelper.cs
+++ b/src/Bicep.Cli/Helpers/ParamsFileHelper.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Immutable;
 using System.Globalization;
-using Bicep.Core.Navigation;
 using Bicep.Core.Syntax;
 using Bicep.Core.Syntax.Rewriters;
 using Bicep.Core.Workspaces;
@@ -86,6 +85,6 @@ public static class ParamsFileHelper
             return sourceFile;
         }
 
-        return SourceFileFactory.CreateBicepParamFile(sourceFile.FileUri, newProgramSyntax.ToText());
+        return SourceFileFactory.CreateBicepParamFile(sourceFile.FileUri, newProgramSyntax.ToString());
     }
 }

--- a/src/Bicep.Core.IntegrationTests/ParserTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParserTests.cs
@@ -99,7 +99,7 @@ namespace Bicep.Core.IntegrationTests
             var program = ParserHelper.Parse(contents);
             program.Should().BeOfType<ProgramSyntax>();
 
-            program.ToTextPreserveFormatting().Should().Be(contents);
+            program.ToString().Should().Be(contents);
         }
 
         private static void RunSpanConsistencyTest(string text)

--- a/src/Bicep.Core.IntegrationTests/PrettyPrint/PrettyPrinterTests.cs
+++ b/src/Bicep.Core.IntegrationTests/PrettyPrint/PrettyPrinterTests.cs
@@ -74,8 +74,8 @@ namespace Bicep.Core.IntegrationTests.PrettyPrint
 
             // Normalize formatting
             var regex = new Regex("[\\r\\n\\s]+");
-            string programText = regex.Replace(program.ToTextPreserveFormatting(), "");
-            string formattedProgramText = regex.Replace(formattedProgram.ToTextPreserveFormatting(), "");
+            string programText = regex.Replace(program.ToString(), "");
+            string formattedProgramText = regex.Replace(formattedProgram.ToString(), "");
 
             formattedProgramText.Should().Be(programText);
         }

--- a/src/Bicep.Core.IntegrationTests/PrettyPrint/PrettyPrinterV2Tests.cs
+++ b/src/Bicep.Core.IntegrationTests/PrettyPrint/PrettyPrinterV2Tests.cs
@@ -85,9 +85,9 @@ namespace Bicep.Core.IntegrationTests.PrettyPrint
                 ? ParserHelper.ParamsParse(programText, out var lexingErrorLookup, out var parsingErrorLookup)
                 : ParserHelper.Parse(programText, out lexingErrorLookup, out parsingErrorLookup);
 
-            var context = PrettyPrinterV2Context.Create(program, options, lexingErrorLookup, parsingErrorLookup);
+            var context = PrettyPrinterV2Context.Create(options, lexingErrorLookup, parsingErrorLookup);
 
-            return PrettyPrinterV2.Print(context);
+            return PrettyPrinterV2.Print(program, context);
         }
 
         private static IEnumerable<object[]> GetData() => DataSets.AllDataSets

--- a/src/Bicep.Core.UnitTests/Assertions/BicepFileAssertions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/BicepFileAssertions.cs
@@ -27,15 +27,15 @@ namespace Bicep.Core.UnitTests.Assertions
 
         public AndConstraint<BicepFileAssertions> HaveSourceText(string expected, string because = "", params object[] becauseArgs)
         {
-            Subject.ProgramSyntax.ToTextPreserveFormatting().Should().EqualIgnoringNewlines(expected, because, becauseArgs);
+            Subject.ProgramSyntax.ToString().Should().EqualIgnoringNewlines(expected, because, becauseArgs);
 
             return new AndConstraint<BicepFileAssertions>(this);
         }
 
         public AndConstraint<BicepFileAssertions> HaveEquivalentSourceText(BicepFile other, string because = "", params object[] becauseArgs)
         {
-            var expectedText = Subject.ProgramSyntax.ToTextPreserveFormatting();
-            var actualText = other.ProgramSyntax.ToTextPreserveFormatting();
+            var expectedText = Subject.ProgramSyntax.ToString();
+            var actualText = other.ProgramSyntax.ToString();
 
             expectedText.Should().EqualIgnoringNewlines(actualText, because, becauseArgs);
 

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseRecentApiVersionRule_InReferenceFunctions_Tests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseRecentApiVersionRule_InReferenceFunctions_Tests.cs
@@ -51,7 +51,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                     var actual = UseRecentApiVersionRule.GetFunctionCallInfos(result.Compilation.GetEntrypointSemanticModel());
                     actual.Should().HaveCount(1, "Expecting a single function call per test");
                     var typedActual = new ExpectedFunctionInfo(
-                            actual.First().FunctionCallSyntax.ToText(),
+                            actual.First().FunctionCallSyntax.ToString(),
                             actual.First().ResourceType,
                             actual.First().ApiVersion?.Formatted);
 
@@ -187,7 +187,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                     var lbPublicIPName = 'lbPublicIPName'
                     output o string = reference(resourceId('Fake.Network/publicIPAddresses', lbPublicIPName),'2420-08-01').dnsSettings.fqdn
                 ",
-                "reference(resourceId('Fake.Network/publicIPAddresses', lbPublicIPName), '2420-08-01')",
+                "reference(resourceId('Fake.Network/publicIPAddresses', lbPublicIPName),'2420-08-01')",
                 "Fake.Network/publicIPAddresses",
                 "2420-08-01"
             )]

--- a/src/Bicep.Core.UnitTests/PrettyPrintV2/PrettyPrinterV2Tests.cs
+++ b/src/Bicep.Core.UnitTests/PrettyPrintV2/PrettyPrinterV2Tests.cs
@@ -33,7 +33,6 @@ namespace Bicep.Core.UnitTests.PrettyPrintV2
 
         [DataTestMethod]
         [DataRow(IndentKind.Space, NewlineKind.CRLF, 2, true, "var foo = {\r\n  prop1: true\r\n  prop2: false\r\n  prop3: {\r\n    nestedProp1: 1\r\n    nestedProp2: 2\r\n  }\r\n}\r\n\r\nvar bar = [\r\n  1\r\n  2\r\n  {\r\n    prop1: true\r\n    prop2: false\r\n  }\r\n]\r\n")]
-        [DataRow(IndentKind.Space, NewlineKind.Auto, 4, false, "var foo = {\n    prop1: true\n    prop2: false\n    prop3: {\n        nestedProp1: 1\n        nestedProp2: 2\n    }\n}\n\nvar bar = [\n    1\n    2\n    {\n        prop1: true\n        prop2: false\n    }\n]")]
         [DataRow(IndentKind.Tab, NewlineKind.LF, 0, false, "var foo = {\n\tprop1: true\n\tprop2: false\n\tprop3: {\n\t\tnestedProp1: 1\n\t\tnestedProp2: 2\n\t}\n}\n\nvar bar = [\n\t1\n\t2\n\t{\n\t\tprop1: true\n\t\tprop2: false\n\t}\n]")]
         [DataRow(IndentKind.Tab, NewlineKind.CR, 2, true, "var foo = {\r\tprop1: true\r\tprop2: false\r\tprop3: {\r\t\tnestedProp1: 1\r\t\tnestedProp2: 2\r\t}\r}\r\rvar bar = [\r\t1\r\t2\r\t{\r\t\tprop1: true\r\t\tprop2: false\r\t}\r]\r")]
         public void Print_VariousOptions_PrintsAccordingly(IndentKind indentKind, NewlineKind newlineKind, int indentSize, bool insertFinalNewline, string expectedOutput)
@@ -47,9 +46,9 @@ namespace Bicep.Core.UnitTests.PrettyPrintV2
             };
 
             var program = ParserHelper.Parse(ProgramText, out var lexingErrorLookup, out var parsingErrorLookup);
-            var context = PrettyPrinterV2Context.Create(program, options, lexingErrorLookup, parsingErrorLookup);
+            var context = PrettyPrinterV2Context.Create(options, lexingErrorLookup, parsingErrorLookup);
 
-            var output = PrettyPrinterV2.Print(context);
+            var output = PrettyPrinterV2.Print(program, context);
 
             output.Should().Be(expectedOutput);
         }
@@ -59,9 +58,9 @@ namespace Bicep.Core.UnitTests.PrettyPrintV2
         {
             var programText = " var foo = { \n prop1: true  \n   \nprop2: false }\n";
             var program = ParserHelper.Parse(programText, out var lexingErrorLookup, out var parsingErrorLookup);
-            var context = PrettyPrinterV2Context.Create(program, PrettyPrinterV2Options.Default, lexingErrorLookup, parsingErrorLookup);
+            var context = PrettyPrinterV2Context.Create(PrettyPrinterV2Options.Default, lexingErrorLookup, parsingErrorLookup);
 
-            var output = PrettyPrinterV2.Print(context);
+            var output = PrettyPrinterV2.Print(program, context);
 
             output.Should().Be("var foo = {\n  prop1: true\n\n  prop2: false\n}\n");
         }
@@ -71,9 +70,9 @@ namespace Bicep.Core.UnitTests.PrettyPrintV2
         {
             var programText = "\n\n\n \n \n // comment  \nvar foo = true\n \n // comment \n \n";
             var program = ParserHelper.Parse(programText, out var lexingErrorLookup, out var parsingErrorLookup);
-            var context = PrettyPrinterV2Context.Create(program, PrettyPrinterV2Options.Default, lexingErrorLookup, parsingErrorLookup);
+            var context = PrettyPrinterV2Context.Create(PrettyPrinterV2Options.Default, lexingErrorLookup, parsingErrorLookup);
 
-            var output = PrettyPrinterV2.Print(context);
+            var output = PrettyPrinterV2.Print(program, context);
 
             output.Should().Be("// comment  \nvar foo = true\n\n// comment \n");
         }
@@ -83,9 +82,9 @@ namespace Bicep.Core.UnitTests.PrettyPrintV2
         {
             var programText = " var foo = {\n prop1: true\n\n\n \n\n   \n\n\nprop2: false}\n\n \n/* leading comment */ \n\n\n   \nvar bar = 1\n";
             var program = ParserHelper.Parse(programText, out var lexingErrorLookup, out var parsingErrorLookup);
-            var context = PrettyPrinterV2Context.Create(program, PrettyPrinterV2Options.Default, lexingErrorLookup, parsingErrorLookup);
+            var context = PrettyPrinterV2Context.Create(PrettyPrinterV2Options.Default, lexingErrorLookup, parsingErrorLookup);
 
-            var output = PrettyPrinterV2.Print(context);
+            var output = PrettyPrinterV2.Print(program, context);
 
             output.Should().Be("var foo = {\n  prop1: true\n\n  prop2: false\n}\n\n/* leading comment */\n\nvar bar = 1\n");
         }

--- a/src/Bicep.Core.UnitTests/Syntax/SyntaxModifierTests.cs
+++ b/src/Bicep.Core.UnitTests/Syntax/SyntaxModifierTests.cs
@@ -34,7 +34,7 @@ public class SyntaxModifierTests
 
         var rewrittenProgram = rewriteFunc(program, nodes, parsingErrorLookup);
 
-        return rewrittenProgram.ToTextPreserveFormatting();
+        return rewrittenProgram.ToString();
     }
 
     [DataTestMethod]

--- a/src/Bicep.Core.UnitTests/Utils/PrintHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/PrintHelper.cs
@@ -47,7 +47,7 @@ namespace Bicep.Core.UnitTests.Utils
 
         private static string[] GetProgramTextLines(BicepSourceFile bicepFile)
         {
-            var programText = bicepFile.ProgramSyntax.ToTextPreserveFormatting();
+            var programText = bicepFile.ProgramSyntax.ToString();
 
             return StringUtils.ReplaceNewlines(programText, "\n").Split("\n");
         }

--- a/src/Bicep.Core/Analyzers/Linter/Common/FindPossibleSecretsVisitor.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Common/FindPossibleSecretsVisitor.cs
@@ -52,7 +52,7 @@ namespace Bicep.Core.Analyzers.Linter.Common
         public override void VisitPropertyAccessSyntax(PropertyAccessSyntax syntax)
         {
             possibleSecrets.AddRange(FindPathsToSecureTypeComponents(semanticModel.GetTypeInfo(syntax))
-                .Select(pathToSecureComponent => new PossibleSecret(syntax.PropertyName, PossibleSecretMessage(syntax.ToTextPreserveFormatting() + pathToSecureComponent))));
+                .Select(pathToSecureComponent => new PossibleSecret(syntax.PropertyName, PossibleSecretMessage(syntax.ToString() + pathToSecureComponent))));
 
             trailingAccessExpressions++;
             base.VisitPropertyAccessSyntax(syntax);
@@ -62,7 +62,7 @@ namespace Bicep.Core.Analyzers.Linter.Common
         public override void VisitArrayAccessSyntax(ArrayAccessSyntax syntax)
         {
             possibleSecrets.AddRange(FindPathsToSecureTypeComponents(semanticModel.GetTypeInfo(syntax))
-                .Select(pathToSecureComponent => new PossibleSecret(syntax.IndexExpression, PossibleSecretMessage(syntax.ToTextPreserveFormatting() + pathToSecureComponent))));
+                .Select(pathToSecureComponent => new PossibleSecret(syntax.IndexExpression, PossibleSecretMessage(syntax.ToString() + pathToSecureComponent))));
 
             trailingAccessExpressions++;
             base.VisitArrayAccessSyntax(syntax);

--- a/src/Bicep.Core/Analyzers/Linter/Common/LinterExpressionHelper.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Common/LinterExpressionHelper.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Text.RegularExpressions;
-using Bicep.Core.Navigation;
 using Bicep.Core.Semantics;
 using Bicep.Core.Semantics.Metadata;
 using Bicep.Core.Syntax;
@@ -88,13 +87,13 @@ namespace Bicep.Core.Analyzers.Linter.Common
 
             if (resourcesAndNames.Any())
             {
-                string formattedSearchName = resourceNameExpression.ToText();
+                string searchName = resourceNameExpression.ToString();
                 string? evaluatedSearchNameLiteral = TryGetEvaluatedStringLiteral(model, resourceNameExpression)?.stringValue;
 
                 foreach (var (resource, resourceName) in resourcesAndNames)
                 {
-                    // First try a formatted expression match
-                    if (resourceName.ToText().EqualsOrdinally(formattedSearchName))
+                    // First try a expression text match
+                    if (resourceName.ToString().EqualsOrdinally(searchName))
                     {
                         yield return resource;
                     }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/NoHardcodedLocationRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/NoHardcodedLocationRule.cs
@@ -104,7 +104,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                     CodeFixKind.QuickFix,
                     new CodeReplacement(
                         definingVariable.DeclaringSyntax.Span,
-                        $"param {definingVariable.Name} string = {definingVariable.DeclaringVariable.Value.ToTextPreserveFormatting()}"));
+                        $"param {definingVariable.Name} string = {definingVariable.DeclaringVariable.Value.ToString()}"));
                 diagnostics.Add(this.CreateFixableDiagnosticForSpan(diagnosticLevel, errorSpan, fix, msg));
             }
             else
@@ -116,7 +116,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
 
                 // Fix: Create a new parameter
                 string newParamName = GetUnusedTopLevelName("location", model);
-                string newDefaultValue = locationValueSyntax.ToTextPreserveFormatting();
+                string newDefaultValue = locationValueSyntax.ToString();
                 CodeReplacement insertNewParamDefinition = new(
                         TextSpan.TextDocumentStart,
                         $"@description('Specifies the location for resources.')\n"

--- a/src/Bicep.Core/Analyzers/Linter/Rules/NoUnnecessaryDependsOnRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/NoUnnecessaryDependsOnRule.cs
@@ -102,13 +102,13 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                         continue;
                     }
 
-                    CodeReplacement? codeReplacement = null;
+                    CodeReplacement codeReplacement = CodeReplacement.Nil;
                     if (declaredDependencies.Items.Count() == 1)
                     {
                         // we only have one entry - remove the whole dependsOn property
                         if (SyntaxModifier.TryRemoveProperty(body, dependsOnProperty, model.ParsingErrorLookup) is { } newObject)
                         {
-                            codeReplacement = new CodeReplacement(body.Span, newObject.ToTextPreserveFormatting());
+                            codeReplacement = new CodeReplacement(body.Span, newObject.ToString());
                         }
                     }
                     else
@@ -116,13 +116,13 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                         // we have multiple entries - just remove this one
                         if (SyntaxModifier.TryRemoveItem(declaredDependencies, declaredDependency, model.ParsingErrorLookup) is { } newArray)
                         {
-                            codeReplacement = new CodeReplacement(declaredDependencies.Span, newArray.ToTextPreserveFormatting());
+                            codeReplacement = new CodeReplacement(declaredDependencies.Span, newArray.ToString());
                         }
                     }
 
                     // if the syntax is in an invald state, we may not have a replacement.
                     // just return a diagnostic and leave it up to the user.
-                    if (codeReplacement is null)
+                    if (codeReplacement.IsNil)
                     {
                         this.diagnostics.Add(
                             parent.CreateDiagnosticForSpan(

--- a/src/Bicep.Core/Analyzers/Linter/Rules/PreferInterpolationRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/PreferInterpolationRule.cs
@@ -84,7 +84,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             {
                 if (RewriteConcatToInterpolate(functionCallSyntax) is StringSyntax newSyntax)
                 {
-                    return CodeReplacement.FromSyntax(functionCallSyntax.Span, newSyntax);
+                    return new CodeReplacement(functionCallSyntax.Span, newSyntax.ToString());
                 }
                 return null;
             }
@@ -97,10 +97,6 @@ namespace Bicep.Core.Analyzers.Linter.Rules
 
             private StringSyntax RewriteConcatCallback(FunctionCallSyntax syntax)
             {
-                var tokens = new List<Token>();
-                var expressions = new List<SyntaxBase>();
-                var segments = new List<string>();
-
                 var flattened = SyntaxFactory.FlattenStringOperations(syntax);
                 if (flattened is FunctionCallSyntax concatSyntax)
                 {

--- a/src/Bicep.Core/Analyzers/Linter/Rules/PreferUnquotedPropertyNamesRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/PreferUnquotedPropertyNamesRule.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Bicep.Core.CodeAction;
 using Bicep.Core.Diagnostics;
-using Bicep.Core.Navigation;
 using Bicep.Core.Parsing;
 using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
@@ -54,7 +53,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                 if (TryGetValidIdentifierToken(syntax.IndexExpression, out string? literal))
                 {
                     var replacement = $".{literal}";
-                    var message = string.Format(CoreResources.PreferUnquotedPropertyNames_DereferenceFixTitle, $"{syntax.BaseExpression.ToText()}{replacement}");
+                    var message = string.Format(CoreResources.PreferUnquotedPropertyNames_DereferenceFixTitle, $"{syntax.BaseExpression}{replacement}");
                     AddCodeFix(TextSpan.Between(syntax.OpenSquare, syntax.CloseSquare), replacement, message);
                 }
 

--- a/src/Bicep.Core/Analyzers/Linter/Rules/SecretsInParamsMustBeSecureRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/SecretsInParamsMustBeSecureRule.cs
@@ -5,8 +5,8 @@ using System.Text.RegularExpressions;
 using Bicep.Core.Analyzers.Linter.Common;
 using Bicep.Core.CodeAction;
 using Bicep.Core.Diagnostics;
-using Bicep.Core.Navigation;
 using Bicep.Core.Parsing;
+using Bicep.Core.PrettyPrintV2;
 using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
 using Bicep.Core.TypeSystem;
@@ -51,7 +51,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             {
                 if (!param.IsSecure())
                 {
-                    if (AnalyzeUnsecuredParameter(diagnosticLevel, param) is IDiagnostic diag)
+                    if (AnalyzeUnsecuredParameter(model, diagnosticLevel, param) is IDiagnostic diag)
                     {
                         yield return diag;
                     }
@@ -59,7 +59,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             }
         }
 
-        private IDiagnostic? AnalyzeUnsecuredParameter(DiagnosticLevel diagnosticLevel, ParameterSymbol parameterSymbol)
+        private AnalyzerFixableDiagnostic? AnalyzeUnsecuredParameter(SemanticModel model, DiagnosticLevel diagnosticLevel, ParameterSymbol parameterSymbol)
         {
             string name = parameterSymbol.Name;
             TypeSymbol type = parameterSymbol.Type;
@@ -71,7 +71,8 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                     {
                         // Create fix
                         var decorator = SyntaxFactory.CreateDecorator("secure");
-                        var decoratorText = $"{decorator.ToText()}\n";
+                        var newline = model.Configuration.Formatting.Data.NewlineKind.ToEscapeSequence();
+                        var decoratorText = $"{decorator}{newline}";
                         var fixSpan = new TextSpan(parameterSymbol.DeclaringSyntax.Span.Position, 0);
                         var codeReplacement = new CodeReplacement(fixSpan, decoratorText);
 

--- a/src/Bicep.Core/Analyzers/Linter/Rules/SecureParamsInNestedDeploymentsRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/SecureParamsInNestedDeploymentsRule.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Bicep.Core.Diagnostics;
-using Bicep.Core.Navigation;
 using Bicep.Core.Semantics;
 using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.Syntax;
@@ -69,7 +68,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                             var message = string.Format(
                                 CoreResources.SecureParamsInNestedDeployRule_Message_ListFunction,
                                 resource.Name,
-                                listFunctionReference.ToText());
+                                listFunctionReference.ToString());
                             yield return CreateDiagnosticForSpan(diagnosticLevel, resource.NameSource.Span, message);
                         }
                     }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/SimplifyInterpolationRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/SimplifyInterpolationRule.cs
@@ -4,7 +4,6 @@
 using Bicep.Core.Analyzers.Linter.Common;
 using Bicep.Core.CodeAction;
 using Bicep.Core.Diagnostics;
-using Bicep.Core.Navigation;
 using Bicep.Core.Parsing;
 using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
@@ -95,7 +94,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                     var type = model.GetTypeInfo(expression);
                     if (type.IsString())
                     {
-                        AddCodeFix(valueSyntax.Span, expression.ToText());
+                        AddCodeFix(valueSyntax.Span, expression.ToString());
                     }
                 }
                 return null;

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseParentPropertyRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseParentPropertyRule.cs
@@ -200,7 +200,7 @@ public sealed class UseParentPropertyRule : LinterRuleBase
             return null;
         }
 
-        var codeReplacement = new CodeReplacement(body.Span, updatedBody.ToTextPreserveFormatting());
+        var codeReplacement = new CodeReplacement(body.Span, updatedBody.ToString());
 
         return CreateFixableDiagnosticForSpan(
             diagnosticLevel,

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseResourceIdFunctionsRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseResourceIdFunctionsRule.cs
@@ -135,7 +135,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
 
                     foreach (Failure failure in visitor.Failures)
                     {
-                        var propertyName = failure.Property.Key.ToText();
+                        var propertyName = failure.Property.Key.ToString();
                         var paths = failure.PathToExpression.Any() ?
                             (new string[] { propertyName }).Concat(failure.PathToExpression.Select(s => s.Name)) :
                             Enumerable.Empty<string>();
@@ -143,7 +143,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                         yield return CreateDiagnosticForSpan(
                             diagnosticLevel,
                             failure.Property.Key.Span,
-                            failure.Property.Key.ToText(),
+                            propertyName,
                             path);
                     }
                 }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseResourceSymbolReferenceRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseResourceSymbolReferenceRule.cs
@@ -152,7 +152,7 @@ public sealed class UseResourceSymbolReferenceRule : LinterRuleBase
             newSyntax = SyntaxFactory.CreatePropertyAccess(newSyntax, "properties");
         }
 
-        var codeReplacement = new CodeReplacement(functionCall.Span, newSyntax.ToTextPreserveFormatting());
+        var codeReplacement = new CodeReplacement(functionCall.Span, newSyntax.ToString());
 
         return CreateFixableDiagnosticForSpan(
             diagnosticLevel,
@@ -188,7 +188,7 @@ public sealed class UseResourceSymbolReferenceRule : LinterRuleBase
             functionCall.Name.IdentifierName,
             newArgs);
 
-        var codeReplacement = new CodeReplacement(functionCall.Span, newFunctionCall.ToTextPreserveFormatting());
+        var codeReplacement = new CodeReplacement(functionCall.Span, newFunctionCall.ToString());
 
         return CreateFixableDiagnosticForSpan(
             diagnosticLevel,

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseStableResourceIdentifiersRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseStableResourceIdentifiersRule.cs
@@ -3,7 +3,6 @@
 
 using System.Text;
 using Bicep.Core.Diagnostics;
-using Bicep.Core.Navigation;
 using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
 
@@ -63,7 +62,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             {
                 if (NonDeterministicFunctionNames.Contains(syntax.Name.IdentifierName))
                 {
-                    pathsToNonDeterministicFunctionsUsed.Add((FormatPath(syntax.ToText()), syntax.Name.IdentifierName));
+                    pathsToNonDeterministicFunctionsUsed.Add((FormatPath(syntax.ToString()), syntax.Name.IdentifierName));
                 }
                 base.VisitFunctionCallSyntax(syntax);
             }

--- a/src/Bicep.Core/CodeAction/CodeReplacement.cs
+++ b/src/Bicep.Core/CodeAction/CodeReplacement.cs
@@ -1,24 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-using Bicep.Core.Navigation;
 using Bicep.Core.Parsing;
-using Bicep.Core.Syntax;
 
 namespace Bicep.Core.CodeAction
 {
-    public class CodeReplacement : IPositionable
+    public readonly record struct CodeReplacement(TextSpan Span, string Text) : IPositionable
     {
-        public CodeReplacement(TextSpan span, string text)
-        {
-            this.Span = span;
-            this.Text = text;
-        }
+        public static readonly CodeReplacement Nil = new(TextSpan.Nil, "");
 
-        public TextSpan Span { get; }
-
-        public string Text { get; }
-
-        public static CodeReplacement FromSyntax(TextSpan span, SyntaxBase syntax)
-            => new(span, syntax.ToText());
+        public bool IsNil => this == Nil;
     }
 }

--- a/src/Bicep.Core/CodeAction/Fixes/DecoratorCodeFixProvider.cs
+++ b/src/Bicep.Core/CodeAction/Fixes/DecoratorCodeFixProvider.cs
@@ -3,6 +3,7 @@
 
 using Bicep.Core.Navigation;
 using Bicep.Core.Parsing;
+using Bicep.Core.PrettyPrintV2;
 using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
 using Bicep.Core.TypeSystem;
@@ -39,7 +40,8 @@ public class DecoratorCodeFixProvider : ICodeFixProvider
         }
 
         var decoratorSyntax = SyntaxFactory.CreateDecorator(decoratorName, GetEmptyParams());
-        var decoratorText = $"{decoratorSyntax.ToText()}{Environment.NewLine}";
+        var newline = semanticModel.Configuration.Formatting.Data.NewlineKind.ToEscapeSequence();
+        var decoratorText = $"{decoratorSyntax}{newline}";
         var newSpan = new TextSpan(decorableSyntax.Span.Position, 0);
         var codeReplacement = new CodeReplacement(newSpan, decoratorText);
 

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -254,7 +254,7 @@ namespace Bicep.Core.Diagnostics
                         showTypeInaccuracy ? TypeInaccuracyLink : null);
                 }
 
-                var codeFix = new CodeFix("Add required properties", true, CodeFixKind.QuickFix, new CodeReplacement(objectSyntax.Span, newSyntax.ToTextPreserveFormatting()));
+                var codeFix = new CodeFix("Add required properties", true, CodeFixKind.QuickFix, new CodeReplacement(objectSyntax.Span, newSyntax.ToString()));
 
                 return new FixableDiagnostic(
                     TextSpan,
@@ -1760,14 +1760,14 @@ namespace Bicep.Core.Diagnostics
                     "If you do not know whether the value will be null and the template would handle a null value for the overall expression, use a `.?` (safe dereference) operator to short-circuit the access expression if the base expression's value is null",
                     true,
                     CodeFixKind.QuickFix,
-                    new(accessExpression.Span, accessExpression.AsSafeAccess().ToTextPreserveFormatting())),
+                    new(accessExpression.Span, accessExpression.AsSafeAccess().ToString())),
                 AsNonNullable(accessExpression.BaseExpression));
 
             private static CodeFix AsNonNullable(SyntaxBase expression) => new(
                 "If you know the value will not be null, use a non-null assertion operator to inform the compiler that the value will not be null",
                 false,
                 CodeFixKind.QuickFix,
-                new(expression.Span, SyntaxFactory.AsNonNullable(expression).ToTextPreserveFormatting()));
+                new(expression.Span, SyntaxFactory.AsNonNullable(expression).ToString()));
 
             public ErrorDiagnostic UnresolvableArmJsonType(string errorSource, string message) => new(
                 TextSpan,

--- a/src/Bicep.Core/Navigation/SyntaxBaseExtensions.cs
+++ b/src/Bicep.Core/Navigation/SyntaxBaseExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System.Text;
-using Bicep.Core.Parsing;
 using Bicep.Core.PrettyPrint;
 using Bicep.Core.Syntax;
 
@@ -74,42 +73,6 @@ namespace Bicep.Core.Navigation
             var document = documentBuildVisitor.BuildDocument(syntax);
             document.Layout(sb, indent, newLineSequence ?? Environment.NewLine);
             return sb.ToString();
-        }
-
-        /// <summary>
-        /// Generate/format/print a string that represents this Syntax element.
-        /// </summary>
-        public static string ToTextPreserveFormatting(this SyntaxBase syntax)
-        {
-            var sb = new StringBuilder();
-            var printVisitor = new PrintVisitor(sb);
-            printVisitor.Visit(syntax);
-            return sb.ToString();
-        }
-
-        private class PrintVisitor : CstVisitor
-        {
-            private readonly StringBuilder buffer;
-
-            public PrintVisitor(StringBuilder buffer)
-            {
-                this.buffer = buffer;
-            }
-
-            public override void VisitToken(Token token)
-            {
-                WriteTrivia(token.LeadingTrivia);
-                buffer.Append(token.Text);
-                WriteTrivia(token.TrailingTrivia);
-            }
-
-            private void WriteTrivia(IEnumerable<SyntaxTrivia> triviaList)
-            {
-                foreach (var trivia in triviaList)
-                {
-                    buffer.Append(trivia.Text);
-                }
-            }
         }
     }
 }

--- a/src/Bicep.Core/PrettyPrintV2/NewlineKind.cs
+++ b/src/Bicep.Core/PrettyPrintV2/NewlineKind.cs
@@ -10,7 +10,5 @@ namespace Bicep.Core.PrettyPrintV2
         CRLF,
 
         CR,
-
-        Auto,
     }
 }

--- a/src/Bicep.Core/PrettyPrintV2/NewlineKindExtensions.cs
+++ b/src/Bicep.Core/PrettyPrintV2/NewlineKindExtensions.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.PrettyPrintV2
+{
+    public static class NewlineKindExtensions
+    {
+        public static string ToEscapeSequence(this NewlineKind newlineKind) => newlineKind switch
+        {
+            NewlineKind.LF => "\n",
+            NewlineKind.CRLF => "\r\n",
+            NewlineKind.CR => "\r",
+            _ => throw new InvalidOperationException($"Unrecognized newline kind '{newlineKind}'."),
+        };
+    }
+}

--- a/src/Bicep.Core/PrettyPrintV2/PrettyPrinterV2.cs
+++ b/src/Bicep.Core/PrettyPrintV2/PrettyPrinterV2.cs
@@ -4,6 +4,7 @@
 using System.Collections.Immutable;
 using System.Text;
 using Bicep.Core.PrettyPrintV2.Documents;
+using Bicep.Core.Syntax;
 
 namespace Bicep.Core.PrettyPrintV2
 {
@@ -21,19 +22,19 @@ namespace Bicep.Core.PrettyPrintV2
             this.context = context;
         }
 
-        public static string Print(PrettyPrinterV2Context context)
+        public static string Print(SyntaxBase syntaxToPrint, PrettyPrinterV2Context context)
         {
             var writer = new StringWriter();
 
-            PrintTo(writer, context);
+            PrintTo(writer, syntaxToPrint, context);
 
             return writer.ToString();
         }
 
-        public static void PrintTo(TextWriter writer, PrettyPrinterV2Context context)
+        public static void PrintTo(TextWriter writer, SyntaxBase syntaxToPrint, PrettyPrinterV2Context context)
         {
             var layouts = new SyntaxLayouts(context);
-            var documents = layouts.Layout(context.SyntaxToPrint);
+            var documents = layouts.Layout(syntaxToPrint);
             var printer = new PrettyPrinterV2(writer, context);
 
             foreach (var document in documents)

--- a/src/Bicep.Core/Rewriters/RewriterHelper.cs
+++ b/src/Bicep.Core/Rewriters/RewriterHelper.cs
@@ -22,7 +22,7 @@ namespace Bicep.Core.Rewriters
                 return (bicepFile, false);
             }
 
-            bicepFile = SourceFileFactory.CreateBicepFile(bicepFile.FileUri, newProgramSyntax.ToTextPreserveFormatting());
+            bicepFile = SourceFileFactory.CreateBicepFile(bicepFile.FileUri, newProgramSyntax.ToString());
             return (bicepFile, true);
         }
 

--- a/src/Bicep.Core/Syntax/SyntaxBase.cs
+++ b/src/Bicep.Core/Syntax/SyntaxBase.cs
@@ -77,5 +77,10 @@ namespace Bicep.Core.Syntax
                 throw new ArgumentException($"{parameterName} is of an unexpected type {syntaxType.Name}. Expected types: {expectedTypes.Select(t => t.Name).ConcatString(", ")}");
             }
         }
+
+        /// <summary>
+        /// Returns a string that mirrors the original text of the syntax node.
+        /// </summary>
+        public override string ToString() => SyntaxStringifier.Stringify(this);
     }
 }

--- a/src/Bicep.Core/Syntax/SyntaxFactory.cs
+++ b/src/Bicep.Core/Syntax/SyntaxFactory.cs
@@ -416,7 +416,7 @@ namespace Bicep.Core.Syntax
 
         public static ParameterAssignmentSyntax CreateParameterAssignmentSyntax(string name, SyntaxBase value)
             => new(
-                CreateIdentifierToken(LanguageConstants.ParameterKeyword),
+                CreateIdentifierToken(LanguageConstants.ParameterKeyword, EmptyTrivia, SingleSpaceTrivia),
                 CreateIdentifier(name),
                 AssignmentToken,
                 value);

--- a/src/Bicep.Core/Syntax/SyntaxStringifier.cs
+++ b/src/Bicep.Core/Syntax/SyntaxStringifier.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT License.
 
 using Bicep.Core.Parsing;
-using Bicep.Core.Syntax;
 
-namespace Bicep.Core.PrettyPrintV2
+namespace Bicep.Core.Syntax
 {
     public class SyntaxStringifier : CstVisitor
     {
@@ -12,9 +11,9 @@ namespace Bicep.Core.PrettyPrintV2
 
         private readonly string? newlineReplacement;
 
-        private SyntaxStringifier(TextWriter buffer, string? newlineReplacement)
+        private SyntaxStringifier(TextWriter writer, string? newlineReplacement)
         {
-            this.writer = buffer;
+            this.writer = writer;
             this.newlineReplacement = newlineReplacement;
         }
 

--- a/src/Bicep.Core/Workspaces/BicepSourceFile.cs
+++ b/src/Bicep.Core/Workspaces/BicepSourceFile.cs
@@ -38,7 +38,7 @@ namespace Bicep.Core.Workspaces
 
         public Uri FileUri { get; }
 
-        public string GetOriginalSource() => ProgramSyntax.ToTextPreserveFormatting();
+        public string GetOriginalSource() => ProgramSyntax.ToString();
 
         public abstract BicepSourceFileKind FileKind { get; }
 

--- a/src/Bicep.LangServer.IntegrationTests/CodeActionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CodeActionTests.cs
@@ -899,7 +899,7 @@ param fo|o {paramType}
             // the handler can contain tabs. convert to double space to simplify printing.
             textToInsert = textToInsert.Replace("\t", "  ");
 
-            var originalFile = bicepFile.ProgramSyntax.ToTextPreserveFormatting();
+            var originalFile = bicepFile.ProgramSyntax.ToString();
             var replaced = originalFile.Substring(0, start) + textToInsert + originalFile.Substring(end);
 
             return SourceFileFactory.CreateBicepFile(bicepFile.FileUri, replaced);

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -703,7 +703,7 @@ module mod 'mod.bicep' = {
             var completions = await file.RequestCompletions(cursors);
             completions.Count().Should().Be(1);
 
-            var withRequiredProps = file.ApplyCompletion(completions.Single(), "required-properties").ProgramSyntax.ToTextPreserveFormatting();
+            var withRequiredProps = file.ApplyCompletion(completions.Single(), "required-properties").ProgramSyntax.ToString();
             withRequiredProps.Should().Contain("requiredProperty");
             withRequiredProps.Should().NotContain("optionalProperty");
         }

--- a/src/Bicep.LangServer.IntegrationTests/Helpers/MultiFileLanguageServerHelper.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Helpers/MultiFileLanguageServerHelper.cs
@@ -73,7 +73,7 @@ namespace Bicep.LangServer.IntegrationTests
         }
 
         public async Task<PublishDiagnosticsParams> OpenFileOnceAsync(TestContext testContext, BicepSourceFile file)
-            => await OpenFileOnceAsync(testContext, file.ProgramSyntax.ToTextPreserveFormatting(), file.FileUri);
+            => await OpenFileOnceAsync(testContext, file.ProgramSyntax.ToString(), file.FileUri);
 
         public async Task<PublishDiagnosticsParams> ChangeFileAsync(TestContext testContext, string text, DocumentUri documentUri, int version)
         {
@@ -110,7 +110,7 @@ namespace Bicep.LangServer.IntegrationTests
         }
 
         public async Task ChangeFileAsync(TestContext testContext, BicepFile file, int version)
-            => await ChangeFileAsync(testContext, file.ProgramSyntax.ToTextPreserveFormatting(), file.FileUri, version);
+            => await ChangeFileAsync(testContext, file.ProgramSyntax.ToString(), file.FileUri, version);
 
         public void Dispose()
         {

--- a/src/Bicep.LangServer.IntegrationTests/Helpers/ServerRequestHelper.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Helpers/ServerRequestHelper.cs
@@ -143,7 +143,7 @@ namespace Bicep.LangServer.IntegrationTests
                     throw new InvalidOperationException();
             }
 
-            var originalFile = bicepFile.ProgramSyntax.ToTextPreserveFormatting();
+            var originalFile = bicepFile.ProgramSyntax.ToString();
             var replaced = originalFile.Substring(0, start) + textToInsert + originalFile.Substring(end);
 
             return SourceFileFactory.CreateBicepFile(bicepFile.FileUri, replaced);
@@ -158,7 +158,7 @@ namespace Bicep.LangServer.IntegrationTests
 
             var changes = edit.Changes![bicepFile.FileUri];
 
-            var replaced = bicepFile.ProgramSyntax.ToTextPreserveFormatting();
+            var replaced = bicepFile.ProgramSyntax.ToString();
             var offset = 0;
 
             foreach (var change in changes)

--- a/src/Bicep.LangServer.IntegrationTests/RenameSymbolTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/RenameSymbolTests.cs
@@ -47,7 +47,7 @@ var blah = '${NewIdentifier}'
 
         var edit = await file.RequestRename(cursor, "NewIdentifier");
 
-        var appliedEdit = file.ApplyWorkspaceEdit(edit).ProgramSyntax.ToTextPreserveFormatting();
+        var appliedEdit = file.ApplyWorkspaceEdit(edit).ProgramSyntax.ToString();
 
         appliedEdit.Should().EqualIgnoringTrailingWhitespace(expectedOutput);
     }

--- a/src/Bicep.LangServer/Handlers/BicepDocumentFormattingHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDocumentFormattingHandler.cs
@@ -53,8 +53,8 @@ namespace Bicep.LanguageServer.Handlers
             if (featureProvider.PrettyPrintingEnabled)
             {
                 var v2Options = context.Compilation.GetEntrypointSemanticModel().Configuration.Formatting.Data;
-                var printerV2Context = PrettyPrinterV2Context.Create(context.ProgramSyntax, v2Options, lexingErrorLookup, parsingErrorLookup);
-                var v2Output = PrettyPrinterV2.Print(printerV2Context);
+                var printerV2Context = PrettyPrinterV2Context.Create(v2Options, lexingErrorLookup, parsingErrorLookup);
+                var v2Output = PrettyPrinterV2.Print(context.ProgramSyntax, printerV2Context);
 
                 return Task.FromResult<TextEditContainer?>(new TextEditContainer(new TextEdit
                 {


### PR DESCRIPTION
As part of v1 formatter deprecation (#11733), the PR eliminates its use within all linter rules and some tests.

Main changes:

- Substituted `SyntaxBaseExtensions.ToTextPreservingFormatting()` with a new implementation `SyntaxBase.ToString()`.
- Replaced `SyntaxBase.ToText()` with `SyntaxBase.ToText()` in linter rules and tests where formatting syntax nodes is unnecessary.

A small number of references to `SyntaxBase.ToText()` persist in the decompiler, which will be addressed separately in an upcoming PR

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/13191)