### PR TITLE
Fixed TPN workflow permissions

### DIFF
--- a/.github/workflows/update-notices.yml
+++ b/.github/workflows/update-notices.yml
@@ -14,6 +14,9 @@ jobs:
     # has to be windows because of the windows installer project
     runs-on: windows-latest
 
+    permissions:
+      contents: write
+
     env:
       DOTNET_NOLOGO: true
       DOTNET_CLI_TELEMETRY_OPTOUT: true


### PR DESCRIPTION
The TPN workflow was failing due to insufficient permissions. Since it pushes commits to a branch, it needs the contents write permission and succeeds once the permission is added.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/13235)